### PR TITLE
Update DIAL repeating discovery patch

### DIFF
--- a/build/patches/Disable-the-DIAL-repeating-discovery.patch
+++ b/build/patches/Disable-the-DIAL-repeating-discovery.patch
@@ -4,8 +4,8 @@ Subject: Disable the DIAL repeating discovery
 
 This causes unnecessary SSDP network spam
 ---
- chrome/browser/media/router/discovery/dial/dial_registry.cc | 4 ----
- 1 file changed, 4 deletions(-)
+ chrome/browser/media/router/discovery/dial/dial_registry.cc | 6 ----
+ 1 file changed, 6 deletions(-)
 
 diff --git a/chrome/browser/media/router/discovery/dial/dial_registry.cc b/chrome/browser/media/router/discovery/dial/dial_registry.cc
 --- a/chrome/browser/media/router/discovery/dial/dial_registry.cc
@@ -21,6 +21,15 @@ diff --git a/chrome/browser/media/router/discovery/dial/dial_registry.cc b/chrom
  }
  
  void DialRegistry::DoDiscovery() {
+@@ -209,8 +205,6 @@ void DialRegistry::StopPeriodicDiscovery
+   if (!dial_)
+     return;
+ 
+-  repeating_timer_->Stop();
+-  repeating_timer_.reset();
+   dial_->RemoveObserver(this);
+   ClearDialService();
+ }
 -- 
 2.17.1
 


### PR DESCRIPTION
This PR adds a fix to the DIAL repeating discovery patch to resolve a potential crash when the network state changes.  
