### PR TITLE
Intent handling fix for local apps on Android 11

### DIFF
--- a/build/bromite_patches_list.txt
+++ b/build/bromite_patches_list.txt
@@ -152,3 +152,4 @@ Flag-for-always-desktop-mode.patch
 Restore-Simplified-NTP-launch.patch
 Revert-the-removal-of-an-option-to-block-autoplay.patch
 Automated-domain-substitution.patch
+Add-query-all-packages-permission-for-R.patch

--- a/build/patches/Add-query-all-packages-permission-for-R.patch
+++ b/build/patches/Add-query-all-packages-permission-for-R.patch
@@ -1,0 +1,16 @@
+From: nikolowry <nikolowry@users.noreply.github.com>
+Date: Fri, 20 Nov 2020 19:47:14 -0500
+Subject: Intent handling fix for local apps on Android 11
+
+---
+ chrome/android/java/AndroidManifest.xml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/chrome/android/java/AndroidManifest.xml b/chrome/android/java/AndroidManifest.xml
+--- a/chrome/android/java/AndroidManifest.xml
++++ b/chrome/android/java/AndroidManifest.xml
+@@ -54,3 +54,4 @@ by a child template that "extends" this file.
+     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+     <uses-permission android:name="android.permission.NFC"/>
++    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
See https://github.com/brave/brave-browser/issues/12330 for more details.

I was experiencing this issue for the past week on my new Pixel 5 running ProtonAOSP, and can confirm the new `QUERY_ALL_PACKAGES` permission resolved the issue.

I see there's currently 5 other patches that target `chrome/android/java/AndroidManifest.xml`, so feel free to reject this requested approach if you think there's a better way to add the permission -- whatever's easiest to maintain.

Sidebar: Google Chrome's official builds seem to have already added this permission, but they overlooked porting it back to Chromium. Wouldn't be surprised if it got forgotten during all the recent build targets shuffling 