### PR TITLE
Enable proxy config for the system network context

### DIFF
--- a/build/patches/Add-a-proxy-configuration-page.patch
+++ b/build/patches/Add-a-proxy-configuration-page.patch
@@ -12,6 +12,9 @@ Offer auto-complete for the proxy page URL.
  .../privacy/settings/PrivacySettings.java     |   5 +-
  .../chrome_autocomplete_provider_client.cc    |   2 +
  chrome/browser/browser_resources.grd          |   6 +
+ chrome/browser/net/proxy_service_factory.cc   |  23 +-
+ chrome/browser/net/proxy_service_factory.h    |   3 +
+ chrome/browser/prefs/browser_prefs.cc         |   4 +
  .../prefs/chrome_command_line_pref_store.cc   |   2 +-
  chrome/browser/resources/proxy_config.css     |  61 +++
  chrome/browser/resources/proxy_config.html    |  80 ++++
@@ -23,11 +26,12 @@ Offer auto-complete for the proxy page URL.
  chrome/common/webui_url_constants.cc          |   4 +
  chrome/common/webui_url_constants.h           |   2 +
  .../core/browser/proxy_policy_handler.cc      |   2 +-
- .../proxy_config/proxy_config_dictionary.cc   |  22 +-
- .../proxy_config/proxy_config_dictionary.h    |   6 +-
+ .../pref_proxy_config_tracker_impl.cc         |   1 +
+ .../proxy_config/proxy_config_dictionary.cc   |  30 +-
+ .../proxy_config/proxy_config_dictionary.h    |   7 +-
  net/proxy_resolution/proxy_config.cc          |  52 ++-
  net/proxy_resolution/proxy_config.h           |   3 +
- 20 files changed, 953 insertions(+), 14 deletions(-)
+ 24 files changed, 992 insertions(+), 15 deletions(-)
  create mode 100644 chrome/browser/resources/proxy_config.css
  create mode 100644 chrome/browser/resources/proxy_config.html
  create mode 100644 chrome/browser/resources/proxy_config.js
@@ -109,6 +113,92 @@ diff --git a/chrome/browser/browser_resources.grd b/chrome/browser/browser_resou
        <if expr="not is_android">
          <!-- New Tab Page -->
          <part file="resources/local_ntp/icons.grdp" />
