### PR TITLE
README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ You can inspect all functionality/privacy changes by reading the [patches](https
 
 Flags which have been retired from upstream Chromium but are still available in Bromite.
 
-* `#enable-horizontal-tab-switcher`
 * `#pull-to-refresh`
 * `#enable-search-ready-omnibox`
 * `#darken-websites-checkbox-in-themes-setting`


### PR DESCRIPTION
Removing `#enable-horizontal-tab-switcher` since it is removed from upstream.