### PR TITLE
always-incognito mode: remove unnecessary code for v90

### DIFF
--- a/build/patches/Add-an-always-incognito-mode.patch
+++ b/build/patches/Add-an-always-incognito-mode.patch
@@ -14,7 +14,6 @@ Enable incognito custom tabs and fix crashes for incognito/custom tab intents (c
  .../chrome/browser/app/ChromeActivity.java    |  4 +
  .../AppMenuPropertiesDelegateImpl.java        |  6 ++
  .../ChromeContextMenuPopulator.java           |  9 ++-
- .../CustomTabIntentDataProvider.java          |  5 +-
  .../browser/init/StartupTabPreloader.java     | 14 +++-
  .../privacy/settings/PrivacySettings.java     |  2 +
  .../browser/tabmodel/ChromeTabCreator.java    | 16 +++-
@@ -22,7 +21,7 @@ Enable incognito custom tabs and fix crashes for incognito/custom tab intents (c
  .../webapps/WebappIntentDataProvider.java     | 14 ++++
  .../flags/android/chrome_feature_list.cc      |  2 +-
  .../strings/android_chrome_strings.grd        |  7 ++
- 15 files changed, 172 insertions(+), 9 deletions(-)
+ 14 files changed, 168 insertions(+), 8 deletions(-)
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java
 
 diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java_sources.gni
@@ -223,28 +222,6 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/Chr
                      if (!mItemDelegate.isIncognito() && mItemDelegate.isIncognitoSupported()) {
                          linkGroup.add(createListItem(Item.OPEN_IN_INCOGNITO_TAB));
                      }
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
---- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
-@@ -48,6 +48,9 @@ import org.chromium.components.browser_ui.widget.TintedDrawable;
- import org.chromium.components.embedder_support.util.UrlConstants;
- import org.chromium.device.mojom.ScreenOrientationLockType;
- 
-+import org.chromium.base.ContextUtils;
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
-+
- import java.lang.annotation.Retention;
- import java.lang.annotation.RetentionPolicy;
- import java.util.ArrayList;
-@@ -781,7 +784,7 @@ public class CustomTabIntentDataProvider extends BrowserServicesIntentDataProvid
- 
-     @Override
-     public boolean isIncognito() {
--        return false;
-+        return ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
-     }
- 
-     @Nullable
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTabPreloader.java b/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTabPreloader.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTabPreloader.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTabPreloader.java


### PR DESCRIPTION
the removed code provided for the management of CCTs in incognito mode, which in v90 is managed differently by means of a flag.
the code must be removed because it is no longer necessary, the flag is active by default https://chromium.googlesource.com/chromium/src.git/+/c7397f8845c7e7ef438b356dc23883c1f27f1ea8

fix for #1051 
fix for #1047