### PR TITLE
reactivation of subresource filter

### DIFF
--- a/build/patches/Disable-safe-browsing.patch
+++ b/build/patches/Disable-safe-browsing.patch
@@ -2182,32 +2182,21 @@ diff --git a/chrome/browser/ssl/security_state_tab_helper.cc b/chrome/browser/ss
 diff --git a/chrome/browser/subresource_filter/chrome_content_subresource_filter_throttle_manager_factory.cc b/chrome/browser/subresource_filter/chrome_content_subresource_filter_throttle_manager_factory.cc
 --- a/chrome/browser/subresource_filter/chrome_content_subresource_filter_throttle_manager_factory.cc
 +++ b/chrome/browser/subresource_filter/chrome_content_subresource_filter_throttle_manager_factory.cc
-@@ -12,6 +12,7 @@
- #include "components/subresource_filter/content/browser/content_subresource_filter_throttle_manager.h"
- #include "components/subresource_filter/content/browser/ruleset_service.h"
- 
+@@ -18,10 +18,14 @@ namespace {
+ // available. Otherwise returns nullptr.
+ const scoped_refptr<safe_browsing::SafeBrowsingDatabaseManager>
+ GetDatabaseManagerFromSafeBrowsingService() {
 +#if defined(FULL_SAFE_BROWSING)
- namespace {
- 
- // Returns a scoped refptr to the SafeBrowsingService's database manager, if
-@@ -25,9 +26,11 @@ GetDatabaseManagerFromSafeBrowsingService() {
+   safe_browsing::SafeBrowsingService* safe_browsing_service =
+       g_browser_process->safe_browsing_service();
+   return safe_browsing_service ? safe_browsing_service->database_manager()
+                                : nullptr;
++#else
++  return nullptr;
++#endif
  }
  
  }  // namespace
-+#endif
- 
- void CreateSubresourceFilterThrottleManagerForWebContents(
-     content::WebContents* web_contents) {
-+#if defined(FULL_SAFE_BROWSING)
-   subresource_filter::RulesetService* ruleset_service =
-       g_browser_process->subresource_filter_ruleset_service();
-   subresource_filter::VerifiedRulesetDealer::Handle* dealer =
-@@ -38,4 +41,5 @@ void CreateSubresourceFilterThrottleManagerForWebContents(
-           SubresourceFilterProfileContextFactory::GetForProfile(
-               Profile::FromBrowserContext(web_contents->GetBrowserContext())),
-           GetDatabaseManagerFromSafeBrowsingService(), dealer);
-+#endif
- }
 diff --git a/chrome/browser/ui/BUILD.gn b/chrome/browser/ui/BUILD.gn
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn


### PR DESCRIPTION
fix #1299 

I tried, the problem is actually there, in this way the adblock is reactivated.
obviously it has nothing to do with the rules, if those are missing they continue to fail!