### PR TITLE
Update zh_CN translations

### DIFF
--- a/build/patches/Update-i18n-zh_CN-support.patch
+++ b/build/patches/Update-i18n-zh_CN-support.patch
@@ -1,24 +1,12 @@
 From: mars <gzhqyz@gmail.com>
-Date: Wed, 13 May 2020 11:28:04 +0800
+Date: Sun, 2 Aug 2020 00:37:49 +0800
 Subject: Update i18n zh_CN support
 
 ---
- .../app/resources/chromium_strings_zh-CN.xtb   |  3 ++-
- .../resources/generated_resources_zh-CN.xtb    |  6 +++++-
- .../android_chrome_strings_zh-CN.xtb           | 18 ++++++++++++++++++
- 3 files changed, 25 insertions(+), 2 deletions(-)
+ .../resources/generated_resources_zh-CN.xtb   |  6 +++++-
+ .../android_chrome_strings_zh-CN.xtb          | 21 ++++++++++++++++++-
+ 2 files changed, 25 insertions(+), 2 deletions(-)
 
-diff --git a/chrome/app/resources/chromium_strings_zh-CN.xtb b/chrome/app/resources/chromium_strings_zh-CN.xtb
---- a/chrome/app/resources/chromium_strings_zh-CN.xtb
-+++ b/chrome/app/resources/chromium_strings_zh-CN.xtb
-@@ -245,4 +245,5 @@ Chromium 无法恢复您的设置。</translation>
- <translation id="93478295209880648">Chromium 可能无法正常运行，因为它不再支持 Windows XP 和 Windows Vista</translation>
- <translation id="95514773681268843"><ph name="DOMAIN" /> 要求您必须先阅读并接受以下服务条款，才能使用此设备。这些条款不会扩大、修改或限制 Chromium 操作系统条款。</translation>
- <translation id="985602178874221306">The Chromium Authors</translation>
--</translationbundle>
-\ No newline at end of file
-+<translation id="9090881409075599658">关于 Bromite</translation>
-+</translationbundle>
 diff --git a/chrome/app/resources/generated_resources_zh-CN.xtb b/chrome/app/resources/generated_resources_zh-CN.xtb
 --- a/chrome/app/resources/generated_resources_zh-CN.xtb
 +++ b/chrome/app/resources/generated_resources_zh-CN.xtb
@@ -36,10 +24,13 @@ diff --git a/chrome/app/resources/generated_resources_zh-CN.xtb b/chrome/app/res
 diff --git a/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb b/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb
 --- a/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb
 +++ b/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb
-@@ -1011,4 +1011,22 @@
- <translation id="666268767214822976">当您在地址栏中输入查询内容时，使用联想查询服务显示相关查询和热门网站</translation>
- <translation id="8283853025636624853">正在同步到 <ph name="SYNC_ACCOUNT_USER_NAME" /></translation>
- <translation id="8981454092730389528">Google 活动控件</translation>
+@@ -994,4 +994,23 @@
+ <translation id="981121421437150478">离线</translation>
+ <translation id="983192555821071799">关闭所有标签页</translation>
+ <translation id="987264212798334818">常规</translation>
+-</translationbundle>
+\ No newline at end of file
++<translation id="5334844597069022743">查看源代码</translation>
 +<translation id="9090881409075599658">关于 Bromite</translation>
 +<translation id="9148058034647219655">退出</translation>
 +<translation id="6544149167512551709">保留 Cookies 直到您退出浏览器</translation>
@@ -58,7 +49,7 @@ diff --git a/chrome/browser/ui/android/strings/translations/android_chrome_strin
 +<translation id="3544784763752062458">编辑过滤器地址</translation>
 +<translation id="4456370887631736415">过滤器地址</translation>
 +<translation id="8189997785233370573">访问帮助页面</translation>
- </translationbundle>
--- 
-2.17.1
++</translationbundle>
+--
+2.28.0
 


### PR DESCRIPTION
- Add translation for `View source` introduced by v84.0.4147.90.
- Remove `About Bromite` translation from `chromium_strings_zh-CN.xtb` since it never works.
