### PR TITLE
Re-introduce patch to add option to use home page as NTP

### DIFF
--- a/build/patches/Add-option-to-use-home-page-as-NTP.patch
+++ b/build/patches/Add-option-to-use-home-page-as-NTP.patch
@@ -1,0 +1,228 @@
+From: csagan5 <32685696+csagan5@users.noreply.github.com>
+Date: Mon, 18 Mar 2019 21:47:12 +0100
+Subject: Add option to use home page as NTP
+
+Use about:blank as default homepage
+---
+ .../java/res/xml/homepage_preferences.xml     |  5 +++
+ .../browser/homepage/HomepageManager.java     | 22 +++++++++-
+ .../homepage/settings/HomepageSettings.java   | 11 +++++
+ .../chrome/browser/tabmodel/TabCreator.java   | 40 ++++++++++++++++++-
+ .../strings/android_chrome_strings.grd        |  3 ++
+ chrome/browser/ui/browser_ui_prefs.cc         |  2 +
+ chrome/common/pref_names.cc                   |  4 ++
+ chrome/common/pref_names.h                    |  1 +
+ 8 files changed, 84 insertions(+), 4 deletions(-)
+
+diff --git a/chrome/android/java/res/xml/homepage_preferences.xml b/chrome/android/java/res/xml/homepage_preferences.xml
+--- a/chrome/android/java/res/xml/homepage_preferences.xml
++++ b/chrome/android/java/res/xml/homepage_preferences.xml
+@@ -12,6 +12,11 @@
+         android:summaryOn="@string/text_on"
+         android:summaryOff="@string/text_off" />
+ 
++    <org.chromium.chrome.browser.settings.ChromeSwitchPreference
++        android:key="ntp_is_homepage_switch"
++        android:summaryOn="@string/options_ntp_is_homepage_label"
++        android:summaryOff="@string/options_ntp_is_homepage_label" />
++
+     <org.chromium.chrome.browser.homepage.settings.RadioButtonGroupHomepagePreference
+         android:key="homepage_radio_group"
+         android:selectable="false"
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/homepage/HomepageManager.java b/chrome/android/java/src/org/chromium/chrome/browser/homepage/HomepageManager.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/homepage/HomepageManager.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/homepage/HomepageManager.java
+@@ -30,6 +30,7 @@ import org.chromium.components.embedder_support.util.UrlUtilities;
+  */
+ public class HomepageManager implements HomepagePolicyManager.HomepagePolicyStateListener,
+                                         PartnerBrowserCustomizations.PartnerHomepageListener {
++    public static final String PREF_NTP_IS_HOMEPAGE = "newtabpage_is_homepage";
+     /**
+      * An interface to use for getting homepage related updates.
+      */
+@@ -117,7 +118,8 @@ public class HomepageManager implements HomepagePolicyManager.HomepagePolicyStat
+      */
+     public static boolean shouldCloseAppWithZeroTabs() {
+         return HomepageManager.isHomepageEnabled()
+-                && !UrlUtilities.isNTPUrl(HomepageManager.getHomepageUri());
++                && !UrlUtilities.isNTPUrl(HomepageManager.getHomepageUri())
++                && (HomepageManager.getHomepageUri() != UrlConstants.CHROME_BLANK_URL);
+     }
+ 
+     /**
+@@ -146,7 +148,7 @@ public class HomepageManager implements HomepagePolicyManager.HomepagePolicyStat
+      *         if the homepage button is force enabled via flag.
+      */
+     public static String getDefaultHomepageUri() {
+-        return UrlConstants.NTP_NON_NATIVE_URL;
++        return UrlConstants.CHROME_BLANK_URL;
+     }
+ 
+     /**
+@@ -201,6 +203,14 @@ public class HomepageManager implements HomepagePolicyManager.HomepagePolicyStat
+         return mSharedPreferencesManager.readBoolean(ChromePreferenceKeys.HOMEPAGE_ENABLED, true);
+     }
+ 
++    /**
++     * Returns the user preference for whether the New Tab Page is the homepage or not.
++     *
++     */
++    public boolean getPrefNTPIsHomepageEnabled() {
++        return mSharedPreferencesManager.readBoolean(PREF_NTP_IS_HOMEPAGE, false);
++    }
++
+     /**
+      * Sets the user preference for whether the homepage is enabled.
+      */
+@@ -209,6 +219,14 @@ public class HomepageManager implements HomepagePolicyManager.HomepagePolicyStat
+         notifyHomepageUpdated();
+     }
+ 
++    /**
++     * Sets the user preference for whether the new tab page is the homepage or not.
++     */
++    public void setPrefNTPIsHomepageEnabled(boolean enabled) {
++        mSharedPreferencesManager.writeBoolean(PREF_NTP_IS_HOMEPAGE, enabled);
++        notifyHomepageUpdated();
++    }
++
+     /**
+      * @return User specified homepage custom URI string.
+      */
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/homepage/settings/HomepageSettings.java b/chrome/android/java/src/org/chromium/chrome/browser/homepage/settings/HomepageSettings.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/homepage/settings/HomepageSettings.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/homepage/settings/HomepageSettings.java
+@@ -32,6 +32,8 @@ public class HomepageSettings extends PreferenceFragmentCompat {
+     @VisibleForTesting
+     public static final String PREF_HOMEPAGE_RADIO_GROUP = "homepage_radio_group";
+ 
++    private static final String PREF_NTP_HOMEPAGE_SWITCH = "ntp_is_homepage_switch";
++
+     /**
+      * Delegate used to mark that the homepage is being managed.
+      * Created for {@link org.chromium.chrome.browser.settings.HomepagePreferences}
+@@ -72,6 +74,15 @@ public class HomepageSettings extends PreferenceFragmentCompat {
+         });
+         mRadioButtons.setupPreferenceValues(createPreferenceValuesForRadioGroup());
+ 
++        ChromeSwitchPreference mNTPIsHomepageSwitch =
++                (ChromeSwitchPreference) findPreference(PREF_NTP_HOMEPAGE_SWITCH);
++        boolean isHomepageNTPEnabled = mHomepageManager.getPrefNTPIsHomepageEnabled();
++        mNTPIsHomepageSwitch.setChecked(isHomepageNTPEnabled);
++        mNTPIsHomepageSwitch.setOnPreferenceChangeListener((preference, newValue) -> {
++            mHomepageManager.setPrefNTPIsHomepageEnabled((boolean) newValue);
++            return true;
++        });
++
+         RecordUserAction.record("Settings.Homepage.Opened");
+     }
+ 
+diff --git a/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/TabCreator.java b/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/TabCreator.java
+--- a/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/TabCreator.java
++++ b/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/TabCreator.java
+@@ -89,14 +89,50 @@ public abstract class TabCreator {
+     }
+ 
+     /**
+-     * Creates a new tab and loads the NTP.
++     * Creates a new tab and loads the NTP or the homepage, depending on user preferences.
+      */
+     public final void launchNTP() {
+         try {
++            String newTabURL = UrlConstants.NTP_URL;
++            if (getPrefNTPIsHomepageEnabled()) {
++                newTabURL = getHomepageUri();
++            }
+             TraceEvent.begin("TabCreator.launchNTP");
+-            launchUrl(UrlConstants.NTP_URL, TabLaunchType.FROM_CHROME_UI);
++            launchUrl(newTabURL, TabLaunchType.FROM_CHROME_UI);
+         } finally {
+             TraceEvent.end("TabCreator.launchNTP");
+         }
+     }
++
++    /* following functions are copied from HomepageManager to avoid a circular dependency */
++
++    private boolean getPrefNTPIsHomepageEnabled() {
++        return mSharedPreferencesManager.readBoolean(PREF_NTP_IS_HOMEPAGE, false);
++    }
++
++    private String getHomepageUri() {
++        boolean isHomePageEnabled = mSharedPreferencesManager.readBoolean(ChromePreferenceKeys.HOMEPAGE_ENABLED, true);
++        if (!isHomePageEnabled) {
++            return "";
++        }
++        if (getPrefHomepageUseChromeNTP() || getPrefHomepageUseDefaultUri()) {
++             //NOTE: ignores partner customizations
++             return UrlConstants.NTP_NON_NATIVE_URL;
++        }
++        return getPrefHomepageCustomUri();
++    }
++
++    private boolean getPrefHomepageUseChromeNTP() {
++        return mSharedPreferencesManager.readBoolean(
++                ChromePreferenceKeys.HOMEPAGE_USE_CHROME_NTP, false);
++    }
++
++    private boolean getPrefHomepageUseDefaultUri() {
++        return mSharedPreferencesManager.readBoolean(
++                ChromePreferenceKeys.HOMEPAGE_USE_DEFAULT_URI, true);
++    }
++
++    private String getPrefHomepageCustomUri() {
++        return mSharedPreferencesManager.readString(ChromePreferenceKeys.HOMEPAGE_CUSTOM_URI, "");
++    }
+ }
+diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+--- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
++++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+@@ -1047,6 +1047,9 @@ Your Google account may have other forms of browsing history like searches and a
+       <message name="IDS_CLEAR_BROWSING_DATA_TAB_PERIOD_HOUR" desc="The option to delete browsing data from the last hour.">
+         Last hour
+       </message>
++      <message name="IDS_OPTIONS_NTP_IS_HOMEPAGE_LABEL" desc="The label for switch that allows the user to toggle whether opening a new tab leads to the new tab page or the home page.">
++        Use for new tabs
++      </message>
+       <message name="IDS_CLEAR_BROWSING_DATA_TAB_PERIOD_24_HOURS" desc="The option to delete browsing data from the last 24 hours.">
+         Last 24 hours
+       </message>
+diff --git a/chrome/browser/ui/browser_ui_prefs.cc b/chrome/browser/ui/browser_ui_prefs.cc
+--- a/chrome/browser/ui/browser_ui_prefs.cc
++++ b/chrome/browser/ui/browser_ui_prefs.cc
+@@ -65,6 +65,8 @@ void RegisterBrowserUserPrefs(user_prefs::PrefRegistrySyncable* registry) {
+                                 GetHomeButtonAndHomePageIsNewTabPageFlags());
+   registry->RegisterBooleanPref(prefs::kShowHomeButton, false,
+                                 GetHomeButtonAndHomePageIsNewTabPageFlags());
++  registry->RegisterBooleanPref(prefs::kNewTabPageIsHomePage, false,
++                                GetHomeButtonAndHomePageIsNewTabPageFlags());
+ 
+   registry->RegisterInt64Pref(prefs::kDefaultBrowserLastDeclined, 0);
+   bool reset_check_default = false;
+diff --git a/chrome/common/pref_names.cc b/chrome/common/pref_names.cc
+--- a/chrome/common/pref_names.cc
++++ b/chrome/common/pref_names.cc
+@@ -55,6 +55,10 @@ const char kForceEphemeralProfiles[] = "profile.ephemeral_mode";
+ // A boolean specifying whether the New Tab page is the home page or not.
+ const char kHomePageIsNewTabPage[] = "homepage_is_newtabpage";
+ 
++// A boolean specifying whether opening a new tab should open the Home page
++// instead of the New Tab page.
++const char kNewTabPageIsHomePage[] = "newtabpage_is_homepage";
++
+ // This is the URL of the page to load when opening new tabs.
+ const char kHomePage[] = "homepage";
+ 
+diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
+--- a/chrome/common/pref_names.h
++++ b/chrome/common/pref_names.h
+@@ -356,6 +356,7 @@ extern const char kExternalStorageReadOnly[];
+ extern const char kSettingsShowOSBanner[];
+ #endif  // defined(OS_CHROMEOS)
+ extern const char kShowHomeButton[];
++extern const char kNewTabPageIsHomePage[];
+ extern const char kSpeechRecognitionFilterProfanities[];
+ extern const char kAllowDeletingBrowserHistory[];
+ extern const char kForceGoogleSafeSearch[];
+-- 
+2.20.1
+


### PR DESCRIPTION
This does not work for a circular dependency and the methods in `TabCreator` would have to be implemented as abstract. There are at last 2 implementations to cover after that.