### PR TITLE
[Build] [Patches] [Disable Safe Browsing] Hotfix for failing patch

### DIFF
--- a/build/patches/Disable-safe-browsing.patch
+++ b/build/patches/Disable-safe-browsing.patch
@@ -75,7 +75,7 @@ diff --git a/chrome/android/java/res/xml/privacy_preferences.xml b/chrome/androi
 +++ b/chrome/android/java/res/xml/privacy_preferences.xml
 @@ -7,24 +7,11 @@
      xmlns:app="http://schemas.android.com/apk/res-auto">
- 
+
      <org.chromium.chrome.browser.preferences.ChromeBaseCheckBoxPreference
 -        android:key="navigation_error"
 -        android:title="@string/navigation_error_title"
@@ -146,7 +146,7 @@ diff --git a/chrome/android/java/res/xml/sync_and_services_preferences.xml b/chr
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/privacy/PrivacyPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/privacy/PrivacyPreferences.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/privacy/PrivacyPreferences.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/privacy/PrivacyPreferences.java
-@@ -17,7 +17,6 @@ import android.view.MenuItem;
+@@ -17,7 +17,6 @@
  import org.chromium.base.BuildInfo;
  import org.chromium.chrome.R;
  import org.chromium.chrome.browser.ChromeFeatureList;
@@ -154,7 +154,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/pri
  import org.chromium.chrome.browser.help.HelpAndFeedback;
  import org.chromium.chrome.browser.preferences.ChromeBaseCheckBoxPreference;
  import org.chromium.chrome.browser.preferences.ManagedPreferenceDelegate;
-@@ -36,21 +35,15 @@ import org.chromium.ui.text.SpanApplier;
+@@ -35,18 +34,12 @@
   */
  public class PrivacyPreferences
          extends PreferenceFragmentCompat implements Preference.OnPreferenceChangeListener {
@@ -169,15 +169,12 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/pri
      private static final String PREF_DO_NOT_TRACK = "do_not_track";
 -    private static final String PREF_USAGE_AND_CRASH_REPORTING = "usage_and_crash_reports";
      private static final String PREF_CLEAR_BROWSING_DATA = "clear_browsing_data";
-     private static final String PREF_SYNC_AND_SERVICES_LINK_DIVIDER =
-             "sync_and_services_link_divider";
-     private static final String PREF_SYNC_AND_SERVICES_LINK = "sync_and_services_link";
 -    private static final String PREF_USAGE_STATS = "usage_stats_reporting";
- 
+
      private ManagedPreferenceDelegate mManagedPreferenceDelegate;
- 
-@@ -78,12 +71,8 @@ public class PrivacyPreferences
- 
+
+@@ -74,12 +67,8 @@
+
          if (ChromeFeatureList.isEnabled(ChromeFeatureList.UNIFIED_CONSENT)) {
              // Remove preferences that were migrated to SyncAndServicesPreferences.
 -            preferenceScreen.removePreference(findPreference(PREF_NAVIGATION_ERROR));
@@ -186,13 +183,13 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/pri
 -            preferenceScreen.removePreference(findPreference(PREF_SAFE_BROWSING));
              preferenceScreen.removePreference(findPreference(PREF_CONTEXTUAL_SEARCH));
 -            preferenceScreen.removePreference(findPreference(PREF_USAGE_AND_CRASH_REPORTING));
- 
+
              // TODO(https://crbug.com/846376): Update strings in XML after UNIFIED_CONSENT launch.
              networkPredictionPref.setTitle(R.string.preload_pages_title);
-@@ -112,32 +101,11 @@ public class PrivacyPreferences
-         preferenceScreen.removePreference(findPreference(PREF_SYNC_AND_SERVICES_LINK_DIVIDER));
-         preferenceScreen.removePreference(findPreference(PREF_SYNC_AND_SERVICES_LINK));
- 
+@@ -97,32 +86,11 @@
+             return;
+         }
+
 -        ChromeBaseCheckBoxPreference navigationErrorPref =
 -                (ChromeBaseCheckBoxPreference) findPreference(PREF_NAVIGATION_ERROR);
 -        navigationErrorPref.setOnPreferenceChangeListener(this);
@@ -202,7 +199,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/pri
                  (ChromeBaseCheckBoxPreference) findPreference(PREF_SEARCH_SUGGESTIONS);
          searchSuggestionsPref.setOnPreferenceChangeListener(this);
          searchSuggestionsPref.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
- 
+
 -        if (!ContextualSearchFieldTrial.isEnabled()) {
 -            preferenceScreen.removePreference(findPreference(PREF_CONTEXTUAL_SEARCH));
 -        }
@@ -221,8 +218,8 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/pri
 -
          updateSummaries();
       }
- 
-@@ -146,18 +114,6 @@ public class PrivacyPreferences
+
+@@ -131,18 +99,6 @@
          String key = preference.getKey();
          if (PREF_SEARCH_SUGGESTIONS.equals(key)) {
              PrefServiceBridge.getInstance().setSearchSuggestEnabled((boolean) newValue);
@@ -239,12 +236,12 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/pri
 -            PrefServiceBridge.getInstance().setBoolean(
 -                    Pref.CAN_MAKE_PAYMENT_ENABLED, (boolean) newValue);
          }
- 
+
          return true;
-@@ -180,32 +136,12 @@ public class PrivacyPreferences
+@@ -165,32 +121,12 @@
          CharSequence textOn = getActivity().getResources().getText(R.string.text_on);
          CharSequence textOff = getActivity().getResources().getText(R.string.text_off);
- 
+
 -        CheckBoxPreference navigationErrorPref = (CheckBoxPreference) findPreference(
 -                PREF_NAVIGATION_ERROR);
 -        if (navigationErrorPref != null) {
@@ -257,7 +254,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/pri
          if (searchSuggestionsPref != null) {
              searchSuggestionsPref.setChecked(prefServiceBridge.isSearchSuggestEnabled());
          }
- 
+
 -        CheckBoxPreference extendedReportingPref =
 -                (CheckBoxPreference) findPreference(PREF_SAFE_BROWSING_SCOUT_REPORTING);
 -        if (extendedReportingPref != null) {
@@ -274,7 +271,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/pri
          CheckBoxPreference canMakePaymentPref =
                  (CheckBoxPreference) findPreference(PREF_CAN_MAKE_PAYMENT);
          if (canMakePaymentPref != null) {
-@@ -223,50 +159,15 @@ public class PrivacyPreferences
+@@ -208,50 +144,15 @@
              boolean isContextualSearchEnabled = !prefServiceBridge.isContextualSearchDisabled();
              contextualPref.setSummary(isContextualSearchEnabled ? textOn : textOff);
          }
@@ -305,7 +302,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/pri
 -            }
 -        }
      }
