### PR TITLE
WebGL & Device Model Fingerprinting Protection

### DIFF
--- a/build/bromite_patches_list.txt
+++ b/build/bromite_patches_list.txt
@@ -150,3 +150,4 @@ Disable-the-DIAL-repeating-discovery.patch
 Timezone-customization.patch
 Block-all-connection-requests-with-qjz9zk-in-the-domain-name-or-with-a-trk-scheme.patch
 Automated-domain-substitution.patch
+Hack-Webgl-WebGLDebugShaders.patch

--- a/build/patches/Hack-Webgl-WebGLDebugShaders.patch
+++ b/build/patches/Hack-Webgl-WebGLDebugShaders.patch
@@ -1,4 +1,4 @@
-From: root <root@ubuntu.cabponte>
+From: uazo <uazo@users.noreply.github.com>
 Date: Sat, 5 Sep 2020 06:58:52 +0000
 Subject: hack WebGLDebugShaders extension
 

--- a/build/patches/Hack-Webgl-WebGLDebugShaders.patch
+++ b/build/patches/Hack-Webgl-WebGLDebugShaders.patch
@@ -1,0 +1,46 @@
+From: root <root@ubuntu.cabponte>
+Date: Sat, 5 Sep 2020 06:58:52 +0000
+Subject: hack WebGLDebugShaders extension
+
+---
+ .../modules/webgl/webgl_debug_renderer_info.cc     |  2 +-
+ .../renderer/modules/webgl/webgl_debug_shaders.cc  | 14 +++++++-------
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/third_party/blink/renderer/modules/webgl/webgl_debug_renderer_info.cc b/third_party/blink/renderer/modules/webgl/webgl_debug_renderer_info.cc
+--- a/third_party/blink/renderer/modules/webgl/webgl_debug_renderer_info.cc
++++ b/third_party/blink/renderer/modules/webgl/webgl_debug_renderer_info.cc
+@@ -36,7 +36,7 @@ WebGLExtensionName WebGLDebugRendererInfo::GetName() const {
+ }
+ 
+ bool WebGLDebugRendererInfo::Supported(WebGLRenderingContextBase*) {
+-  return true;
++  return false;
+ }
+ 
+ const char* WebGLDebugRendererInfo::ExtensionName() {
+diff --git a/third_party/blink/renderer/modules/webgl/webgl_debug_shaders.cc b/third_party/blink/renderer/modules/webgl/webgl_debug_shaders.cc
+--- a/third_party/blink/renderer/modules/webgl/webgl_debug_shaders.cc
++++ b/third_party/blink/renderer/modules/webgl/webgl_debug_shaders.cc
+@@ -44,14 +44,14 @@ WebGLExtensionName WebGLDebugShaders::GetName() const {
+ 
+ String WebGLDebugShaders::getTranslatedShaderSource(WebGLShader* shader) {
+   WebGLExtensionScopedContext scoped(this);
+-  if (scoped.IsLost())
+-    return String();
+-  if (!scoped.Context()->ValidateWebGLObject("getTranslatedShaderSource",
+-                                             shader))
++//  if (scoped.IsLost())
++//    return String();
++//  if (!scoped.Context()->ValidateWebGLObject("getTranslatedShaderSource",
++//                                             shader))
+     return "";
+-  GLStringQuery query(scoped.Context()->ContextGL());
+-  return query.Run<GLStringQuery::TranslatedShaderSourceANGLE>(
+-      shader->Object());
++//  GLStringQuery query(scoped.Context()->ContextGL());
++//  return query.Run<GLStringQuery::TranslatedShaderSourceANGLE>(
++//      shader->Object());
+ }
+ 
+ bool WebGLDebugShaders::Supported(WebGLRenderingContextBase* context) {


### PR DESCRIPTION
as you wrote https://github.com/bromite/bromite/issues/668, I propose a possible patch to hide vendor info in WebGLDebugRendererInfo.

tell me what you think and if you prefer a switch