+diff --git a/chrome/browser/net/proxy_service_factory.cc b/chrome/browser/net/proxy_service_factory.cc
+--- a/chrome/browser/net/proxy_service_factory.cc
++++ b/chrome/browser/net/proxy_service_factory.cc
+@@ -14,6 +14,9 @@
+ #include "content/public/browser/browser_thread.h"
+ #include "net/proxy_resolution/configured_proxy_resolution_service.h"
+ #include "net/proxy_resolution/proxy_config_service.h"
++#include "components/proxy_config/proxy_config_pref_names.h"
++#include "components/prefs/pref_service.h"
++#include "components/prefs/pref_registry_simple.h"
+ 
+ #if defined(OS_CHROMEOS)
+ #include "chromeos/network/proxy/proxy_config_service_impl.h"
+@@ -58,7 +61,20 @@ ProxyServiceFactory::CreatePrefProxyConfigTrackerOfProfile(
+   return std::make_unique<chromeos::ProxyConfigServiceImpl>(
+       profile_prefs, local_state_prefs, nullptr);
+ #else
+-  return std::make_unique<PrefProxyConfigTrackerImpl>(profile_prefs, nullptr);
++  // Migrate from profile_prefs to local_state_prefs
++  if (local_state_prefs->GetBoolean("proxy_migrated") == false) {
++    const base::DictionaryValue* dict =
++        profile_prefs->GetDictionary(proxy_config::prefs::kProxy);
++
++    LOG(INFO) << "CreatePrefProxyConfigTrackerOfProfile: Migration from profile to local state";
++
++    const base::Value /*ProxyConfigDictionary*/ proxy_dict(dict->Clone());
++    local_state_prefs->Set(proxy_config::prefs::kProxy, proxy_dict);
++
++    local_state_prefs->SetBoolean("proxy_migrated", true);
++    local_state_prefs->CommitPendingWrite();
++  }
++  return std::make_unique<PrefProxyConfigTrackerImpl>(local_state_prefs, nullptr);
+ #endif  // defined(OS_CHROMEOS)
+ }
+ 
+@@ -74,3 +90,8 @@ ProxyServiceFactory::CreatePrefProxyConfigTrackerOfLocalState(
+                                                       nullptr);
+ #endif  // defined(OS_CHROMEOS)
+ }
++
++// static
++void ProxyServiceFactory::RegisterPrefs(PrefRegistrySimple* registry) {
++  registry->RegisterBooleanPref("proxy_migrated", false);
++}
+\ No newline at end of file
+diff --git a/chrome/browser/net/proxy_service_factory.h b/chrome/browser/net/proxy_service_factory.h
+--- a/chrome/browser/net/proxy_service_factory.h
++++ b/chrome/browser/net/proxy_service_factory.h
+@@ -8,6 +8,7 @@
+ #include <memory>
+ 
+ #include "base/macros.h"
++#include "components/prefs/pref_registry_simple.h"
+ 
+ class PrefProxyConfigTracker;
+ class PrefService;
+@@ -37,6 +38,8 @@ class ProxyServiceFactory {
+   static std::unique_ptr<PrefProxyConfigTracker>
+   CreatePrefProxyConfigTrackerOfLocalState(PrefService* local_state_prefs);
+ 
++  static void RegisterPrefs(PrefRegistrySimple* registry);
++
+  private:
+   DISALLOW_IMPLICIT_CONSTRUCTORS(ProxyServiceFactory);
+ };
+diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browser_prefs.cc
+--- a/chrome/browser/prefs/browser_prefs.cc
++++ b/chrome/browser/prefs/browser_prefs.cc
+@@ -401,6 +401,8 @@
+ #include "chrome/browser/media/kaleidoscope/kaleidoscope_prefs.h"
+ #endif
+ 
++#include "chrome/browser/net/proxy_service_factory.h"
++
+ namespace {
+ 
+ // Deprecated 9/2019
+@@ -642,6 +644,8 @@ void RegisterLocalState(PrefRegistrySimple* registry) {
+   PluginsResourceService::RegisterPrefs(registry);
+ #endif
+ 
++  ProxyServiceFactory::RegisterPrefs(registry);
++
+ #if defined(OS_ANDROID)
+   ::android::RegisterPrefs(registry);
+ 
 diff --git a/chrome/browser/prefs/chrome_command_line_pref_store.cc b/chrome/browser/prefs/chrome_command_line_pref_store.cc
 --- a/chrome/browser/prefs/chrome_command_line_pref_store.cc
 +++ b/chrome/browser/prefs/chrome_command_line_pref_store.cc
@@ -676,7 +766,7 @@ new file mode 100644
 +
 + private:
 +  // Not owned.
-+  Profile *profile_;
++  PrefService *pref_service_;
 +  std::unique_ptr<net::ProxyConfigService> proxy_config_service_;
 +  // Monitors global and Profile prefs related to proxy configuration.
 +  std::unique_ptr<PrefProxyConfigTracker> pref_proxy_config_tracker_;
@@ -696,7 +786,7 @@ new file mode 100644
 +      weak_ptr_factory_(this) {
 +
 +  // used to set new configuration preferences
-+  profile_ = profile->GetOriginalProfile();
++  pref_service_ = g_browser_process->local_state();
 +  // observer is explicitly added only later in enableNotifyUIWithState
 +  is_observing_ = false;
 +
@@ -834,7 +924,7 @@ new file mode 100644
 +  auto availability = proxy_config_service_->GetLatestProxyConfig(&config);
 +
 +  const base::DictionaryValue* dict =
-+      profile_->GetPrefs()->GetDictionary(proxy_config::prefs::kProxy);
++      pref_service_->GetDictionary(proxy_config::prefs::kProxy);
 +  ProxyConfigDictionary proxy_dict(dict->Clone());
 +  ProxyPrefs::ProxyMode mode;
 +  if (!proxy_dict.GetMode(&mode) || mode == ProxyPrefs::MODE_SYSTEM) {
@@ -848,8 +938,8 @@ new file mode 100644
 +  DCHECK_CURRENTLY_ON(BrowserThread::UI);
 +
 +  const base::Value cfg = ProxyConfigDictionary::CreateSystem();
-+  profile_->GetPrefs()->Set(proxy_config::prefs::kProxy, cfg);
-+  profile_->GetPrefs()->CommitPendingWrite();
++  pref_service_->Set(proxy_config::prefs::kProxy, cfg);
++  pref_service_->CommitPendingWrite();
 +  OnEnableNotifyUIWithState(nullptr);
 +}
 +
@@ -959,13 +1049,13 @@ new file mode 100644
 +void ProxyConfigMessageHandler::apply(const net::ProxyConfig& proxyConfig) {
 +  if (proxyConfig.auto_detect()) {
 +    const base::Value cfg = ProxyConfigDictionary::CreateAutoDetect();
-+    profile_->GetPrefs()->Set(proxy_config::prefs::kProxy, cfg);
++    pref_service_->Set(proxy_config::prefs::kProxy, cfg);
 +  } else if (proxyConfig.has_pac_url()) {
 +    const base::Value cfg = ProxyConfigDictionary::CreatePacScript(proxyConfig.pac_url().spec(), proxyConfig.pac_mandatory());
-+    profile_->GetPrefs()->Set(proxy_config::prefs::kProxy, cfg);
++    pref_service_->Set(proxy_config::prefs::kProxy, cfg);
 +  } else if (proxyConfig.proxy_rules().type == net::ProxyConfig::ProxyRules::Type::EMPTY) {
 +    const base::Value cfg = ProxyConfigDictionary::CreateDirect();
-+    profile_->GetPrefs()->Set(proxy_config::prefs::kProxy, cfg);
++    pref_service_->Set(proxy_config::prefs::kProxy, cfg);
 +  } else {
 +    auto proxyRulesAsString = proxyConfig.proxy_rules().ToString();
 +    auto bypassRulesAsString = proxyConfig.proxy_rules().bypass_rules.ToString();
@@ -973,9 +1063,9 @@ new file mode 100644
 +    // fixed servers
 +    const base::Value cfg = ProxyConfigDictionary::CreateFixedServers(proxyRulesAsString,
 +                            bypassRulesAsString, proxyConfig.proxy_rules().reverse_bypass);
-+    profile_->GetPrefs()->Set(proxy_config::prefs::kProxy, cfg);
++    pref_service_->Set(proxy_config::prefs::kProxy, cfg);
 +  }
-+  profile_->GetPrefs()->CommitPendingWrite();
++  pref_service_->CommitPendingWrite();
 +  OnEnableNotifyUIWithState(nullptr);
 +}
 +
@@ -1079,6 +1169,17 @@ diff --git a/components/policy/core/browser/proxy_policy_handler.cc b/components
        }
        break;
      }
+diff --git a/components/proxy_config/pref_proxy_config_tracker_impl.cc b/components/proxy_config/pref_proxy_config_tracker_impl.cc
+--- a/components/proxy_config/pref_proxy_config_tracker_impl.cc
++++ b/components/proxy_config/pref_proxy_config_tracker_impl.cc
+@@ -380,6 +380,7 @@ bool PrefProxyConfigTrackerImpl::PrefConfigToNetConfig(
+       if (proxy_dict.GetBypassList(&proxy_bypass)) {
+         proxy_config.proxy_rules().bypass_rules.ParseFromString(proxy_bypass);
+       }
++      proxy_config.proxy_rules().reverse_bypass = proxy_dict.HasReverseBypass();
+       *config = net::ProxyConfigWithAnnotation(
+           proxy_config, kSettingsProxyConfigTrafficAnnotation);
+       return true;
 diff --git a/components/proxy_config/proxy_config_dictionary.cc b/components/proxy_config/proxy_config_dictionary.cc
 --- a/components/proxy_config/proxy_config_dictionary.cc
 +++ b/components/proxy_config/proxy_config_dictionary.cc
@@ -1091,7 +1192,22 @@ diff --git a/components/proxy_config/proxy_config_dictionary.cc b/components/pro
  
  }  // namespace
  
-@@ -79,29 +81,30 @@ const base::Value& ProxyConfigDictionary::GetDictionary() const {
+@@ -72,6 +74,14 @@ bool ProxyConfigDictionary::HasBypassList() const {
+   return dict_.FindKey(kProxyBypassList);
+ }
+ 
++bool ProxyConfigDictionary::HasReverseBypass() const {
++  const base::Value* value = dict_.FindKey(kProxyReverseBypass);
++  if (!value || !value->is_bool()) {
++    return false;
++  }
++  return value->GetBool();
++}
++
+ const base::Value& ProxyConfigDictionary::GetDictionary() const {
+   return dict_;
+ }
+@@ -79,29 +89,30 @@ const base::Value& ProxyConfigDictionary::GetDictionary() const {
  // static
  base::Value ProxyConfigDictionary::CreateDirect() {
    return CreateDictionary(ProxyPrefs::MODE_DIRECT, std::string(), false,
@@ -1127,7 +1243,7 @@ diff --git a/components/proxy_config/proxy_config_dictionary.cc b/components/pro
    } else {
      return CreateDirect();
    }
-@@ -110,7 +113,7 @@ base::Value ProxyConfigDictionary::CreateFixedServers(
+@@ -110,7 +121,7 @@ base::Value ProxyConfigDictionary::CreateFixedServers(
  // static
  base::Value ProxyConfigDictionary::CreateSystem() {
    return CreateDictionary(ProxyPrefs::MODE_SYSTEM, std::string(), false,
@@ -1136,7 +1252,7 @@ diff --git a/components/proxy_config/proxy_config_dictionary.cc b/components/pro
  }
  
  // static
-@@ -119,7 +122,8 @@ base::Value ProxyConfigDictionary::CreateDictionary(
+@@ -119,7 +130,8 @@ base::Value ProxyConfigDictionary::CreateDictionary(
      const std::string& pac_url,
      bool pac_mandatory,
      const std::string& proxy_server,
@@ -1146,7 +1262,7 @@ diff --git a/components/proxy_config/proxy_config_dictionary.cc b/components/pro
    base::Value dict(base::Value::Type::DICTIONARY);
    dict.SetKey(kProxyMode, base::Value(ProxyModeToString(mode)));
    if (!pac_url.empty()) {
-@@ -128,8 +132,10 @@ base::Value ProxyConfigDictionary::CreateDictionary(
+@@ -128,8 +140,10 @@ base::Value ProxyConfigDictionary::CreateDictionary(
    }
    if (!proxy_server.empty())
      dict.SetKey(kProxyServer, base::Value(proxy_server));
@@ -1161,7 +1277,15 @@ diff --git a/components/proxy_config/proxy_config_dictionary.cc b/components/pro
 diff --git a/components/proxy_config/proxy_config_dictionary.h b/components/proxy_config/proxy_config_dictionary.h
 --- a/components/proxy_config/proxy_config_dictionary.h
 +++ b/components/proxy_config/proxy_config_dictionary.h
-@@ -46,7 +46,8 @@ class PROXY_CONFIG_EXPORT ProxyConfigDictionary {
+@@ -38,6 +38,7 @@ class PROXY_CONFIG_EXPORT ProxyConfigDictionary {
+   bool GetProxyServer(std::string* out) const;
+   bool GetBypassList(std::string* out) const;
+   bool HasBypassList() const;
++  bool HasReverseBypass() const;
+ 
+   const base::Value& GetDictionary() const;
+ 
+@@ -46,7 +47,8 @@ class PROXY_CONFIG_EXPORT ProxyConfigDictionary {
    static base::Value CreatePacScript(const std::string& pac_url,
                                       bool pac_mandatory);
    static base::Value CreateFixedServers(const std::string& proxy_server,
@@ -1171,7 +1295,7 @@ diff --git a/components/proxy_config/proxy_config_dictionary.h b/components/prox
    static base::Value CreateSystem();
  
    // Encodes the proxy server as "<url-scheme>=<proxy-scheme>://<proxy>".
-@@ -62,7 +63,8 @@ class PROXY_CONFIG_EXPORT ProxyConfigDictionary {
+@@ -62,7 +64,8 @@ class PROXY_CONFIG_EXPORT ProxyConfigDictionary {
                                        const std::string& pac_url,
                                        bool pac_mandatory,
                                        const std::string& proxy_server,


### PR DESCRIPTION
The current patch comes from the implementation for ChromeOS which gets the proxy information from the local_state for the system network context.

This is not completely correct in Android, since the network context is never connected to any user profile and only gets the proxy information from the system.

With this change settings are moved from the Profile to LocalState, allowing the transparent use of the proxy also for SimpleURLLoaders (for example used for downloading Adblock filters and for favicons, which currently do not use any proxy even if set). Existing settings are automatically migrated on first startup.