- 
+
      private ManagedPreferenceDelegate createManagedPreferenceDelegate() {
          return preference -> {
              String key = preference.getKey();
@@ -329,9 +326,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/syn
 --- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
 @@ -163,14 +163,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
- 
+
          mPrivacyPrefManager.migrateNetworkPredictionPreferences();
- 
+
 -        getActivity().setTitle(R.string.prefs_sync_and_services);
          setHasOptionsMenu(true);
 -        if (mIsFromSigninScreen) {
@@ -340,9 +337,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/syn
 -            actionBar.setHomeActionContentDescription(
 -                    R.string.prefs_sync_and_services_content_description);
 -        }
- 
+
          PreferenceUtils.addPreferencesFromResource(this, R.xml.sync_and_services_preferences);
- 
+
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncPreferenceUtils.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncPreferenceUtils.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncPreferenceUtils.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncPreferenceUtils.java
@@ -369,7 +366,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/webshare/ShareS
  import org.chromium.content_public.browser.WebContents;
 @@ -194,11 +193,6 @@ public class ShareServiceImpl implements ShareService {
          }
- 
+
          for (SharedFile file : files) {
 -            RecordHistogram.recordSparseHistogram(
 -                    "WebShare.Unverified", FileTypePolicies.umaValueForFile(file.name));
@@ -415,8 +412,8 @@ diff --git a/chrome/android/java/strings/android_chrome_strings.grd b/chrome/and
          Make searches and browsing better
        </message>
 @@ -421,12 +406,6 @@ CHAR-LIMIT guidelines:
-       <message name="IDS_PRIVACY_SYNC_AND_SERVICES_LINK" desc="The text for Privacy preferences that is shown after all preference rows.">
-         For more settings that relate to privacy, security, and data collection, see <ph name="BEGIN_LINK">&lt;link&gt;</ph>Sync and Google services<ph name="END_LINK">&lt;/link&gt;</ph>
+       <message name="IDS_URL_KEYED_ANONYMIZED_DATA_SUMMARY" desc="Summary for a checkbox in Settings that controls non-personalized URL collection and informs the user about the data shared by this feature.">
+         Sends URLs of pages you visit to Google
        </message>
 -      <message name="IDS_USAGE_AND_CRASH_REPORTS_TITLE" desc="Title for a preference that enables sending usage statistics and crash reports.">
 -        Help improve Chrome's features and performance
@@ -486,7 +483,7 @@ diff --git a/chrome/browser/browser_process.h b/chrome/browser/browser_process.h
 @@ -45,10 +45,6 @@ class NetworkQualityTracker;
  class SharedURLLoaderFactory;
  }
- 
+
 -namespace safe_browsing {
 -class SafeBrowsingService;
 -}
@@ -497,7 +494,7 @@ diff --git a/chrome/browser/browser_process.h b/chrome/browser/browser_process.h
 @@ -106,10 +102,6 @@ class ResourceCoordinatorParts;
  class TabManager;
  }
- 
+
 -namespace safe_browsing {
 -class ClientSideDetectionService;
 -}
@@ -508,7 +505,7 @@ diff --git a/chrome/browser/browser_process.h b/chrome/browser/browser_process.h
 @@ -210,14 +202,6 @@ class BrowserProcess {
    // on this platform (or this is a unit test).
    virtual StatusTray* status_tray() = 0;
- 
+
 -  // Returns the SafeBrowsing service.
 -  virtual safe_browsing::SafeBrowsingService* safe_browsing_service() = 0;
 -
@@ -532,7 +529,7 @@ diff --git a/chrome/browser/browser_process_impl.cc b/chrome/browser/browser_pro
  #include "chrome/browser/site_isolation/prefs_observer.h"
  #include "chrome/browser/ssl/secure_origin_prefs_observer.h"
 @@ -361,8 +360,6 @@ void BrowserProcessImpl::StartTearDown() {
- 
+
    metrics_services_manager_.reset();
    intranet_redirect_detector_.reset();
 -  if (safe_browsing_service_.get())
@@ -543,7 +540,7 @@ diff --git a/chrome/browser/browser_process_impl.cc b/chrome/browser/browser_pro
 @@ -954,22 +951,6 @@ StatusTray* BrowserProcessImpl::status_tray() {
    return status_tray_.get();
  }
- 
+
 -safe_browsing::SafeBrowsingService*
 -BrowserProcessImpl::safe_browsing_service() {
 -  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
@@ -565,7 +562,7 @@ diff --git a/chrome/browser/browser_process_impl.cc b/chrome/browser/browser_pro
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 @@ -1228,23 +1209,6 @@ void BrowserProcessImpl::CreateBackgroundPrintingManager() {
  }
- 
+
  void BrowserProcessImpl::CreateSafeBrowsingService() {
 -  DCHECK(!safe_browsing_service_);
 -  // Set this flag to true so that we don't retry indefinitely to
@@ -585,7 +582,7 @@ diff --git a/chrome/browser/browser_process_impl.cc b/chrome/browser/browser_pro
 -  if (safe_browsing_service_)
 -    safe_browsing_service_->Initialize();
  }
- 
+
  void BrowserProcessImpl::CreateSubresourceFilterRulesetService() {
 diff --git a/chrome/browser/browser_process_impl.h b/chrome/browser/browser_process_impl.h
 --- a/chrome/browser/browser_process_impl.h
@@ -603,7 +600,7 @@ diff --git a/chrome/browser/browser_process_impl.h b/chrome/browser/browser_proc
 @@ -312,9 +309,6 @@ class BrowserProcessImpl : public BrowserProcess,
    std::unique_ptr<BackgroundModeManager> background_mode_manager_;
  #endif
- 
+
 -  bool created_safe_browsing_service_ = false;
 -  scoped_refptr<safe_browsing::SafeBrowsingService> safe_browsing_service_;
 -
@@ -616,7 +613,7 @@ diff --git a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.
 @@ -256,17 +256,6 @@ bool DoesOriginMatchEmbedderMask(int origin_type_mask,
    return false;
  }
- 
+
 -// Callback for when cookies have been deleted. Invokes NotifyIfDone.
 -// Receiving |cookie_manager| as a parameter so that the receive pipe is
 -// not deleted before the response is received.
@@ -629,12 +626,12 @@ diff --git a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.
 -}
 -
  }  // namespace
- 
+
  ChromeBrowsingDataRemoverDelegate::ChromeBrowsingDataRemoverDelegate(
 @@ -662,36 +651,6 @@ void ChromeBrowsingDataRemoverDelegate::RemoveEmbedderData(
          CONTENT_SETTINGS_TYPE_CLIENT_HINTS, base::Time(), base::Time::Max(),
          website_settings_filter);
- 
+
 -    // Clear the safebrowsing cookies only if time period is for "all time".  It
 -    // doesn't make sense to apply the time period of deleting in the last X
 -    // hours/days to the safebrowsing cookies since they aren't the result of
@@ -667,7 +664,7 @@ diff --git a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.
 -
      MediaDeviceIDSalt::Reset(profile_->GetPrefs());
    }
- 
+
 diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
@@ -702,7 +699,7 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
 @@ -861,30 +862,6 @@ void SetApplicationLocaleOnIOThread(const std::string& locale) {
    GetIOThreadApplicationLocale() = locale;
  }
- 
+
 -// An implementation of the SSLCertReporter interface used by
 -// SSLErrorHandler. Uses CertificateReportingService to send reports. The
 -// service handles queueing and re-sending of failed reports. Each certificate
@@ -732,13 +729,13 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
    static const float kMinFSM = 1.05f;
 @@ -1263,7 +1240,9 @@ void ChromeContentBrowserClient::PostAfterStartupTask(
    InitNetworkContextsParentDirectory();
- 
+
    DCHECK_CURRENTLY_ON(BrowserThread::UI);
 +#if defined(FULL_SAFE_BROWSING)
    safe_browsing_service_ = g_browser_process->safe_browsing_service();
 +#endif
  }
- 
+
  bool ChromeContentBrowserClient::IsBrowserStartupComplete() {
 @@ -2030,7 +2009,7 @@ void ChromeContentBrowserClient::AppendExtraCommandLineSwitches(
    }
@@ -759,7 +756,7 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
              switches::kDisableClientSidePhishingDetection);
        }
 @@ -4201,12 +4180,12 @@ ChromeContentBrowserClient::CreateThrottlesForNavigation(
- 
+
    throttles.push_back(std::make_unique<PolicyBlacklistNavigationThrottle>(
        handle, handle->GetWebContents()->GetBrowserContext()));
 -
@@ -771,7 +768,7 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
 -
 +#endif
    throttles.push_back(std::make_unique<LoginNavigationThrottle>(handle));
- 
+
    std::unique_ptr<content::NavigationThrottle> https_upgrade_timing_throttle =
 @@ -4237,11 +4216,6 @@ ChromeContentBrowserClient::CreateThrottlesForNavigation(
        PreviewsLitePageDecider::MaybeCreateThrottleFor(handle);
@@ -782,13 +779,13 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
 -        std::make_unique<safe_browsing::SafeBrowsingNavigationThrottle>(
 -            handle));
 -  }
- 
+
  #if defined(OS_WIN) || defined(OS_MACOSX) || \
      (defined(OS_LINUX) && !defined(OS_CHROMEOS))
 @@ -5249,19 +5223,7 @@ ChromeContentBrowserClient::GetSafeBrowsingUrlCheckerDelegate(
      content::ResourceContext* resource_context) {
    DCHECK_CURRENTLY_ON(BrowserThread::IO);
- 
+
 -  ProfileIOData* io_data = ProfileIOData::FromResourceContext(resource_context);
 -  if (!io_data->safe_browsing_enabled()->GetValue())
 -    return nullptr;
@@ -804,7 +801,7 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
 -  return safe_browsing_url_checker_delegate_;
 +  return nullptr;
  }
- 
+
  base::Optional<std::string>
 diff --git a/chrome/browser/component_updater/file_type_policies_component_installer.cc b/chrome/browser/component_updater/file_type_policies_component_installer.cc
 --- a/chrome/browser/component_updater/file_type_policies_component_installer.cc
@@ -817,11 +814,11 @@ diff --git a/chrome/browser/component_updater/file_type_policies_component_insta
  #include "chrome/common/safe_browsing/file_type_policies.h"
 +#endif
  #include "components/component_updater/component_updater_paths.h"
- 
+
  using component_updater::ComponentUpdateService;
 @@ -38,20 +40,6 @@ const uint8_t kFileTypePoliciesPublicKeySHA256[32] = {
  const char kFileTypePoliciesManifestName[] = "File Type Policies";
- 
+
  void LoadFileTypesFromDisk(const base::FilePath& pb_path) {
 -  if (pb_path.empty())
 -    return;
@@ -838,7 +835,7 @@ diff --git a/chrome/browser/component_updater/file_type_policies_component_insta
 -  safe_browsing::FileTypePolicies::GetInstance()->PopulateFromDynamicUpdate(
 -      binary_pb);
  }
- 
+
  }  // namespace
 diff --git a/chrome/browser/download/chrome_download_manager_delegate.cc b/chrome/browser/download/chrome_download_manager_delegate.cc
 --- a/chrome/browser/download/chrome_download_manager_delegate.cc
@@ -873,11 +870,11 @@ diff --git a/chrome/browser/download/chrome_download_manager_delegate.cc b/chrom
  using safe_browsing::DownloadFileType;
  using safe_browsing::DownloadProtectionService;
 +#endif
- 
+
  namespace {
- 
+
 @@ -345,13 +351,6 @@ ChromeDownloadManagerDelegate::~ChromeDownloadManagerDelegate() {
- 
+
  void ChromeDownloadManagerDelegate::SetDownloadManager(DownloadManager* dm) {
    download_manager_ = dm;
 -
@@ -888,10 +885,10 @@ diff --git a/chrome/browser/download/chrome_download_manager_delegate.cc b/chrom
 -    sb_service->AddDownloadManager(dm);
 -  }
  }
- 
+
  #if defined(OS_ANDROID)
 @@ -654,16 +653,6 @@ void ChromeDownloadManagerDelegate::ChooseSavePath(
- 
+
  void ChromeDownloadManagerDelegate::SanitizeSavePackageResourceName(
      base::FilePath* filename) {
 -  safe_browsing::FileTypePolicies* file_type_policies =
@@ -905,12 +902,12 @@ diff --git a/chrome/browser/download/chrome_download_manager_delegate.cc b/chrom
 -      l10n_util::GetStringUTF8(IDS_DEFAULT_DOWNLOAD_FILENAME));
 -  *filename = filename->AddExtension(default_filename.BaseName().value());
  }
- 
+
  void ChromeDownloadManagerDelegate::OpenDownloadUsingPlatformHandler(
 @@ -797,19 +786,19 @@ ChromeDownloadManagerDelegate::ApplicationClientIdForFileScanning() {
    return std::string(chrome::kApplicationClientIDStringForAVScanning);
  }
- 
+
 +#if BUILDFLAG(FULL_SAFE_BROWSING)
  DownloadProtectionService*
      ChromeDownloadManagerDelegate::GetDownloadProtectionService() {
@@ -926,13 +923,13 @@ diff --git a/chrome/browser/download/chrome_download_manager_delegate.cc b/chrom
    return nullptr;
  }
 +#endif
- 
+
  void ChromeDownloadManagerDelegate::ShouldBlockDownload(
      download::DownloadItem* download,
 @@ -1262,13 +1251,17 @@ void ChromeDownloadManagerDelegate::OnDownloadTargetDetermined(
        DownloadItemModel(item).SetShouldPreferOpeningInBrowser(true);
  #endif
- 
+
 +#if defined(FULL_SAFE_BROWSING)
      DownloadItemModel(item).SetDangerLevel(target_info->danger_level);
 +#endif
@@ -944,7 +941,7 @@ diff --git a/chrome/browser/download/chrome_download_manager_delegate.cc b/chrom
      target_info->danger_type = download::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS;
    }
 +#endif
- 
+
    if (base::FeatureList::IsEnabled(
            download::features::kPreventDownloadsWithSamePath)) {
 diff --git a/chrome/browser/download/chrome_download_manager_delegate.h b/chrome/browser/download/chrome_download_manager_delegate.h
@@ -963,25 +960,25 @@ diff --git a/chrome/browser/download/chrome_download_manager_delegate.h b/chrome
  #include "components/download/public/common/download_path_reservation_tracker.h"
 @@ -135,8 +137,10 @@ class ChromeDownloadManagerDelegate
    DownloadPrefs* download_prefs() { return download_prefs_.get(); }
- 
+
   protected:
 +#if defined(FULL_SAFE_BROWSING)
    virtual safe_browsing::DownloadProtectionService*
        GetDownloadProtectionService();
 +#endif
- 
+
    // Show file picker for |download|.
    virtual void ShowFilePickerForDownload(
 @@ -205,9 +209,11 @@ class ChromeDownloadManagerDelegate
                 const content::NotificationSource& source,
                 const content::NotificationDetails& details) override;
- 
+
 +#if defined(FULL_SAFE_BROWSING)
    // Callback function after the DownloadProtectionService completes.
    void CheckClientDownloadDone(uint32_t download_id,
                                 safe_browsing::DownloadCheckResult result);
 +#endif
- 
+
    // Internal gateways for ShouldCompleteDownload().
    bool IsDownloadReadyForCompletion(
 diff --git a/chrome/browser/download/download_item_model.cc b/chrome/browser/download/download_item_model.cc
@@ -1000,25 +997,25 @@ diff --git a/chrome/browser/download/download_item_model.cc b/chrome/browser/dow
  #include "chrome/grit/generated_resources.h"
  #include "components/download/public/common/download_danger_type.h"
 @@ -43,7 +45,9 @@
- 
+
  using base::TimeDelta;
  using download::DownloadItem;
 +#if defined(FULL_SAFE_BROWSING)
  using safe_browsing::DownloadFileType;
 +#endif
- 
+
  namespace {
- 
+
 @@ -73,9 +77,11 @@ class DownloadItemModelData : public base::SupportsUserData::Data {
    // for the file type.
    bool should_prefer_opening_in_browser_;
- 
+
 +#if defined(FULL_SAFE_BROWSING)
    // Danger level of the file determined based on the file type and whether
    // there was a user action associated with the download.
    DownloadFileType::DangerLevel danger_level_;
 +#endif
- 
+
    // Whether the download is currently being revived.
    bool is_being_revived_;
 @@ -112,7 +118,9 @@ DownloadItemModelData::DownloadItemModelData()
@@ -1029,12 +1026,12 @@ diff --git a/chrome/browser/download/download_item_model.cc b/chrome/browser/dow
        danger_level_(DownloadFileType::NOT_DANGEROUS),
 +#endif
        is_being_revived_(false) {}
- 
+
  } // namespace
 @@ -378,6 +386,7 @@ void DownloadItemModel::SetShouldPreferOpeningInBrowser(bool preference) {
    data->should_prefer_opening_in_browser_ = preference;
  }
- 
+
 +#if defined(FULL_SAFE_BROWSING)
  DownloadFileType::DangerLevel DownloadItemModel::GetDangerLevel() const {
    const DownloadItemModelData* data = DownloadItemModelData::Get(download_);
@@ -1044,7 +1041,7 @@ diff --git a/chrome/browser/download/download_item_model.cc b/chrome/browser/dow
    data->danger_level_ = danger_level;
  }
 +#endif
- 
+
  bool DownloadItemModel::IsBeingRevived() const {
    const DownloadItemModelData* data = DownloadItemModelData::Get(download_);
 @@ -536,9 +546,6 @@ bool DownloadItemModel::IsCommandEnabled(
@@ -1068,7 +1065,7 @@ diff --git a/chrome/browser/download/download_item_model.h b/chrome/browser/down
  #include "chrome/common/safe_browsing/download_file_types.pb.h"
 +#endif
  #include "components/download/public/common/download_item.h"
- 
+
  // Implementation of DownloadUIModel that wrappers around a |DownloadItem*|. As
 @@ -48,9 +50,11 @@ class DownloadItemModel : public DownloadUIModel,
    void SetWasUINotified(bool should_notify) override;
@@ -1102,13 +1099,13 @@ diff --git a/chrome/browser/download/download_prefs.cc b/chrome/browser/download
 +#if defined(FULL_SAFE_BROWSING)
  using safe_browsing::FileTypePolicies;
 +#endif
- 
+
  namespace {
- 
+
 @@ -224,14 +228,7 @@ DownloadPrefs::DownloadPrefs(Profile* profile) : profile_(profile) {
          base::FilePath::StringType(1, base::FilePath::kExtensionSeparator) +
          extension);
- 
+
 -    // Note that the list of file types that are not allowed to open
 -    // automatically can change in the future. When the list is tightened, it is
 -    // expected that some entries in the users' auto open list will get dropped
@@ -1120,7 +1117,7 @@ diff --git a/chrome/browser/download/download_prefs.cc b/chrome/browser/download
 +    auto_open_.insert(extension);
    }
  }
- 
+
 @@ -381,10 +378,6 @@ bool DownloadPrefs::IsAutoOpenEnabledBasedOnExtension(
  bool DownloadPrefs::EnableAutoOpenBasedOnExtension(
      const base::FilePath& file_name) {
@@ -1129,7 +1126,7 @@ diff --git a/chrome/browser/download/download_prefs.cc b/chrome/browser/download
 -          file_name)) {
 -    return false;
 -  }
- 
+
    DCHECK(extension[0] == base::FilePath::kExtensionSeparator);
    extension.erase(0, 1);
 diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/browser/download/download_target_determiner.cc
@@ -1152,12 +1149,12 @@ diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/brow
 +#if defined(FULL_SAFE_BROWSING)
  using safe_browsing::DownloadFileType;
 +#endif
- 
+
  namespace {
- 
+
  const base::FilePath::CharType kCrdownloadSuffix[] =
      FILE_PATH_LITERAL(".crdownload");
- 
+
 +#if defined(FULL_SAFE_BROWSING)
  // Condenses the results from HistoryService::GetVisibleVisitCountToHost() to a
  // single bool. A host is considered visited before if prior visible visits were
@@ -1167,7 +1164,7 @@ diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/brow
        (result.first_visit.LocalMidnight() < base::Time::Now().LocalMidnight()));
  }
 +#endif
- 
+
  #if defined(OS_WIN)
  // Keeps track of whether Adobe Reader is up to date.
 @@ -101,7 +107,9 @@ DownloadTargetDeterminer::DownloadTargetDeterminer(
@@ -1196,7 +1193,7 @@ diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/brow
 @@ -789,6 +801,7 @@ DownloadTargetDeterminer::Result
      return CONTINUE;
    }
- 
+
 +#if defined(FULL_SAFE_BROWSING)
    // First determine the danger level assuming that the user doesn't have any
    // prior visits to the referrer recoreded in history. The resulting danger
@@ -1208,7 +1205,7 @@ diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/brow
 +#endif
    return CONTINUE;
  }
- 
+
 @@ -832,11 +846,13 @@ void DownloadTargetDeterminer::CheckVisitedReferrerBeforeDone(
      bool visited_referrer_before) {
    DCHECK_CURRENTLY_ON(BrowserThread::UI);
@@ -1222,7 +1219,7 @@ diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/brow
 +#endif
    DoLoop();
  }
- 
+
 @@ -941,7 +957,9 @@ void DownloadTargetDeterminer::ScheduleCallbackAndDeleteSelf(
              << " Intermediate:" << intermediate_path_.AsUTF8Unsafe()
              << " Confirmation reason:" << static_cast<int>(confirmation_reason_)
@@ -1232,7 +1229,7 @@ diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/brow
 +#endif
              << " Result:" << static_cast<int>(result);
    std::unique_ptr<DownloadTargetInfo> target_info(new DownloadTargetInfo);
- 
+
 @@ -953,7 +971,9 @@ void DownloadTargetDeterminer::ScheduleCallbackAndDeleteSelf(
             ? DownloadItem::TARGET_DISPOSITION_PROMPT
             : DownloadItem::TARGET_DISPOSITION_OVERWRITE);
@@ -1246,7 +1243,7 @@ diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/brow
 @@ -1039,6 +1059,7 @@ bool DownloadTargetDeterminer::HasPromptedForPath() const {
                                  DownloadItem::TARGET_DISPOSITION_PROMPT);
  }
- 
+
 +#if defined(FULL_SAFE_BROWSING)
  DownloadFileType::DangerLevel DownloadTargetDeterminer::GetDangerLevel(
      PriorVisitsToReferrer visits) const {
@@ -1254,7 +1251,7 @@ diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/brow
 @@ -1063,30 +1084,9 @@ DownloadFileType::DangerLevel DownloadTargetDeterminer::GetDangerLevel(
        download_->HasUserGesture())
      return DownloadFileType::NOT_DANGEROUS;
- 
+
 -  DownloadFileType::DangerLevel danger_level =
 -      safe_browsing::FileTypePolicies::GetInstance()->GetFileDangerLevel(
 -          virtual_path_.BaseName());
@@ -1281,7 +1278,7 @@ diff --git a/chrome/browser/download/download_target_determiner.cc b/chrome/brow
 +  return DownloadFileType::NOT_DANGEROUS;
  }
 +#endif
- 
+
  void DownloadTargetDeterminer::OnDownloadDestroyed(
      DownloadItem* download) {
 diff --git a/chrome/browser/download/download_target_determiner.h b/chrome/browser/download/download_target_determiner.h
@@ -1300,7 +1297,7 @@ diff --git a/chrome/browser/download/download_target_determiner.h b/chrome/brows
 @@ -313,6 +315,7 @@ class DownloadTargetDeterminer : public download::DownloadItem::Observer {
    // operation.
    bool HasPromptedForPath() const;
- 
+
 +#if defined(FULL_SAFE_BROWSING)
    // Returns true if this download should show the "dangerous file" warning.
    // Various factors are considered, such as the type of the file, whether a
@@ -1310,7 +1307,7 @@ diff --git a/chrome/browser/download/download_target_determiner.h b/chrome/brows
    safe_browsing::DownloadFileType::DangerLevel GetDangerLevel(
        PriorVisitsToReferrer visits) const;
 +#endif
- 
+
    // download::DownloadItem::Observer
    void OnDownloadDestroyed(download::DownloadItem* download) override;
 @@ -334,7 +338,9 @@ class DownloadTargetDeterminer : public download::DownloadItem::Observer {
@@ -1327,13 +1324,13 @@ diff --git a/chrome/browser/download/download_target_info.cc b/chrome/browser/do
 --- a/chrome/browser/download/download_target_info.cc
 +++ b/chrome/browser/download/download_target_info.cc
 @@ -4,12 +4,16 @@
- 
+
  #include "chrome/browser/download/download_target_info.h"
- 
+
 +#if defined(FULL_SAFE_BROWSING)
  #include "chrome/common/safe_browsing/file_type_policies.h"
 +#endif
- 
+
  DownloadTargetInfo::DownloadTargetInfo()
      : target_disposition(download::DownloadItem::TARGET_DISPOSITION_OVERWRITE),
        danger_type(download::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS),
@@ -1342,13 +1339,13 @@ diff --git a/chrome/browser/download/download_target_info.cc b/chrome/browser/do
 +#endif
        is_filetype_handled_safely(false),
        result(download::DOWNLOAD_INTERRUPT_REASON_NONE) {}
- 
+
 diff --git a/chrome/browser/download/download_target_info.h b/chrome/browser/download/download_target_info.h
 --- a/chrome/browser/download/download_target_info.h
 +++ b/chrome/browser/download/download_target_info.h
 @@ -8,7 +8,9 @@
  #include <string>
- 
+
  #include "base/files/file_path.h"
 +#if defined(FULL_SAFE_BROWSING)
  #include "chrome/common/safe_browsing/download_file_types.pb.h"
@@ -1359,7 +1356,7 @@ diff --git a/chrome/browser/download/download_target_info.h b/chrome/browser/dow
 @@ -32,6 +34,7 @@ struct DownloadTargetInfo {
    // Danger type of the download.
    download::DownloadDangerType danger_type;
- 
+
 +#if defined(FULL_SAFE_BROWSING)
    // The danger type of the download could be set to MAYBE_DANGEROUS_CONTENT if
    // the file type is handled by SafeBrowsing. However, if the SafeBrowsing
@@ -1369,37 +1366,37 @@ diff --git a/chrome/browser/download/download_target_info.h b/chrome/browser/dow
    //       malicious classification should take precedence.
    safe_browsing::DownloadFileType::DangerLevel danger_level;
 +#endif
- 
+
    // Suggested intermediate path. The downloaded bytes should be written to this
    // path until all the bytes are available and the user has accepted a
 diff --git a/chrome/browser/download/download_ui_model.cc b/chrome/browser/download/download_ui_model.cc
 --- a/chrome/browser/download/download_ui_model.cc
 +++ b/chrome/browser/download/download_ui_model.cc
 @@ -32,7 +32,9 @@
- 
+
  using base::TimeDelta;
  using download::DownloadItem;
 +#if defined(FULL_SAFE_BROWSING)
  using safe_browsing::DownloadFileType;
 +#endif
  using offline_items_collection::FailState;
- 
+
  namespace {
 @@ -390,12 +392,14 @@ bool DownloadUIModel::ShouldPreferOpeningInBrowser() const {
- 
+
  void DownloadUIModel::SetShouldPreferOpeningInBrowser(bool preference) {}
- 
+
 +#if defined(FULL_SAFE_BROWSING)
  DownloadFileType::DangerLevel DownloadUIModel::GetDangerLevel() const {
    return DownloadFileType::NOT_DANGEROUS;
  }
- 
+
  void DownloadUIModel::SetDangerLevel(
      DownloadFileType::DangerLevel danger_level) {}
 +#endif
- 
+
  void DownloadUIModel::OpenUsingPlatformHandler() {}
- 
+
 diff --git a/chrome/browser/download/download_ui_model.h b/chrome/browser/download/download_ui_model.h
 --- a/chrome/browser/download/download_ui_model.h
 +++ b/chrome/browser/download/download_ui_model.h
@@ -1412,11 +1409,11 @@ diff --git a/chrome/browser/download/download_ui_model.h b/chrome/browser/downlo
 +#endif
  #include "components/download/public/common/download_item.h"
  #include "components/offline_items_collection/core/offline_item.h"
- 
+
 @@ -172,6 +174,7 @@ class DownloadUIModel {
    // Change what's returned by ShouldPreferOpeningInBrowser to |preference|.
    virtual void SetShouldPreferOpeningInBrowser(bool preference);
- 
+
 +#if defined(FULL_SAFE_BROWSING)
    // Return the danger level determined during download target determination.
    // The value returned here is independent of the danger level as determined by
@@ -1426,7 +1423,7 @@ diff --git a/chrome/browser/download/download_ui_model.h b/chrome/browser/downlo
    virtual void SetDangerLevel(
        safe_browsing::DownloadFileType::DangerLevel danger_level);
 +#endif
- 
+
    // Open the download using the platform handler for the download. The behavior
    // of this method will be different from DownloadItem::OpenDownload() if
 diff --git a/chrome/browser/extensions/api/downloads/downloads_api.cc b/chrome/browser/extensions/api/downloads/downloads_api.cc
@@ -1441,9 +1438,9 @@ diff --git a/chrome/browser/extensions/api/downloads/downloads_api.cc b/chrome/b
  #include "chrome/browser/download/download_open_prompt.h"
  #include "chrome/browser/download/download_prefs.h"
 @@ -1311,9 +1310,6 @@ DownloadsAcceptDangerFunction::DownloadsAcceptDangerFunction() {}
- 
+
  DownloadsAcceptDangerFunction::~DownloadsAcceptDangerFunction() {}
- 
+
 -DownloadsAcceptDangerFunction::OnPromptCreatedCallback*
 -    DownloadsAcceptDangerFunction::on_prompt_created_ = NULL;
 -
@@ -1490,7 +1487,7 @@ diff --git a/chrome/browser/extensions/api/downloads/downloads_api.cc b/chrome/b
 -  SendResponse(error_.empty());
 +  download_item->ValidateDangerousDownload();
  }
- 
+
  DownloadsShowFunction::DownloadsShowFunction() {}
 diff --git a/chrome/browser/extensions/api/downloads/downloads_api.h b/chrome/browser/extensions/api/downloads/downloads_api.h
 --- a/chrome/browser/extensions/api/downloads/downloads_api.h
@@ -1504,7 +1501,7 @@ diff --git a/chrome/browser/extensions/api/downloads/downloads_api.h b/chrome/br
  #include "chrome/common/extensions/api/downloads.h"
  #include "components/download/content/public/all_download_item_notifier.h"
 @@ -189,25 +188,16 @@ class DownloadsRemoveFileFunction : public ChromeAsyncExtensionFunction {
- 
+
  class DownloadsAcceptDangerFunction : public ChromeAsyncExtensionFunction {
   public:
 -  typedef base::Callback<void(DownloadDangerPrompt*)> OnPromptCreatedCallback;
@@ -1516,24 +1513,24 @@ diff --git a/chrome/browser/extensions/api/downloads/downloads_api.h b/chrome/br
    DECLARE_EXTENSION_FUNCTION("downloads.acceptDanger", DOWNLOADS_ACCEPTDANGER)
    DownloadsAcceptDangerFunction();
    bool RunAsync() override;
- 
+
   protected:
    ~DownloadsAcceptDangerFunction() override;
 -  void DangerPromptCallback(int download_id,
 -                            DownloadDangerPrompt::Action action);
- 
+
   private:
    void PromptOrWait(int download_id, int retries);
- 
+
 -  static OnPromptCreatedCallback* on_prompt_created_;
    DISALLOW_COPY_AND_ASSIGN(DownloadsAcceptDangerFunction);
  };
- 
+
 diff --git a/chrome/browser/extensions/api/webstore_private/webstore_private_api.cc b/chrome/browser/extensions/api/webstore_private/webstore_private_api.cc
 --- a/chrome/browser/extensions/api/webstore_private/webstore_private_api.cc
 +++ b/chrome/browser/extensions/api/webstore_private/webstore_private_api.cc
 @@ -682,51 +682,9 @@ WebstorePrivateGetReferrerChainFunction::
- 
+
  ExtensionFunction::ResponseAction
  WebstorePrivateGetReferrerChainFunction::Run() {
 -  Profile* profile = chrome_details_.GetProfile();
@@ -1583,7 +1580,7 @@ diff --git a/chrome/browser/extensions/api/webstore_private/webstore_private_api
 -      ArgumentList(api::webstore_private::GetReferrerChain::Results::Create(
 -          serialized_referrer_proto)));
  }
- 
+
  }  // namespace extensions
 diff --git a/chrome/browser/extensions/blacklist_state_fetcher.cc b/chrome/browser/extensions/blacklist_state_fetcher.cc
 --- a/chrome/browser/extensions/blacklist_state_fetcher.cc
@@ -1618,12 +1615,12 @@ diff --git a/chrome/browser/extensions/blacklist_state_fetcher.cc b/chrome/brows
 +      FROM_HERE, base::BindOnce(callback, BLACKLISTED_UNKNOWN));
 +  return;
  }
- 
+
  void BlacklistStateFetcher::SendRequest(const std::string& id) {
 @@ -64,8 +45,7 @@ void BlacklistStateFetcher::SendRequest(const std::string& id) {
    std::string request_str;
    request.SerializeToString(&request_str);
- 
+
 -  GURL request_url = GURL(safe_browsing::GetReportUrl(
 -      *safe_browsing_config_, "clientreport/crx-list-info"));
 +  GURL request_url = GURL();
@@ -1633,7 +1630,7 @@ diff --git a/chrome/browser/extensions/blacklist_state_fetcher.cc b/chrome/brows
 @@ -112,12 +92,6 @@ void BlacklistStateFetcher::SendRequest(const std::string& id) {
                       base::Unretained(this), fetcher));
  }
- 
+
 -void BlacklistStateFetcher::SetSafeBrowsingConfig(
 -    const safe_browsing::V4ProtocolConfig& config) {
 -  safe_browsing_config_ =
@@ -1647,21 +1644,21 @@ diff --git a/chrome/browser/extensions/blacklist_state_fetcher.h b/chrome/browse
 --- a/chrome/browser/extensions/blacklist_state_fetcher.h
 +++ b/chrome/browser/extensions/blacklist_state_fetcher.h
 @@ -34,8 +34,6 @@ class BlacklistStateFetcher {
- 
+
    virtual void Request(const std::string& id, const RequestCallback& callback);
- 
+
 -  void SetSafeBrowsingConfig(const safe_browsing::V4ProtocolConfig& config);
 -
   protected:
    void OnURLLoaderComplete(network::SimpleURLLoader* url_loader,
                             std::unique_ptr<std::string> response_body);
 @@ -54,7 +52,6 @@ class BlacklistStateFetcher {
- 
+
    void SendRequest(const std::string& id);
- 
+
 -  std::unique_ptr<safe_browsing::V4ProtocolConfig> safe_browsing_config_;
    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
- 
+
    // SimpleURLLoader -> (owned loader, extension id).
 diff --git a/chrome/browser/metrics/chrome_metrics_service_client.cc b/chrome/browser/metrics/chrome_metrics_service_client.cc
 --- a/chrome/browser/metrics/chrome_metrics_service_client.cc
@@ -1669,7 +1666,7 @@ diff --git a/chrome/browser/metrics/chrome_metrics_service_client.cc b/chrome/br
 @@ -773,9 +773,6 @@ void ChromeMetricsServiceClient::RegisterMetricsServiceProviders() {
    metrics_service_->RegisterMetricsProvider(
        std::make_unique<HttpsEngagementMetricsProvider>());
- 
+
 -  metrics_service_->RegisterMetricsProvider(
 -      std::make_unique<CertificateReportingMetricsProvider>());
 -
@@ -1690,7 +1687,7 @@ diff --git a/chrome/browser/native_file_system/chrome_native_file_system_permiss
 @@ -322,74 +321,6 @@ class ReadPermissionGrantImpl
    PermissionStatus status_ = PermissionStatus::GRANTED;
  };
- 
+
 -void DoSafeBrowsingCheckOnUIThread(
 -    int process_id,
 -    int frame_id,
@@ -1760,12 +1757,12 @@ diff --git a/chrome/browser/native_file_system/chrome_native_file_system_permiss
 -}
 -
  }  // namespace
- 
+
  ChromeNativeFileSystemPermissionContext::Grants::Grants() = default;
 @@ -666,28 +597,6 @@ void ChromeNativeFileSystemPermissionContext::ConfirmSensitiveDirectoryAccess(
                       std::move(callback)));
  }
- 
+
 -void ChromeNativeFileSystemPermissionContext::PerformSafeBrowsingChecks(
 -    std::unique_ptr<content::NativeFileSystemWriteItem> item,
 -    int process_id,
@@ -1797,7 +1794,7 @@ diff --git a/chrome/browser/native_file_system/chrome_native_file_system_permiss
 @@ -155,12 +155,6 @@ class ChromeNativeFileSystemPermissionContext
        int frame_id,
        base::OnceCallback<void(PermissionStatus)> callback) override;
- 
+
 -  void PerformSafeBrowsingChecks(
 -      std::unique_ptr<content::NativeFileSystemWriteItem> item,
 -      int process_id,
@@ -1818,7 +1815,7 @@ diff --git a/chrome/browser/net/trial_comparison_cert_verifier_controller.cc b/c
 -  CertificateReportingServiceFactory::GetForBrowserContext(profile_)->Send(
 -      serialized_report);
  }
- 
+
  // static
 diff --git a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc b/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
 --- a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
@@ -1844,7 +1841,7 @@ diff --git a/chrome/browser/profiles/profile_impl.cc b/chrome/browser/profiles/p
  #include "chrome/browser/signin/signin_ui_util.h"
 @@ -623,16 +622,6 @@ void ProfileImpl::LoadPrefsForNormalStartup(bool async_prefs) {
                           pref_registry_.get());
- 
+
    prefs::mojom::TrackedPreferenceValidationDelegatePtr pref_validation_delegate;
 -  scoped_refptr<safe_browsing::SafeBrowsingService> safe_browsing_service(
 -      g_browser_process->safe_browsing_service());
@@ -1856,7 +1853,7 @@ diff --git a/chrome/browser/profiles/profile_impl.cc b/chrome/browser/profiles/p
 -                              mojo::MakeRequest(&pref_validation_delegate));
 -    }
 -  }
- 
+
    prefs_ =
        CreatePrefService(pref_registry_, CreateExtensionPrefStore(this, false),
 diff --git a/chrome/browser/safe_browsing/BUILD.gn b/chrome/browser/safe_browsing/BUILD.gn
@@ -1864,7 +1861,7 @@ diff --git a/chrome/browser/safe_browsing/BUILD.gn b/chrome/browser/safe_browsin
 +++ b/chrome/browser/safe_browsing/BUILD.gn
 @@ -7,6 +7,7 @@ import("//components/safe_browsing/buildflags.gni")
  import("//extensions/buildflags/buildflags.gni")
- 
+
  jumbo_static_library("safe_browsing") {
 +  if (false) {
    sources = [
@@ -1883,7 +1880,7 @@ diff --git a/chrome/browser/safe_browsing/BUILD.gn b/chrome/browser/safe_browsin
      deps += [ "//extensions/browser" ]
    }
 +  }
- 
+
    if (safe_browsing_mode != 0) {
      # "Safe Browsing Basic" files used for safe browsing in full mode
 diff --git a/chrome/browser/ssl/captive_portal_blocking_page.cc b/chrome/browser/ssl/captive_portal_blocking_page.cc
@@ -1892,14 +1889,14 @@ diff --git a/chrome/browser/ssl/captive_portal_blocking_page.cc b/chrome/browser
 @@ -211,10 +211,7 @@ void CaptivePortalBlockingPage::PopulateInterstitialStrings(
    load_time_data->SetString("recurrentErrorParagraph", "");
    load_time_data->SetBoolean("show_recurrent_error_paragraph", false);
- 
+
 -  if (cert_report_helper())
 -    cert_report_helper()->PopulateExtendedReportingOption(load_time_data);
 -  else
 -    load_time_data->SetBoolean(security_interstitials::kDisplayCheckBox, false);
 +  load_time_data->SetBoolean(security_interstitials::kDisplayCheckBox, false);
  }
- 
+
  void CaptivePortalBlockingPage::CommandReceived(const std::string& command) {
 @@ -229,8 +226,6 @@ void CaptivePortalBlockingPage::CommandReceived(const std::string& command) {
    security_interstitials::SecurityInterstitialCommand cmd =
@@ -1920,13 +1917,13 @@ diff --git a/chrome/browser/ssl/cert_report_helper.cc b/chrome/browser/ssl/cert_
 -
 -  ssl_cert_reporter_->ReportInvalidCertificateChain(serialized_report);
  }
- 
+
  bool CertReportHelper::ShouldShowCertificateReporterCheckbox() {
 diff --git a/chrome/browser/ssl/security_state_tab_helper.cc b/chrome/browser/ssl/security_state_tab_helper.cc
 --- a/chrome/browser/ssl/security_state_tab_helper.cc
 +++ b/chrome/browser/ssl/security_state_tab_helper.cc
 @@ -160,88 +160,6 @@ bool SecurityStateTabHelper::UsedPolicyInstalledCertificate() const {
- 
+
  security_state::MaliciousContentStatus
  SecurityStateTabHelper::GetMaliciousContentStatus() const {
 -  content::NavigationEntry* entry =
@@ -2013,7 +2010,7 @@ diff --git a/chrome/browser/ssl/security_state_tab_helper.cc b/chrome/browser/ss
 -  }
    return security_state::MALICIOUS_CONTENT_STATUS_NONE;
  }
- 
+
 diff --git a/chrome/browser/subresource_filter/chrome_subresource_filter_client.cc b/chrome/browser/subresource_filter/chrome_subresource_filter_client.cc
 --- a/chrome/browser/subresource_filter/chrome_subresource_filter_client.cc
 +++ b/chrome/browser/subresource_filter/chrome_subresource_filter_client.cc
@@ -2031,7 +2028,7 @@ diff --git a/chrome/browser/subresource_filter/chrome_subresource_filter_client.
 -            base::CreateSingleThreadTaskRunner({content::BrowserThread::IO}),
 -            safe_browsing_service->database_manager()));
 -  }
- 
+
    throttle_manager_->MaybeAppendNavigationThrottles(navigation_handle,
                                                      throttles);
 diff --git a/chrome/browser/ui/BUILD.gn b/chrome/browser/ui/BUILD.gn
@@ -2093,7 +2090,7 @@ diff --git a/chrome/browser/ui/webui/interstitials/interstitial_ui.cc b/chrome/b
 @@ -271,6 +271,7 @@ LookalikeUrlInterstitialPage* CreateLookalikeInterstitialPage(
                                                       safe_url));
  }
- 
+
 +#if 0
  safe_browsing::SafeBrowsingBlockingPage* CreateSafeBrowsingBlockingPage(
      content::WebContents* web_contents) {
@@ -2103,7 +2100,7 @@ diff --git a/chrome/browser/ui/webui/interstitials/interstitial_ui.cc b/chrome/b
        web_contents, main_frame_url, resource);
  }
 +#endif
- 
+
 +#if 0
  TestSafeBrowsingBlockingPageQuiet* CreateSafeBrowsingQuietBlockingPage(
      content::WebContents* web_contents) {
@@ -2113,7 +2110,7 @@ diff --git a/chrome/browser/ui/webui/interstitials/interstitial_ui.cc b/chrome/b
        web_contents, main_frame_url, resource, is_giant_webview);
  }
 +#endif
- 
+
  #if BUILDFLAG(ENABLE_CAPTIVE_PORTAL_DETECTION)
  CaptivePortalBlockingPage* CreateCaptivePortalBlockingPage(
 @@ -487,8 +491,6 @@ void InterstitialHTMLSource::StartDataRequest(
@@ -2145,7 +2142,7 @@ diff --git a/chrome/common/safe_browsing/BUILD.gn b/chrome/common/safe_browsing/
 @@ -14,20 +14,6 @@ proto_library("proto") {
    ]
  }
- 
+
 -source_set("file_type_policies") {
 -  sources = [
 -    "file_type_policies.cc",
@@ -2164,12 +2161,12 @@ diff --git a/chrome/common/safe_browsing/BUILD.gn b/chrome/common/safe_browsing/
    source_set("archive_analyzer_results") {
      sources = [
 @@ -150,7 +136,6 @@ if (safe_browsing_mode == 1) {
- 
+
  source_set("safe_browsing") {
    deps = [
 -    ":file_type_policies",
    ]
- 
+
    if (safe_browsing_mode == 1) {
 diff --git a/chrome/renderer/chrome_content_renderer_client.cc b/chrome/renderer/chrome_content_renderer_client.cc
 --- a/chrome/renderer/chrome_content_renderer_client.cc
@@ -2186,12 +2183,12 @@ diff --git a/components/password_manager/core/browser/BUILD.gn b/components/pass
 --- a/components/password_manager/core/browser/BUILD.gn
 +++ b/components/password_manager/core/browser/BUILD.gn
 @@ -12,7 +12,7 @@ if (is_android) {
- 
+
  # TODO(crbug.com/706392): Fix password reuse detection for Android.
  password_reuse_detection_support = !is_android && !is_ios
 -password_on_focus_ping_support = !is_ios
 +password_on_focus_ping_support = !is_android && !is_ios
- 
+
  config("password_reuse_detection_config") {
    defines = []
 diff --git a/components/safe_browsing/features.cc b/components/safe_browsing/features.cc
@@ -2199,11 +2196,11 @@ diff --git a/components/safe_browsing/features.cc b/components/safe_browsing/fea
 +++ b/components/safe_browsing/features.cc
 @@ -63,7 +63,7 @@ const base::Feature kSendOnFocusPing {
  #endif
- 
+
  const base::Feature kSuspiciousSiteTriggerQuotaFeature{
 -    "SafeBrowsingSuspiciousSiteTriggerQuota", base::FEATURE_ENABLED_BY_DEFAULT};
 +    "SafeBrowsingSuspiciousSiteTriggerQuota", base::FEATURE_DISABLED_BY_DEFAULT};
- 
+
  const base::Feature kThreatDomDetailsTagAndAttributeFeature{
      "ThreatDomDetailsTagAttributes", base::FEATURE_DISABLED_BY_DEFAULT};
 diff --git a/components/unified_consent/unified_consent_service.cc b/components/unified_consent/unified_consent_service.cc
@@ -2211,12 +2208,12 @@ diff --git a/components/unified_consent/unified_consent_service.cc b/components/
 +++ b/components/unified_consent/unified_consent_service.cc
 @@ -75,7 +75,7 @@ void UnifiedConsentService::SetUrlKeyedAnonymizedDataCollectionEnabled(
      SetMigrationState(MigrationState::kCompleted);
- 
+
    pref_service_->SetBoolean(prefs::kUrlKeyedAnonymizedDataCollectionEnabled,
 -                            enabled);
 +                            false);
  }
- 
+
  void UnifiedConsentService::Shutdown() {
 diff --git a/content/browser/native_file_system/native_file_system_file_writer_impl.cc b/content/browser/native_file_system/native_file_system_file_writer_impl.cc
 --- a/content/browser/native_file_system/native_file_system_file_writer_impl.cc
@@ -2230,11 +2227,11 @@ diff --git a/content/browser/native_file_system/native_file_system_file_writer_i
 +      swap_url_(swap_url) {
    DCHECK_EQ(swap_url.type(), url.type());
  }
- 
+
 @@ -296,48 +295,7 @@ void NativeFileSystemFileWriterImpl::CloseImpl(CloseCallback callback) {
    // swap file even if the writer was destroyed at that point.
    state_ = State::kClosePending;
- 
+
 -  if (!require_safe_browsing_check() || !manager()->permission_context()) {
 -    DidPassSafeBrowsingCheck(std::move(callback));
 -    return;
@@ -2279,7 +2276,7 @@ diff --git a/content/browser/native_file_system/native_file_system_file_writer_i
 -                     file_writer, swap_path, std::move(callback)));
 +  DidPassSafeBrowsingCheck(std::move(callback));
  }
- 
+
  // static
 diff --git a/content/browser/native_file_system/native_file_system_file_writer_impl.h b/content/browser/native_file_system/native_file_system_file_writer_impl.h
 --- a/content/browser/native_file_system/native_file_system_file_writer_impl.h
@@ -2302,31 +2299,31 @@ diff --git a/content/browser/native_file_system/native_file_system_file_writer_i
        base::WeakPtr<NativeFileSystemFileWriterImpl> file_writer,
        const base::FilePath& swap_path,
 @@ -109,7 +102,7 @@ class CONTENT_EXPORT NativeFileSystemFileWriterImpl
- 
+
    // Safe browsing checks only apply to native local paths.
    bool require_safe_browsing_check() {
 -    return url().type() == storage::kFileSystemTypeNativeLocal;
 +    return false;
    }
- 
+
    // Quarantine checks only apply to native local paths.
 @@ -149,10 +142,6 @@ class CONTENT_EXPORT NativeFileSystemFileWriterImpl
- 
+
    bool skip_quarantine_check_for_testing_ = false;
- 
+
 -  // Keeps track of user activation state at creation time for SafeBrowsing
 -  // checks.
 -  bool has_transient_user_activation_ = false;
 -
    base::WeakPtr<NativeFileSystemHandleBase> AsWeakPtr() override;
- 
+
    base::WeakPtrFactory<NativeFileSystemFileWriterImpl> weak_factory_{this};
 diff --git a/content/public/browser/native_file_system_permission_context.h b/content/public/browser/native_file_system_permission_context.h
 --- a/content/public/browser/native_file_system_permission_context.h
 +++ b/content/public/browser/native_file_system_permission_context.h
 @@ -95,13 +95,6 @@ class NativeFileSystemPermissionContext {
        base::OnceCallback<void(SensitiveDirectoryResult)> callback) = 0;
- 
+
    enum class SafeBrowsingResult { kAllow, kBlock };
 -  // Runs a recently finished write operation through Safe Browsing code to
 -  // determine if the write should be allowed or blocked.
@@ -2335,9 +2332,9 @@ diff --git a/content/public/browser/native_file_system_permission_context.h b/co
 -      int process_id,
 -      int frame_id,
 -      base::OnceCallback<void(SafeBrowsingResult)> callback) = 0;
- 
+
    // Returns whether the given |origin| is allowed to ask for write access.
    // This is used to block save file dialogs from being shown
--- 
+--
 2.11.0
 


### PR DESCRIPTION
Applying `Disable-safe-browsing.patch` was failing due to `chrome/android/java/src/org/chromium/chrome/browser/preferences/privacy/PrivacyPreferences.java:36` and `chrome/android/java/strings/android_chrome_strings.grd:421`.

NOTE: When `Disable-safe-browsing.patch` fails, these additional patches fail as well(dependent patches):
- `Add-custom-tab-intents-privacy-option.patch`
- `Add-option-to-not-persist-tabs-across-sessions.patch`
- `Add-a-proxy-configuration-page.patch`