### PR TITLE
README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ New flags:
 * `#enable-device-motion` and `#enable-device-orientation`
 * `#show-legacy-tls-warnings`
 * `#save-data-header`, disabled by default
-* `#export-bookmarks-use-saf`, enabled by default
+* `#export-bookmarks-use-saf`, disabled by default
 
 # Privacy limitations
 


### PR DESCRIPTION
Since, `export-bookmarks-use-saf`, is disabled by default, I edited the `New Flags` section of README.