### PR TITLE
revert last changes + remove record incognito launch reason histogram

### DIFF
--- a/build/patches/Add-an-always-incognito-mode.patch
+++ b/build/patches/Add-an-always-incognito-mode.patch
@@ -14,6 +14,8 @@ Enable incognito custom tabs and fix crashes for incognito/custom tab intents (c
  .../chrome/browser/app/ChromeActivity.java    |  4 +
  .../AppMenuPropertiesDelegateImpl.java        |  6 ++
  .../ChromeContextMenuPopulator.java           |  9 ++-
+ .../CustomTabActivityLifecycleUmaTracker.java |  5 --
+ .../CustomTabIntentDataProvider.java          |  5 +-
  .../browser/init/StartupTabPreloader.java     | 14 +++-
  .../privacy/settings/PrivacySettings.java     |  2 +
  .../browser/tabmodel/ChromeTabCreator.java    | 16 +++-
@@ -21,7 +23,7 @@ Enable incognito custom tabs and fix crashes for incognito/custom tab intents (c
  .../webapps/WebappIntentDataProvider.java     | 14 ++++
  .../flags/android/chrome_feature_list.cc      |  2 +-
  .../strings/android_chrome_strings.grd        |  7 ++
- 14 files changed, 168 insertions(+), 8 deletions(-)
+ 16 files changed, 172 insertions(+), 14 deletions(-)
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java
 
 diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java_sources.gni
@@ -222,6 +224,43 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/Chr
                      if (!mItemDelegate.isIncognito() && mItemDelegate.isIncognitoSupported()) {
                          linkGroup.add(createListItem(Item.OPEN_IN_INCOGNITO_TAB));
                      }
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivityLifecycleUmaTracker.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivityLifecycleUmaTracker.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivityLifecycleUmaTracker.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivityLifecycleUmaTracker.java
+@@ -34,11 +34,6 @@ public class CustomTabActivityLifecycleUmaTracker implements PauseResumeWithNati
+     private boolean mIsInitialResume = true;
+ 
+     private void recordIncognitoLaunchReason() {
+-        IncognitoCustomTabIntentDataProvider incognitoProvider =
+-                (IncognitoCustomTabIntentDataProvider) mIntentDataProvider;
+-        RecordHistogram.recordEnumeratedHistogram("CustomTabs.IncognitoCCTCallerId",
+-                incognitoProvider.getFeatureIdForMetricsCollection(),
+-                IntentHandler.IncognitoCCTCallerId.NUM_ENTRIES);
+     }
+ 
+     private void recordUserAction() {
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
+@@ -48,6 +48,9 @@ import org.chromium.components.browser_ui.widget.TintedDrawable;
+ import org.chromium.components.embedder_support.util.UrlConstants;
+ import org.chromium.device.mojom.ScreenOrientationLockType;
+ 
++import org.chromium.base.ContextUtils;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
++
+ import java.lang.annotation.Retention;
+ import java.lang.annotation.RetentionPolicy;
+ import java.util.ArrayList;
+@@ -781,7 +784,7 @@ public class CustomTabIntentDataProvider extends BrowserServicesIntentDataProvid
+ 
+     @Override
+     public boolean isIncognito() {
+-        return false;
++        return ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
+     }
+ 
+     @Nullable
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTabPreloader.java b/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTabPreloader.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTabPreloader.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTabPreloader.java


### PR DESCRIPTION
I checked every possible path, I think the best is simply to remove the histogram.
I put back the code that I had removed because the flag is active only for

`This feature is now used in Offline pages and Reader Mode.`

instead the patch also activates it for the custom tab. use this to reproduce
```
adb shell am start -a android.intent.action.VIEW -d http://www.stackoverflow.com --es android.support.customtabs.extra.SESSION "1"
```

checked https://github.com/bromite/bromite/issues/1051 it works

fix for #1116 

