### PR TITLE
Disable conversion measurement api

### DIFF
--- a/build/patches/Disable-conversion-measurement-api.patch
+++ b/build/patches/Disable-conversion-measurement-api.patch
@@ -1,0 +1,333 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Mon, 15 Nov 2021 09:43:29 +0000
+Subject: Disable conversion measurement api
+
+Disable Conversion Measurement API by disabling the flag and removing 
+support for the AttributionReporting provider. it also removes 
+the handling of attributions via intents between apps.
+This patch enforces the deactivation by preventing the report from 
+being sent and being saved to disk, although it is currently in uncalled code.
+---
+ chrome/android/java/AndroidManifest.xml         |  8 --------
+ .../AttributionIntentHandlerFactory.java        |  9 +--------
+ .../flags/android/chrome_feature_list.cc        |  2 +-
+ .../embedder_support/origin_trials/features.cc  |  3 ++-
+ .../render_view_context_menu_base.cc            |  3 ---
+ .../browser/android/navigation_handle_proxy.cc  | 10 ----------
+ content/browser/conversions/conversion_host.cc  |  8 --------
+ content/browser/conversions/conversion_host.h   |  3 ---
+ .../conversions/conversion_host_utils.cc        |  6 ++++++
+ .../conversion_network_sender_impl.cc           | 17 ++++++++++-------
+ .../conversions/conversion_storage_sql.cc       |  2 +-
+ .../navigation_controller_android.cc            | 15 ---------------
+ content/browser/storage_partition_impl.cc       |  7 +------
+ .../browser/AttributionReporterImpl.java        |  4 ----
+ content/public/browser/navigation_controller.cc |  1 -
+ third_party/blink/common/features.cc            |  2 +-
+ .../platform/runtime_enabled_features.json5     |  6 ++----
+ 17 files changed, 25 insertions(+), 81 deletions(-)
+
+diff --git a/chrome/android/java/AndroidManifest.xml b/chrome/android/java/AndroidManifest.xml
+--- a/chrome/android/java/AndroidManifest.xml
++++ b/chrome/android/java/AndroidManifest.xml
+@@ -1276,14 +1276,6 @@ by a child template that "extends" this file.
+                   android:readPermission="android.permission.GLOBAL_SEARCH" />
+       </provider>
+ 
+-      <!-- Provider for App to Web impression attribution.
+-           TODO(https://crbug.com/1210171): Gate this provider behind a custom permission? -->
+-      <provider android:name="org.chromium.chrome.browser.attribution_reporting.AttributionReportingProvider"
+-          android:authorities="{{ manifest_package }}.AttributionReporting"
+-          android:exported="true"
+-          tools:ignore="ExportedContentProvider">
+-      </provider>
+-
+       {% block base_application_definitions %}
+       {% endblock %}
+       {% block extra_application_definitions_for_test %}
+diff --git a/chrome/browser/attribution_reporting/android/internal/java/src/org/chromium/chrome/browser/attribution_reporting/AttributionIntentHandlerFactory.java b/chrome/browser/attribution_reporting/android/internal/java/src/org/chromium/chrome/browser/attribution_reporting/AttributionIntentHandlerFactory.java
+--- a/chrome/browser/attribution_reporting/android/internal/java/src/org/chromium/chrome/browser/attribution_reporting/AttributionIntentHandlerFactory.java
++++ b/chrome/browser/attribution_reporting/android/internal/java/src/org/chromium/chrome/browser/attribution_reporting/AttributionIntentHandlerFactory.java
+@@ -26,14 +26,7 @@ public class AttributionIntentHandlerFactory {
+      * @return an AttributionIntentHandler instance.
+      */
+     public static AttributionIntentHandler getInstance() {
+-        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.APP_TO_WEB_ATTRIBUTION)) {
+-            if (sIntentHandler == null) {
+-                sIntentHandler = new AttributionIntentHandlerImpl(sValidator);
+-            }
+-            return sIntentHandler;
+-        } else {
+-            return new NoopAttributionIntentHandler();
+-        }
++        return new NoopAttributionIntentHandler();
+     }
+ 
+     public static void setInputEventValidatorForTesting(Predicate<InputEvent> validator) {
+diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
+--- a/chrome/browser/flags/android/chrome_feature_list.cc
++++ b/chrome/browser/flags/android/chrome_feature_list.cc
+@@ -416,7 +416,7 @@ const base::Feature kAppMenuMobileSiteOption{"AppMenuMobileSiteOption",
+                                              base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ const base::Feature kAppToWebAttribution{"AppToWebAttribution",
+-                                         base::FEATURE_DISABLED_BY_DEFAULT};
++                                         base::FEATURE_DISABLED_BY_DEFAULT}; // guard this
+ 
+ const base::Feature kBackgroundThreadPool{"BackgroundThreadPool",
+                                           base::FEATURE_DISABLED_BY_DEFAULT};
+diff --git a/components/embedder_support/origin_trials/features.cc b/components/embedder_support/origin_trials/features.cc
+--- a/components/embedder_support/origin_trials/features.cc
++++ b/components/embedder_support/origin_trials/features.cc
+@@ -17,8 +17,9 @@ const base::Feature kOriginTrialsSampleAPIThirdPartyAlternativeUsage{
+     "OriginTrialsSampleAPIThirdPartyAlternativeUsage",
+     base::FEATURE_ENABLED_BY_DEFAULT};
+ 
++// When disabled, the API cannot be enabled by tokens.
+ const base::Feature kConversionMeasurementAPIAlternativeUsage{
+     "ConversionMeasurementAPIAlternativeUsage",
+-    base::FEATURE_ENABLED_BY_DEFAULT};
++    base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ }  // namespace embedder_support
+diff --git a/components/renderer_context_menu/render_view_context_menu_base.cc b/components/renderer_context_menu/render_view_context_menu_base.cc
+--- a/components/renderer_context_menu/render_view_context_menu_base.cc
++++ b/components/renderer_context_menu/render_view_context_menu_base.cc
+@@ -484,9 +484,6 @@ void RenderViewContextMenuBase::OpenURLWithExtraHeaders(
+ 
+   open_url_params.source_site_instance = site_instance_;
+ 
+-  if (disposition != WindowOpenDisposition::OFF_THE_RECORD)
+-    open_url_params.impression = params_.impression;
+-
+   source_web_contents_->OpenURL(open_url_params);
+ }
+ 
+diff --git a/content/browser/android/navigation_handle_proxy.cc b/content/browser/android/navigation_handle_proxy.cc
+--- a/content/browser/android/navigation_handle_proxy.cc
++++ b/content/browser/android/navigation_handle_proxy.cc
+@@ -30,16 +30,6 @@ NavigationHandleProxy::NavigationHandleProxy(
+   base::android::ScopedJavaLocalRef<jobject> impression_byte_buffer = nullptr;
+ 
+   // Scoped to out-live the java call as this uses a DirectByteBuffer.
+-  std::vector<uint8_t> byte_vector;
+-  if (cpp_navigation_handle_->GetImpression()) {
+-    blink::mojom::ImpressionPtr impression =
+-        ConversionHost::MojoImpressionFromImpression(
+-            *cpp_navigation_handle_->GetImpression());
+-    byte_vector = blink::mojom::Impression::Serialize(&impression);
+-    impression_byte_buffer = base::android::ScopedJavaLocalRef<jobject>(
+-        env, env->NewDirectByteBuffer(byte_vector.data(), byte_vector.size()));
+-    base::android::CheckException(env);
+-  }
+   java_navigation_handle_ = Java_NavigationHandle_Constructor(
+       env, reinterpret_cast<jlong>(this),
+       url::GURLAndroid::FromNativeGURL(env, cpp_navigation_handle_->GetURL()),
+diff --git a/content/browser/conversions/conversion_host.cc b/content/browser/conversions/conversion_host.cc
+--- a/content/browser/conversions/conversion_host.cc
++++ b/content/browser/conversions/conversion_host.cc
+@@ -400,14 +400,6 @@ void ConversionHost::BindReceiver(
+   conversion_host->receivers_.Bind(rfh, std::move(receiver));
+ }
+ 
+-// static
+-blink::mojom::ImpressionPtr ConversionHost::MojoImpressionFromImpression(
+-    const blink::Impression& impression) {
+-  return blink::mojom::Impression::New(
+-      impression.conversion_destination, impression.reporting_origin,
+-      impression.impression_data, impression.expiry, impression.priority);
+-}
+-
+ // static
+ void ConversionHost::SetReceiverImplForTesting(ConversionHost* impl) {
+   g_receiver_for_testing = impl;
+diff --git a/content/browser/conversions/conversion_host.h b/content/browser/conversions/conversion_host.h
+--- a/content/browser/conversions/conversion_host.h
++++ b/content/browser/conversions/conversion_host.h
+@@ -58,9 +58,6 @@ class CONTENT_EXPORT ConversionHost
+       const url::Origin& impression_origin,
+       const blink::Impression& impression);
+ 
+-  static blink::mojom::ImpressionPtr MojoImpressionFromImpression(
+-      const blink::Impression& impression) WARN_UNUSED_RESULT;
+-
+   // Overrides the target object to bind |receiver| to in BindReceiver().
+   static void SetReceiverImplForTesting(ConversionHost* impl);
+ 
+diff --git a/content/browser/conversions/conversion_host_utils.cc b/content/browser/conversions/conversion_host_utils.cc
+--- a/content/browser/conversions/conversion_host_utils.cc
++++ b/content/browser/conversions/conversion_host_utils.cc
+@@ -18,6 +18,8 @@
+ #include "url/gurl.h"
+ #include "url/origin.h"
+ 
++// will change in attribution_host_utils.cc
++
+ namespace content {
+ 
+ namespace conversion_host_utils {
+@@ -77,6 +79,10 @@ absl::optional<blink::Impression> ParseImpressionFromApp(
+   // Java API should have rejected these already.
+   DCHECK(!source_event_id.empty() && !destination.empty());
+ 
++  // no impression from app
++  if ((true))
++    return absl::nullopt;
++
+   blink::Impression impression;
+   if (!base::StringToUint64(source_event_id, &impression.impression_data))
+     return absl::nullopt;
+diff --git a/content/browser/conversions/conversion_network_sender_impl.cc b/content/browser/conversions/conversion_network_sender_impl.cc
+--- a/content/browser/conversions/conversion_network_sender_impl.cc
++++ b/content/browser/conversions/conversion_network_sender_impl.cc
+@@ -144,13 +144,9 @@ void ConversionNetworkSenderImpl::SendReport(ConversionReport report,
+ 
+   LogMetricsOnReportSend(report);
+ 
+-  // Unretained is safe because the URLLoader is owned by |this| and will be
+-  // deleted before |this|.
+-  simple_url_loader_ptr->DownloadHeadersOnly(
+-      url_loader_factory_.get(),
+-      base::BindOnce(&ConversionNetworkSenderImpl::OnReportSent,
+-                     base::Unretained(this), std::move(it), std::move(report),
+-                     std::move(sent_callback)));
++  // this code is never called but if it were, nothing would be sent
++  OnReportSent(std::move(it), std::move(report), std::move(sent_callback),
++    nullptr);
+ }
+ 
+ void ConversionNetworkSenderImpl::SetURLLoaderFactoryForTesting(
+@@ -163,6 +159,13 @@ void ConversionNetworkSenderImpl::OnReportSent(
+     ConversionReport report,
+     ReportSentCallback sent_callback,
+     scoped_refptr<net::HttpResponseHeaders> headers) {
++  if ((true)) {
++    std::move(sent_callback)
++      .Run(SentReportInfo(std::move(report),
++                          SentReportInfo::Status::kSent,
++                          /*response_code*/200));
++    return;
++  }
+   network::SimpleURLLoader* loader = it->get();
+ 
+   // Consider a non-200 HTTP code as a non-internal error.
+diff --git a/content/browser/conversions/conversion_storage_sql.cc b/content/browser/conversions/conversion_storage_sql.cc
+--- a/content/browser/conversions/conversion_storage_sql.cc
++++ b/content/browser/conversions/conversion_storage_sql.cc
+@@ -227,7 +227,7 @@ void ConversionStorageSql::RunInMemoryForTesting() {
+ }
+ 
+ // static
+-bool ConversionStorageSql::g_run_in_memory_ = false;
++bool ConversionStorageSql::g_run_in_memory_ = true; // use in-memory db
+ 
+ ConversionStorageSql::ConversionStorageSql(
+     const base::FilePath& path_to_database,
+diff --git a/content/browser/renderer_host/navigation_controller_android.cc b/content/browser/renderer_host/navigation_controller_android.cc
+--- a/content/browser/renderer_host/navigation_controller_android.cc
++++ b/content/browser/renderer_host/navigation_controller_android.cc
+@@ -316,21 +316,6 @@ void NavigationControllerAndroid::LoadUrl(
+   if (input_start != 0)
+     params.input_start = base::TimeTicks::FromUptimeMillis(input_start);
+ 
+-  if (source_package_name) {
+-    DCHECK(!params.initiator_origin);
+-    // At the moment, source package name is only used for attribution.
+-    DCHECK(attribution_source_event_id);
+-    params.initiator_origin = OriginFromAndroidPackageName(
+-        ConvertJavaStringToUTF8(env, source_package_name));
+-
+-    params.impression = conversion_host_utils::ParseImpressionFromApp(
+-        ConvertJavaStringToUTF8(env, attribution_source_event_id),
+-        ConvertJavaStringToUTF8(env, attribution_destination),
+-        attribution_report_to
+-            ? ConvertJavaStringToUTF8(env, attribution_report_to)
+-            : "",
+-        attribution_expiry);
+-  }
+ 
+   params.override_user_agent = static_cast<NavigationController::UserAgentOverrideOption>(
+     user_agent_override_option);
+diff --git a/content/browser/storage_partition_impl.cc b/content/browser/storage_partition_impl.cc
+--- a/content/browser/storage_partition_impl.cc
++++ b/content/browser/storage_partition_impl.cc
+@@ -1338,12 +1338,7 @@ void StoragePartitionImpl::Initialize(
+   bucket_context_ = base::MakeRefCounted<BucketContext>();
+   bucket_context_->Initialize();
+ 
+-  // The Conversion Measurement API is not available in Incognito mode.
+-  if (!is_in_memory() &&
+-      base::FeatureList::IsEnabled(blink::features::kConversionMeasurement)) {
+-    conversion_manager_ = std::make_unique<ConversionManagerImpl>(
+-        this, path, special_storage_policy_);
+-  }
++  // The Conversion Measurement API is not available
+ 
+   if (base::FeatureList::IsEnabled(blink::features::kFledgeInterestGroups)) {
+     interest_group_manager_ = std::make_unique<InterestGroupManager>(
+diff --git a/content/public/android/java/src/org/chromium/content/browser/AttributionReporterImpl.java b/content/public/android/java/src/org/chromium/content/browser/AttributionReporterImpl.java
+--- a/content/public/android/java/src/org/chromium/content/browser/AttributionReporterImpl.java
++++ b/content/public/android/java/src/org/chromium/content/browser/AttributionReporterImpl.java
+@@ -22,8 +22,6 @@ public class AttributionReporterImpl extends AttributionReporter {
+     public void reportAttributionForCurrentNavigation(WebContents webContents,
+             String sourcePackageName, String sourceEventId, String destination, String reportTo,
+             long expiry) {
+-        AttributionReporterImplJni.get().reportAttributionForCurrentNavigation(
+-                webContents, sourcePackageName, sourceEventId, destination, reportTo, expiry);
+     }
+ 
+     /**
+@@ -32,8 +30,6 @@ public class AttributionReporterImpl extends AttributionReporter {
+     @Override
+     public void reportAppImpression(BrowserContextHandle browserContext, String sourcePackageName,
+             String sourceEventId, String destination, String reportTo, long expiry) {
+-        AttributionReporterImplJni.get().reportAppImpression(
+-                browserContext, sourcePackageName, sourceEventId, destination, reportTo, expiry);
+     }
+ 
+     @NativeMethods
+diff --git a/content/public/browser/navigation_controller.cc b/content/public/browser/navigation_controller.cc
+--- a/content/public/browser/navigation_controller.cc
++++ b/content/public/browser/navigation_controller.cc
+@@ -36,7 +36,6 @@ NavigationController::LoadURLParams::LoadURLParams(const OpenURLParams& input)
+       blob_url_loader_factory(input.blob_url_loader_factory),
+       href_translate(input.href_translate),
+       reload_type(input.reload_type),
+-      impression(input.impression),
+       is_pdf(input.is_pdf) {
+ #if DCHECK_IS_ON()
+   DCHECK(input.Valid());
+diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
+--- a/third_party/blink/common/features.cc
++++ b/third_party/blink/common/features.cc
+@@ -32,7 +32,7 @@ const base::Feature kCSSContainerQueries{"CSSContainerQueries",
+ 
+ // Controls whether the Conversion Measurement API infrastructure is enabled.
+ const base::Feature kConversionMeasurement{"ConversionMeasurement",
+-                                           base::FEATURE_ENABLED_BY_DEFAULT};
++                                           base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ const base::Feature kGMSCoreEmoji{"GMSCoreEmoji",
+                                   base::FEATURE_DISABLED_BY_DEFAULT};
+diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+--- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
++++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+@@ -470,13 +470,11 @@
+     },
+     {
+       name: "ConversionMeasurement",
+-      origin_trial_feature_name: "ConversionMeasurement",
+-      origin_trial_allows_third_party: true,
+-      status: "experimental",
++      depends_on: ["DisabledForBromite"],
+     },
+     {
+       name: "ConversionMeasurementEventSources",
+-      status: "test",
++      depends_on: ["DisabledForBromite"],
+     },
+     {
+       name: "CooperativeScheduling"
+-- 
+2.20.1
+


### PR DESCRIPTION
Disable `Conversion Measurement API` by disabling the flag and removing support for the AttributionReporting provider. it also removes the handling of attributions via intents between apps.
This patch enforces the deactivation by preventing the report from being sent and being saved to disk, although it is currently in uncalled code.

For this patch I preferred the "soft" approach for two reasons. The first is that the deletion is intrusive ([this](https://gist.github.com/uazo/2ac3c8d6640a300c4e764bfe082f9a32) is the patch that completely removes it), the second is that I have seen that it is still under development and in any case the flag actually seems to disable most of the code.
what was left I took off.

consider that it is currently active in bromite.

fix #1531