### PR TITLE
New flag "allow-user-certificates"

### DIFF
--- a/build/bromite_patches_list.txt
+++ b/build/bromite_patches_list.txt
@@ -146,4 +146,5 @@ Make-all-favicon-requests-on-demand.patch
 Add-Alt-D-hotkey-to-focus-address-bar.patch
 Remove-offline-measurement-background-task.patch
 User-agent-customization.patch
+Add-a-flag-to-disallow-user-certificates.patch
 Automated-domain-substitution.patch

--- a/build/patches/Add-a-flag-to-disallow-user-certificates.patch
+++ b/build/patches/Add-a-flag-to-disallow-user-certificates.patch
@@ -1,0 +1,169 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Mon, 26 Apr 2021 13:28:24 +0000
+Subject: Add a flag AllowUserCertificates default false
+
+---
+ .../src/org/chromium/chrome/browser/app/ChromeActivity.java  | 3 +++
+ .../chromium/chrome/browser/app/flags/ChromeCachedFlags.java | 1 +
+ chrome/browser/about_flags.cc                                | 4 ++++
+ chrome/browser/flag_descriptions.cc                          | 5 +++++
+ chrome/browser/flag_descriptions.h                           | 3 +++
+ chrome/browser/flags/android/chrome_feature_list.cc          | 4 ++++
+ chrome/browser/flags/android/chrome_feature_list.h           | 1 +
+ .../chromium/chrome/browser/flags/CachedFeatureFlags.java    | 1 +
+ .../org/chromium/chrome/browser/flags/ChromeFeatureList.java | 1 +
+ net/android/java/src/org/chromium/net/X509Util.java          | 5 +++++
+ 10 files changed, 28 insertions(+)
+
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
+@@ -207,6 +207,7 @@ import org.chromium.content_public.browser.ScreenOrientationProvider;
+ import org.chromium.content_public.browser.SelectionPopupController;
+ import org.chromium.content_public.browser.WebContents;
+ import org.chromium.content_public.common.ContentSwitches;
++import org.chromium.net.X509Util;
+ import org.chromium.printing.PrintManagerDelegateImpl;
+ import org.chromium.printing.PrintingController;
+ import org.chromium.printing.PrintingControllerImpl;
+@@ -866,6 +867,8 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
+         UpdateMenuItemHelper.getInstance().onStart();
+         ChromeActivitySessionTracker.getInstance().onStartWithNative();
+         ChromeCachedFlags.getInstance().cacheNativeFlags();
++        X509Util.AllowUserCertificates = ChromeFeatureList.isEnabled(
++                                            ChromeFeatureList.ALLOW_USER_CERTIFICATES);
+         OfflineIndicatorController.initialize();
+ 
+         // postDeferredStartupIfNeeded() is called in TabModelSelectorTabObsever#onLoadStopped(),
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java b/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
+@@ -64,6 +64,7 @@ public class ChromeCachedFlags {
+ 
+         // clang-format off
+         List<String> featuresToCache = Arrays.asList(
++                ChromeFeatureList.ALLOW_USER_CERTIFICATES,
+                 ChromeFeatureList.ADAPTIVE_BUTTON_IN_TOP_TOOLBAR,
+                 ChromeFeatureList.ANDROID_MANAGED_BY_MENU_ITEM,
+                 ChromeFeatureList.ANDROID_PARTNER_CUSTOMIZATION_PHENOTYPE,
+diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -2755,6 +2755,10 @@ const FeatureEntry kFeatureEntries[] = {
+      flag_descriptions::kCOLRV1FontsDescription, kOsAll,
+      FEATURE_VALUE_TYPE(blink::features::kCOLRV1Fonts)},
+ #if defined(OS_ANDROID)
++    {"allow-user-certificates",
++     flag_descriptions::kAllowUserCertificatesName,
++     flag_descriptions::kAllowUserCertificatesDescription, kOsAndroid,
++     FEATURE_VALUE_TYPE(chrome::android::kAllowUserCertificates)},
+     {"contextual-search-debug", flag_descriptions::kContextualSearchDebugName,
+      flag_descriptions::kContextualSearchDebugDescription, kOsAndroid,
+      FEATURE_VALUE_TYPE(chrome::android::kContextualSearchDebug)},
+diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
+--- a/chrome/browser/flag_descriptions.cc
++++ b/chrome/browser/flag_descriptions.cc
+@@ -11,6 +11,11 @@
+ 
+ namespace flag_descriptions {
+ 
++const char kAllowUserCertificatesName[] = "Allow user certificates";
++const char kAllowUserCertificatesDescription[] =
++    "Enables the use of user CA certificates during the "
++    "validation of the certificate chain";
++
+ const char kAccelerated2dCanvasName[] = "Accelerated 2D canvas";
+ const char kAccelerated2dCanvasDescription[] =
+     "Enables the use of the GPU to perform 2d canvas rendering instead of "
+diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
+--- a/chrome/browser/flag_descriptions.h
++++ b/chrome/browser/flag_descriptions.h
+@@ -45,6 +45,9 @@ namespace flag_descriptions {
+ 
+ // Cross-platform -------------------------------------------------------------
+ 
++extern const char kAllowUserCertificatesName[];
++extern const char kAllowUserCertificatesDescription[];
++
+ extern const char kAccelerated2dCanvasName[];
+ extern const char kAccelerated2dCanvasDescription[];
+ 
+diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
+--- a/chrome/browser/flags/android/chrome_feature_list.cc
++++ b/chrome/browser/flags/android/chrome_feature_list.cc
+@@ -127,6 +127,7 @@ const base::Feature* kFeaturesExposedToJava[] = {
+     &feed::kWebFeed,
+     &feed::kXsurfaceMetricsReporting,
+     &history::kHideFromApi3Transitions,
++    &kAllowUserCertificates,
+     &kAdjustWebApkInstallationSpace,
+     &kAllowNewIncognitoTabIntents,
+     &kAllowRemoteContextForNotifications,
+@@ -331,6 +332,9 @@ const base::Feature* FindFeatureExposedToJava(const std::string& feature_name) {
+ }  // namespace
+ 
+ // Alphabetical:
++const base::Feature kAllowUserCertificates = {
++    "AllowUserCertificates", base::FEATURE_DISABLED_BY_DEFAULT};
++
+ const base::Feature kAdjustWebApkInstallationSpace = {
+     "AdjustWebApkInstallationSpace", base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser/flags/android/chrome_feature_list.h
+--- a/chrome/browser/flags/android/chrome_feature_list.h
++++ b/chrome/browser/flags/android/chrome_feature_list.h
+@@ -12,6 +12,7 @@ namespace chrome {
+ namespace android {
+ 
+ // Alphabetical:
++extern const base::Feature kAllowUserCertificates;
+ extern const base::Feature kAdjustWebApkInstallationSpace;
+ extern const base::Feature kAllowNewIncognitoTabIntents;
+ extern const base::Feature kAllowRemoteContextForNotifications;
+diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
+--- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
++++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
+@@ -47,6 +47,7 @@ public class CachedFeatureFlags {
+      */
+     private static Map<String, Boolean> sDefaults = new HashMap<String, Boolean>() {
+         {
++            put(ChromeFeatureList.ALLOW_USER_CERTIFICATES, false);
+             put(ChromeFeatureList.ADAPTIVE_BUTTON_IN_TOP_TOOLBAR, false);
+             put(ChromeFeatureList.ANDROID_MANAGED_BY_MENU_ITEM, true);
+             put(ChromeFeatureList.ANDROID_PARTNER_CUSTOMIZATION_PHENOTYPE, true);
+diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
+--- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
++++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
+@@ -203,6 +203,7 @@ public abstract class ChromeFeatureList {
+     }
+ 
+     /* Alphabetical: */
++    public static final String ALLOW_USER_CERTIFICATES = "AllowUserCertificates";
+     public static final String ADAPTIVE_BUTTON_IN_TOP_TOOLBAR = "AdaptiveButtonInTopToolbar";
+     public static final String ALLOW_NEW_INCOGNITO_TAB_INTENTS = "AllowNewIncognitoTabIntents";
+     public static final String ALLOW_REMOTE_CONTEXT_FOR_NOTIFICATIONS =
+diff --git a/net/android/java/src/org/chromium/net/X509Util.java b/net/android/java/src/org/chromium/net/X509Util.java
+--- a/net/android/java/src/org/chromium/net/X509Util.java
++++ b/net/android/java/src/org/chromium/net/X509Util.java
+@@ -488,6 +488,8 @@ public class X509Util {
+         return false;
+     }
+ 
++    public static boolean AllowUserCertificates = false;
++
+     public static AndroidCertVerifyResult verifyServerCertificates(byte[][] certChain,
+                                                                    String authType,
+                                                                    String host)
+@@ -568,6 +570,9 @@ public class X509Util {
+                 isIssuedByKnownRoot = isKnownRoot(root);
+             }
+ 
++            if (AllowUserCertificates == false && isIssuedByKnownRoot == false)
++                return new AndroidCertVerifyResult(CertVerifyStatusAndroid.NO_TRUSTED_ROOT);
++
+             return new AndroidCertVerifyResult(CertVerifyStatusAndroid.OK,
+                                                isIssuedByKnownRoot, verifiedChain);
+         }
+-- 
+2.17.1
+


### PR DESCRIPTION
Added flag "allow-user-certificates" disabled by default to allow the use of user CA certificates

Fixes #921