### PR TITLE
Ignore StrictMode warning

### DIFF
--- a/build/patches/JIT-less-toggle.patch
+++ b/build/patches/JIT-less-toggle.patch
@@ -7,8 +7,8 @@ Subject: JIT-less toggle
  .../browser/privacy/settings/PrivacySettings.java    | 12 ++++++++++++
  .../ui/android/strings/android_chrome_strings.grd    |  7 +++++++
  .../browser/BrowserStartupControllerImpl.java        |  1 +
- .../chromium/content/browser/DeviceUtilsImpl.java    |  6 ++++++
- 5 files changed, 31 insertions(+)
+ .../chromium/content/browser/DeviceUtilsImpl.java    |  8 ++++++++
+ 5 files changed, 33 insertions(+)
 
 diff --git a/chrome/android/java/res/xml/privacy_preferences.xml b/chrome/android/java/res/xml/privacy_preferences.xml
 --- a/chrome/android/java/res/xml/privacy_preferences.xml
@@ -107,13 +107,15 @@ diff --git a/content/public/android/java/src/org/chromium/content/browser/Device
  import org.chromium.base.StrictModeContext;
  import org.chromium.content_public.common.ContentSwitches;
  import org.chromium.ui.base.DeviceFormFactor;
-@@ -22,4 +23,9 @@ public class DeviceUtilsImpl {
+@@ -22,4 +23,11 @@ public class DeviceUtilsImpl {
              }
          }
      }
 +    public static void addJitlessSwitch() {
-+	if (ContextUtils.getAppSharedPreferences().getBoolean("force_no_jit", false)) {
-+	    CommandLine.getInstance().appendSwitchWithValue("js-flags", "--jitless");
++	try (StrictModeContext ignored = StrictModeContext.allowDiskReads()) {
++	    if (ContextUtils.getAppSharedPreferences().getBoolean("force_no_jit", false)) {
++		CommandLine.getInstance().appendSwitchWithValue("js-flags", "--jitless");
++	    }
 +	}
 +    }
  }


### PR DESCRIPTION
Currently the SystemWebView fails a CTS test case, specifically
testStrictMode from WebViewHostSideStartupTest, due to StrictMode
warnings. So ignore the StrictMode warning as is done elsewhere.