### PR TITLE
Reactivation of browser autofill

### DIFF
--- a/build/patches/Enable-native-Android-autofill.patch
+++ b/build/patches/Enable-native-Android-autofill.patch
@@ -6,25 +6,46 @@ There are 2 different types of autofill: one managed via GCM and the
 native Android one that uses the provider assigned by the user
 (which can be any user installed app like Bitwarden for example).
 In chromium GCM is active while in the WebView the latter.
-This patch uses the WebView code to activate native Android autofill.
+This patch uses WebView code to enable native Android autofill 
+along with browser-managed autofill.
 
 See also: https://github.com/bromite/bromite/issues/547
 ---
+ android_webview/browser/aw_contents.cc        |  3 +-
  chrome/android/BUILD.gn                       |  1 +
- .../settings/PasswordSettings.java            | 58 ++++++++++++++++++-
- .../chromium/chrome/browser/tab/TabImpl.java  | 43 ++++++++++++++
- .../browser/tab/TabViewAndroidDelegate.java   | 14 +++++
- chrome/browser/BUILD.gn                       |  8 +++
- chrome/browser/android/tab_android.cc         | 26 +++++++++
+ .../settings/PasswordSettings.java            | 81 ++++++++++++++++++-
+ .../chromium/chrome/browser/tab/TabImpl.java  | 51 ++++++++++++
+ .../browser/tab/TabViewAndroidDelegate.java   | 14 ++++
+ chrome/browser/BUILD.gn                       |  8 ++
+ chrome/browser/android/tab_android.cc         | 27 +++++++
  chrome/browser/android/tab_android.h          |  2 +
- .../strings/android_chrome_strings.grd        |  3 +
- chrome/browser/ui/tab_helpers.cc              |  6 +-
- .../autofill/core/common/autofill_prefs.cc    |  5 ++
- .../autofill/core/common/autofill_prefs.h     |  1 +
- .../embedder_support/view/ContentView.java    | 48 +++++++++++++++
- .../chromium/ui/base/ViewAndroidDelegate.java |  8 +++
- 13 files changed, 221 insertions(+), 2 deletions(-)
+ .../strings/android_chrome_strings.grd        |  6 ++
+ chrome/browser/ui/tab_helpers.cc              |  7 +-
+ .../browser/content_autofill_driver.cc        | 52 ++++++++++--
+ .../content/browser/content_autofill_driver.h | 10 ++-
+ .../content_autofill_driver_factory.cc        | 24 ++++--
+ .../browser/content_autofill_driver_factory.h |  7 +-
+ .../renderer/password_autofill_agent.cc       |  5 +-
+ .../autofill/core/common/autofill_prefs.cc    |  8 ++
+ .../autofill/core/common/autofill_prefs.h     |  2 +
+ .../embedder_support/view/ContentView.java    | 48 +++++++++++
+ .../chromium/ui/base/ViewAndroidDelegate.java |  8 ++
+ weblayer/browser/tab_impl.cc                  |  3 +-
+ 20 files changed, 343 insertions(+), 24 deletions(-)
 
+diff --git a/android_webview/browser/aw_contents.cc b/android_webview/browser/aw_contents.cc
+--- a/android_webview/browser/aw_contents.cc
++++ b/android_webview/browser/aw_contents.cc
+@@ -337,7 +337,8 @@ void AwContents::InitAutofillIfNecessary(bool autocomplete_enabled) {
+           : autofill::AutofillManager::DISABLE_AUTOFILL_DOWNLOAD_MANAGER,
+       autofill_provider
+           ? base::BindRepeating(&autofill::AndroidAutofillManager::Create)
+-          : autofill::AutofillManager::AutofillManagerFactoryCallback());
++          : autofill::AutofillManager::AutofillManagerFactoryCallback(),
++      /*enable_browser_autofill_manager*/false);
+ }
+ 
+ void AwContents::SetAwAutofillClient(const JavaRef<jobject>& client) {
 diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
 --- a/chrome/android/BUILD.gn
 +++ b/chrome/android/BUILD.gn
@@ -59,26 +80,28 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/password_manage
      // Keys for name/password dictionaries.
      public static final String PASSWORD_LIST_URL = "url";
      public static final String PASSWORD_LIST_NAME = "name";
-@@ -75,6 +81,10 @@ public class PasswordSettings extends PreferenceFragmentCompat
+@@ -75,6 +81,11 @@ public class PasswordSettings extends PreferenceFragmentCompat
      public static final String PREF_TRUSTED_VAULT_OPT_IN = "trusted_vault_opt_in";
      public static final String PREF_KEY_MANAGE_ACCOUNT_LINK = "manage_account_link";
      public static final String PREF_KEY_SECURITY_KEY_LINK = "security_key_link";
 +    public static final String PREF_ANDROID_AUTOFILL_SWITCH = "android_autofill_switch";
++    public static final String PREF_ANDROID_AUTOFILL_INCOGNITO_SWITCH = "android_autofill_incognito_switch";
 +
 +    private SnackbarManager mSnackbarManager;
 +    private Snackbar mSnackbar;
  
      // A PasswordEntryViewer receives a boolean value with this key. If set true, the the entry was
  
-@@ -110,6 +120,7 @@ public class PasswordSettings extends PreferenceFragmentCompat
+@@ -110,6 +121,8 @@ public class PasswordSettings extends PreferenceFragmentCompat
      private Preference mLinkPref;
      private Preference mSecurityKey;
      private ChromeSwitchPreference mSavePasswordsSwitch;
 +    private ChromeSwitchPreference mEnableAndroidAutofillSwitch;
++    private ChromeSwitchPreference mEnableAndroidAutofillIncognitoSwitch;
      private ChromeSwitchPreference mAutoSignInSwitch;
      private ChromeBasePreference mCheckPasswords;
      private ChromeBasePreference mTrustedVaultOptIn;
-@@ -274,6 +285,7 @@ public class PasswordSettings extends PreferenceFragmentCompat
+@@ -274,6 +287,7 @@ public class PasswordSettings extends PreferenceFragmentCompat
          getPreferenceScreen().removeAll();
          if (mSearchQuery == null) {
              createSavePasswordsSwitch();
@@ -86,7 +109,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/password_manage
              createAutoSignInCheckbox();
              if (mPasswordCheck != null) {
                  createCheckPasswords();
-@@ -517,6 +529,50 @@ public class PasswordSettings extends PreferenceFragmentCompat
+@@ -517,6 +531,71 @@ public class PasswordSettings extends PreferenceFragmentCompat
                  getPrefService().getBoolean(Pref.CREDENTIALS_ENABLE_SERVICE));
      }
  
@@ -124,6 +147,27 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/password_manage
 +
 +        mEnableAndroidAutofillSwitch.setOnPreferenceChangeListener((preference, newValue) -> {
 +            getPrefService().setBoolean(Pref.AUTOFILL_ANDROID_ENABLED, (boolean) newValue);
++            if (!mSnackbarManager.isShowing())
++                mSnackbarManager.showSnackbar(mSnackbar);
++            return true;
++        });
++
++        mEnableAndroidAutofillIncognitoSwitch = new ChromeSwitchPreference(getStyledContext(), null);
++        mEnableAndroidAutofillIncognitoSwitch.setKey(PREF_ANDROID_AUTOFILL_INCOGNITO_SWITCH);
++        mEnableAndroidAutofillIncognitoSwitch.setTitle(R.string.enable_android_autofill_incognito);
++        mEnableAndroidAutofillIncognitoSwitch.setOrder(ORDER_SWITCH);
++        mEnableAndroidAutofillIncognitoSwitch.setSummaryOn(R.string.text_on);
++        mEnableAndroidAutofillIncognitoSwitch.setSummaryOff(R.string.text_off);
++
++        try (StrictModeContext ignored = StrictModeContext.allowDiskReads()) {
++            getPreferenceScreen().addPreference(mEnableAndroidAutofillIncognitoSwitch);
++        }
++
++        mEnableAndroidAutofillIncognitoSwitch.setChecked(
++                getPrefService().getBoolean(Pref.AUTOFILL_ANDROID_INCOGNITO_ENABLED));
++
++        mEnableAndroidAutofillIncognitoSwitch.setOnPreferenceChangeListener((preference, newValue) -> {
++            getPrefService().setBoolean(Pref.AUTOFILL_ANDROID_INCOGNITO_ENABLED, (boolean) newValue);
 +            if (!mSnackbarManager.isShowing())
 +                mSnackbarManager.showSnackbar(mSnackbar);
 +            return true;
@@ -197,27 +241,35 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabImpl.jav
      /**
       * Initializes the {@link WebContents}. Completes the browser content components initialization
       * around a native WebContents pointer.
-@@ -1407,6 +1436,19 @@ public class TabImpl implements Tab, TabObscuringHandler.Observer {
+@@ -1407,6 +1436,27 @@ public class TabImpl implements Tab, TabObscuringHandler.Observer {
                              mDelegateFactory.createContextMenuPopulatorFactory(this), this));
  
              mWebContents.notifyRendererPreferenceUpdate();
-+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-+                    UserPrefs.get(Profile.getLastUsedRegularProfile())
-+                             .getBoolean(Pref.AUTOFILL_ANDROID_ENABLED) == true) {
-+                SelectionPopupController selectionController =
-+                        SelectionPopupController.fromWebContents(mWebContents);
++            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
++                boolean autofillEnabled = false;
++                if (isIncognito()) {
++                    autofillEnabled = UserPrefs.get(Profile.getLastUsedRegularProfile())
++                                               .getBoolean(Pref.AUTOFILL_ANDROID_INCOGNITO_ENABLED);
++                } else {
++                    autofillEnabled = UserPrefs.get(Profile.getLastUsedRegularProfile())
++                                               .getBoolean(Pref.AUTOFILL_ANDROID_ENABLED);
++                }
 +
-+                mAutofillProvider = new AutofillProvider(getContext(), cv, webContents, "bromite");
-+                TabImplJni.get().initializeAutofillIfNecessary(mNativeTabAndroid);
-+                mAutofillProvider.setWebContents(webContents);
-+                cv.setWebContents(webContents);
-+                selectionController.setNonSelectionActionModeCallback(
-+                        new AutofillActionModeCallback(mThemedApplicationContext, mAutofillProvider));
++                if (autofillEnabled) {
++                    SelectionPopupController selectionController =
++                            SelectionPopupController.fromWebContents(mWebContents);
++                    mAutofillProvider = new AutofillProvider(getContext(), cv, webContents, "bromite");
++                    TabImplJni.get().initializeAutofillIfNecessary(mNativeTabAndroid);
++                    mAutofillProvider.setWebContents(webContents);
++                    cv.setWebContents(webContents);
++                    selectionController.setNonSelectionActionModeCallback(
++                            new AutofillActionModeCallback(mThemedApplicationContext, mAutofillProvider));
++                }
 +            }
              TabHelpers.initWebContentsHelpers(this);
              notifyContentChanged();
          } finally {
-@@ -1769,5 +1811,6 @@ public class TabImpl implements Tab, TabObscuringHandler.Observer {
+@@ -1769,5 +1819,6 @@ public class TabImpl implements Tab, TabObscuringHandler.Observer {
          void setActiveNavigationEntryTitleForUrl(long nativeTabAndroid, String url, String title);
          void loadOriginalImage(long nativeTabAndroid);
          boolean handleNonNavigationAboutURL(GURL url);
@@ -288,7 +340,7 @@ diff --git a/chrome/browser/android/tab_android.cc b/chrome/browser/android/tab_
  using base::android::AttachCurrentThread;
  using base::android::ConvertUTF8ToJavaString;
  using base::android::JavaParamRef;
-@@ -437,3 +444,22 @@ static void JNI_TabImpl_Init(JNIEnv* env, const JavaParamRef<jobject>& obj) {
+@@ -437,3 +444,23 @@ static void JNI_TabImpl_Init(JNIEnv* env, const JavaParamRef<jobject>& obj) {
    // This will automatically bind to the Java object and pass ownership there.
    new TabAndroid(env, obj);
  }
@@ -308,7 +360,8 @@ diff --git a/chrome/browser/android/tab_android.cc b/chrome/browser/android/tab_
 +        autofill::ChromeAutofillClient::FromWebContents(web_contents),
 +        g_browser_process->GetApplicationLocale(),
 +        autofill::BrowserAutofillManager::DISABLE_AUTOFILL_DOWNLOAD_MANAGER,
-+        base::BindRepeating(&autofill::AndroidAutofillManager::Create));
++        base::BindRepeating(&autofill::AndroidAutofillManager::Create),
++        /*enable_browser_autofill_manager*/true);
 +  }
 +}
 diff --git a/chrome/browser/android/tab_android.h b/chrome/browser/android/tab_android.h
@@ -326,12 +379,15 @@ diff --git a/chrome/browser/android/tab_android.h b/chrome/browser/android/tab_a
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -555,6 +555,9 @@ CHAR_LIMIT guidelines:
+@@ -555,6 +555,12 @@ CHAR_LIMIT guidelines:
        <message name="IDS_PASSWORD_SETTINGS_SAVE_PASSWORDS" desc="Title for the checkbox toggling whether passwords are saved or not. [CHAR_LIMIT=32]">
          Save passwords
        </message>
 +      <message name="IDS_ENABLE_ANDROID_AUTOFILL" desc="Title for the checkbox toggling whether enable Android native autofill or not. [CHAR_LIMIT=32]">
 +        Enable native Android autofill
++      </message>
++      <message name="IDS_ENABLE_ANDROID_AUTOFILL_INCOGNITO" desc="Title for the checkbox toggling whether enable Android native autofill or not in incognito mode. [CHAR_LIMIT=32]">
++        Enable native Android autofill in incognito
 +      </message>
        <message name="IDS_PASSWORDS_AUTO_SIGNIN_TITLE" desc="Title for checkbox to enable automatically signing the user in to websites">
          Auto Sign-in
@@ -349,46 +405,364 @@ diff --git a/chrome/browser/ui/tab_helpers.cc b/chrome/browser/ui/tab_helpers.cc
  #else
  #include "chrome/browser/accuracy_tips/accuracy_service_factory.h"
  #include "chrome/browser/banners/app_banner_manager_desktop.h"
-@@ -245,7 +248,8 @@ void TabHelpers::AttachTabHelpers(WebContents* web_contents) {
+@@ -245,7 +248,9 @@ void TabHelpers::AttachTabHelpers(WebContents* web_contents) {
        web_contents,
        autofill::ChromeAutofillClient::FromWebContents(web_contents),
        g_browser_process->GetApplicationLocale(),
 -      autofill::BrowserAutofillManager::ENABLE_AUTOFILL_DOWNLOAD_MANAGER);
 +      autofill::BrowserAutofillManager::ENABLE_AUTOFILL_DOWNLOAD_MANAGER,
-+      base::BindRepeating(&autofill::AndroidAutofillManager::Create));
++      base::BindRepeating(&autofill::AndroidAutofillManager::Create),
++      /*enable_browser_autofill_manager*/true);
    chrome_browser_net::NetErrorTabHelper::CreateForWebContents(web_contents);
    ChromePasswordManagerClient::CreateForWebContentsWithAutofillClient(
        web_contents,
+diff --git a/components/autofill/content/browser/content_autofill_driver.cc b/components/autofill/content/browser/content_autofill_driver.cc
+--- a/components/autofill/content/browser/content_autofill_driver.cc
++++ b/components/autofill/content/browser/content_autofill_driver.cc
+@@ -69,7 +69,8 @@ ContentAutofillDriver::ContentAutofillDriver(
+     ContentAutofillRouter* autofill_router,
+     AutofillManager::AutofillDownloadManagerState enable_download_manager,
+     AutofillManager::AutofillManagerFactoryCallback
+-        autofill_manager_factory_callback)
++        autofill_manager_factory_callback,
++    bool enable_browser_autofill_manager)
+     : render_frame_host_(render_frame_host),
+       autofill_router_(autofill_router),
+       browser_autofill_manager_(nullptr),
+@@ -83,9 +84,11 @@ ContentAutofillDriver::ContentAutofillDriver(
+     GetAutofillAgent()->SetSecureContextRequired(true);
+     GetAutofillAgent()->SetFocusRequiresScroll(false);
+     GetAutofillAgent()->SetQueryPasswordSuggestion(true);
+-  } else {
++  }
++  if (!autofill_manager_factory_callback || enable_browser_autofill_manager) {
+     SetBrowserAutofillManager(std::make_unique<BrowserAutofillManager>(
+-        this, client, app_locale, enable_download_manager));
++        this, client, app_locale, enable_download_manager),
++        enable_browser_autofill_manager);
+   }
+   if (client && ShouldEnableHeavyFormDataScraping(client->GetChannel())) {
+     GetAutofillAgent()->EnableHeavyFormDataScraping();
+@@ -336,6 +339,8 @@ void ContentAutofillDriver::RendererShouldSetSuggestionAvailability(
+ 
+ void ContentAutofillDriver::FormsSeenImpl(const std::vector<FormData>& forms) {
+   autofill_manager_->OnFormsSeen(forms);
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnFormsSeen(forms);
+ }
+ 
+ void ContentAutofillDriver::SetFormToBeProbablySubmittedImpl(
+@@ -358,6 +363,8 @@ void ContentAutofillDriver::FormSubmittedImpl(const FormData& form,
+   }
+ 
+   autofill_manager_->OnFormSubmitted(form, known_success, source);
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnFormSubmitted(form, known_success, source);
+ }
+ 
+ void ContentAutofillDriver::TextFieldDidChangeImpl(
+@@ -366,6 +373,8 @@ void ContentAutofillDriver::TextFieldDidChangeImpl(
+     const gfx::RectF& bounding_box,
+     base::TimeTicks timestamp) {
+   autofill_manager_->OnTextFieldDidChange(form, field, bounding_box, timestamp);
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnTextFieldDidChange(form, field, bounding_box, timestamp);
+ }
+ 
+ void ContentAutofillDriver::TextFieldDidScrollImpl(
+@@ -373,6 +382,8 @@ void ContentAutofillDriver::TextFieldDidScrollImpl(
+     const FormFieldData& field,
+     const gfx::RectF& bounding_box) {
+   autofill_manager_->OnTextFieldDidScroll(form, field, bounding_box);
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnTextFieldDidScroll(form, field, bounding_box);
+ }
+ 
+ void ContentAutofillDriver::SelectControlDidChangeImpl(
+@@ -380,6 +391,8 @@ void ContentAutofillDriver::SelectControlDidChangeImpl(
+     const FormFieldData& field,
+     const gfx::RectF& bounding_box) {
+   autofill_manager_->OnSelectControlDidChange(form, field, bounding_box);
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnSelectControlDidChange(form, field, bounding_box);
+ }
+ 
+ void ContentAutofillDriver::AskForValuesToFillImpl(
+@@ -390,15 +403,22 @@ void ContentAutofillDriver::AskForValuesToFillImpl(
+     bool autoselect_first_suggestion) {
+   autofill_manager_->OnAskForValuesToFill(id, form, field, bounding_box,
+                                           autoselect_first_suggestion);
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnAskForValuesToFill(id, form, field, bounding_box,
++                                          autoselect_first_suggestion);
+ }
+ 
+ void ContentAutofillDriver::HidePopupImpl() {
+   DCHECK(!IsPrerendering()) << "We should never affect UI while prerendering";
+   autofill_manager_->OnHidePopup();
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnHidePopup();
+ }
+ 
+ void ContentAutofillDriver::FocusNoLongerOnFormImpl(bool had_interacted_form) {
+   autofill_manager_->OnFocusNoLongerOnForm(had_interacted_form);
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnFocusNoLongerOnForm(had_interacted_form);
+ }
+ 
+ void ContentAutofillDriver::FocusOnFormFieldImpl(
+@@ -406,25 +426,35 @@ void ContentAutofillDriver::FocusOnFormFieldImpl(
+     const FormFieldData& field,
+     const gfx::RectF& bounding_box) {
+   autofill_manager_->OnFocusOnFormField(form, field, bounding_box);
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnFocusOnFormField(form, field, bounding_box);
+ }
+ 
+ void ContentAutofillDriver::DidFillAutofillFormDataImpl(
+     const FormData& form,
+     base::TimeTicks timestamp) {
+   autofill_manager_->OnDidFillAutofillFormData(form, timestamp);
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnDidFillAutofillFormData(form, timestamp);
+ }
+ 
+ void ContentAutofillDriver::DidPreviewAutofillFormDataImpl() {
+   autofill_manager_->OnDidPreviewAutofillFormData();
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnDidPreviewAutofillFormData();
+ }
+ 
+ void ContentAutofillDriver::DidEndTextFieldEditingImpl() {
+   autofill_manager_->OnDidEndTextFieldEditing();
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->OnDidEndTextFieldEditing();
+ }
+ 
+ void ContentAutofillDriver::SelectFieldOptionsDidChangeImpl(
+     const FormData& form) {
+   autofill_manager_->SelectFieldOptionsDidChange(form);
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->SelectFieldOptionsDidChange(form);
+ }
+ 
+ void ContentAutofillDriver::FillFormForAssistantImpl(
+@@ -629,13 +659,21 @@ void ContentAutofillDriver::DidNavigateFrame(
+   if (autofill_router_)  // Can be nullptr only in tests.
+     autofill_router_->UnregisterDriver(this);
+   autofill_manager_->Reset();
++  if (browser_autofill_manager_ptr_)
++    browser_autofill_manager_->Reset();
+ }
+ 
+ void ContentAutofillDriver::SetBrowserAutofillManager(
+-    std::unique_ptr<BrowserAutofillManager> manager) {
+-  autofill_manager_ = std::move(manager);
+-  browser_autofill_manager_ =
+-      static_cast<BrowserAutofillManager*>(autofill_manager_.get());
++    std::unique_ptr<BrowserAutofillManager> manager,
++    bool enable_browser_autofill_manager) {
++  if (enable_browser_autofill_manager) {
++    browser_autofill_manager_ptr_ = std::move(manager);
++    browser_autofill_manager_ = browser_autofill_manager_ptr_.get();
++  } else {
++    autofill_manager_ = std::move(manager);
++    browser_autofill_manager_ =
++        static_cast<BrowserAutofillManager*>(autofill_manager_.get());
++  }
+ }
+ 
+ ContentAutofillDriver::ContentAutofillDriver(content::RenderFrameHost* rfh)
+diff --git a/components/autofill/content/browser/content_autofill_driver.h b/components/autofill/content/browser/content_autofill_driver.h
+--- a/components/autofill/content/browser/content_autofill_driver.h
++++ b/components/autofill/content/browser/content_autofill_driver.h
+@@ -138,7 +138,8 @@ class ContentAutofillDriver : public AutofillDriver,
+       ContentAutofillRouter* autofill_router,
+       AutofillManager::AutofillDownloadManagerState enable_download_manager,
+       AutofillManager::AutofillManagerFactoryCallback
+-          autofill_manager_factory_callback);
++          autofill_manager_factory_callback,
++      bool enable_browser_autofill_manager);
+   ContentAutofillDriver(const ContentAutofillDriver&) = delete;
+   ContentAutofillDriver& operator=(const ContentAutofillDriver&) = delete;
+   ~ContentAutofillDriver() override;
+@@ -357,7 +358,8 @@ class ContentAutofillDriver : public AutofillDriver,
+ 
+   // Sets the manager to |manager|. Takes ownership of |manager|.
+   void SetBrowserAutofillManager(
+-      std::unique_ptr<BrowserAutofillManager> manager);
++      std::unique_ptr<BrowserAutofillManager> manager,
++      bool enable_browser_autofill_manager);
+ 
+   // Reports whether a document collects phone numbers, uses one time code, uses
+   // WebOTP. There are cases that the reporting is not expected:
+@@ -428,6 +430,10 @@ class ContentAutofillDriver : public AutofillDriver,
+   // pointer to a common root.
+   BrowserAutofillManager* browser_autofill_manager_;
+ 
++  // adds a reference for BrowserAutofillManager, since native autofill works in
++  // conjunction with browser autofill in Bromite
++  std::unique_ptr<BrowserAutofillManager> browser_autofill_manager_ptr_;
++
+   // Pointer to an implementation of InternalAuthenticator.
+   std::unique_ptr<webauthn::InternalAuthenticator> authenticator_impl_;
+ 
+diff --git a/components/autofill/content/browser/content_autofill_driver_factory.cc b/components/autofill/content/browser/content_autofill_driver_factory.cc
+--- a/components/autofill/content/browser/content_autofill_driver_factory.cc
++++ b/components/autofill/content/browser/content_autofill_driver_factory.cc
+@@ -31,10 +31,12 @@ std::unique_ptr<AutofillDriver> CreateDriver(
+     BrowserAutofillManager::AutofillDownloadManagerState
+         enable_download_manager,
+     AutofillManager::AutofillManagerFactoryCallback
+-        autofill_manager_factory_callback) {
++        autofill_manager_factory_callback,
++    bool enable_browser_autofill_manager) {
+   return std::make_unique<ContentAutofillDriver>(
+       render_frame_host, client, app_locale, router, enable_download_manager,
+-      std::move(autofill_manager_factory_callback));
++      std::move(autofill_manager_factory_callback),
++      enable_browser_autofill_manager);
+ }
+ 
+ }  // namespace
+@@ -62,7 +64,8 @@ void ContentAutofillDriverFactory::CreateForWebContentsAndDelegate(
+         enable_download_manager) {
+   CreateForWebContentsAndDelegate(
+       contents, client, app_locale, enable_download_manager,
+-      AutofillManager::AutofillManagerFactoryCallback());
++      AutofillManager::AutofillManagerFactoryCallback(),
++      /*enable_browser_autofill_manager*/true);
+ }
+ 
+ void ContentAutofillDriverFactory::CreateForWebContentsAndDelegate(
+@@ -72,7 +75,8 @@ void ContentAutofillDriverFactory::CreateForWebContentsAndDelegate(
+     BrowserAutofillManager::AutofillDownloadManagerState
+         enable_download_manager,
+     AutofillManager::AutofillManagerFactoryCallback
+-        autofill_manager_factory_callback) {
++        autofill_manager_factory_callback,
++    bool enable_browser_autofill_manager) {
+   if (FromWebContents(contents))
+     return;
+ 
+@@ -80,7 +84,8 @@ void ContentAutofillDriverFactory::CreateForWebContentsAndDelegate(
+       kContentAutofillDriverFactoryWebContentsUserDataKey,
+       std::make_unique<ContentAutofillDriverFactory>(
+           contents, client, app_locale, enable_download_manager,
+-          std::move(autofill_manager_factory_callback)));
++          std::move(autofill_manager_factory_callback),
++          enable_browser_autofill_manager));
+ }
+ 
+ // static
+@@ -120,13 +125,15 @@ ContentAutofillDriverFactory::ContentAutofillDriverFactory(
+     BrowserAutofillManager::AutofillDownloadManagerState
+         enable_download_manager,
+     AutofillManager::AutofillManagerFactoryCallback
+-        autofill_manager_factory_callback)
++        autofill_manager_factory_callback,
++    bool enable_browser_autofill_manager)
+     : AutofillDriverFactory(client),
+       content::WebContentsObserver(web_contents),
+       app_locale_(app_locale),
+       enable_download_manager_(enable_download_manager),
+       autofill_manager_factory_callback_(
+-          std::move(autofill_manager_factory_callback)) {}
++          std::move(autofill_manager_factory_callback)),
++      enable_browser_autofill_manager_(enable_browser_autofill_manager) {}
+ 
+ ContentAutofillDriver* ContentAutofillDriverFactory::DriverForFrame(
+     content::RenderFrameHost* render_frame_host) {
+@@ -138,7 +145,8 @@ ContentAutofillDriver* ContentAutofillDriverFactory::DriverForFrame(
+         render_frame_host,
+         base::BindRepeating(CreateDriver, render_frame_host, client(),
+                             app_locale_, &router_, enable_download_manager_,
+-                            autofill_manager_factory_callback_));
++                            autofill_manager_factory_callback_,
++                            enable_browser_autofill_manager_));
+     driver = DriverForKey(render_frame_host);
+   }
+ 
+diff --git a/components/autofill/content/browser/content_autofill_driver_factory.h b/components/autofill/content/browser/content_autofill_driver_factory.h
+--- a/components/autofill/content/browser/content_autofill_driver_factory.h
++++ b/components/autofill/content/browser/content_autofill_driver_factory.h
+@@ -39,7 +39,8 @@ class ContentAutofillDriverFactory : public AutofillDriverFactory,
+       BrowserAutofillManager::AutofillDownloadManagerState
+           enable_download_manager,
+       AutofillManager::AutofillManagerFactoryCallback
+-          autofill_manager_factory_callback);
++          autofill_manager_factory_callback,
++      bool enable_browser_autofill_manager);
+ 
+   ContentAutofillDriverFactory(const ContentAutofillDriver&) = delete;
+   ContentAutofillDriverFactory& operator=(const ContentAutofillDriver&) =
+@@ -61,7 +62,8 @@ class ContentAutofillDriverFactory : public AutofillDriverFactory,
+       BrowserAutofillManager::AutofillDownloadManagerState
+           enable_download_manager,
+       AutofillManager::AutofillManagerFactoryCallback
+-          autofill_manager_factory_callback);
++          autofill_manager_factory_callback,
++      bool enable_browser_autofill_manager);
+ 
+   static ContentAutofillDriverFactory* FromWebContents(
+       content::WebContents* contents);
+@@ -91,6 +93,7 @@ class ContentAutofillDriverFactory : public AutofillDriverFactory,
+   AutofillManager::AutofillManagerFactoryCallback
+       autofill_manager_factory_callback_;
+   ContentAutofillRouter router_;
++  bool enable_browser_autofill_manager_;
+ };
+ 
+ }  // namespace autofill
+diff --git a/components/autofill/content/renderer/password_autofill_agent.cc b/components/autofill/content/renderer/password_autofill_agent.cc
+--- a/components/autofill/content/renderer/password_autofill_agent.cc
++++ b/components/autofill/content/renderer/password_autofill_agent.cc
+@@ -727,7 +727,10 @@ void PasswordAutofillAgent::UpdateStateForTextChange(
+ 
+ void PasswordAutofillAgent::TrackAutofilledElement(
+     const blink::WebFormControlElement& element) {
+-  autofill_agent_->TrackAutofilledElement(element);
++  // fix for https://github.com/bromite/bromite/issues/1570
++  AutofillAgent* agent = autofill_agent_.get();
++  if (agent)
++    agent->TrackAutofilledElement(element);
+ }
+ 
+ bool PasswordAutofillAgent::FillSuggestion(
 diff --git a/components/autofill/core/common/autofill_prefs.cc b/components/autofill/core/common/autofill_prefs.cc
 --- a/components/autofill/core/common/autofill_prefs.cc
 +++ b/components/autofill/core/common/autofill_prefs.cc
-@@ -128,6 +128,9 @@ const char kAutofillWalletImportStorageCheckboxState[] =
+@@ -128,6 +128,10 @@ const char kAutofillWalletImportStorageCheckboxState[] =
  const char kAutocompleteLastVersionRetentionPolicy[] =
      "autocomplete.retention_policy_last_version";
  
 +// Boolean that is true to enable native Android Autofill
 +const char kAutofillAndroidEnabled[] = "autofill.android_autofill_enabled";
++const char kAutofillAndroidIncognitoEnabled[] = "autofill.android_autofill_incognito_enabled";
 +
  void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
    // Synced prefs. Used for cross-device choices, e.g., credit card Autofill.
    registry->RegisterBooleanPref(
-@@ -160,6 +163,8 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+@@ -160,6 +164,10 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
    registry->RegisterBooleanPref(
        prefs::kAutofillCreditCardFidoAuthOfferCheckboxState, true);
  #endif
 +  registry->RegisterBooleanPref(
 +      prefs::kAutofillAndroidEnabled, true);
++  registry->RegisterBooleanPref(
++      prefs::kAutofillAndroidIncognitoEnabled, false);
    registry->RegisterIntegerPref(
        prefs::kAutofillCreditCardSigninPromoImpressionCount, 0);
    registry->RegisterBooleanPref(prefs::kAutofillWalletImportEnabled, true);
 diff --git a/components/autofill/core/common/autofill_prefs.h b/components/autofill/core/common/autofill_prefs.h
 --- a/components/autofill/core/common/autofill_prefs.h
 +++ b/components/autofill/core/common/autofill_prefs.h
-@@ -47,6 +47,7 @@ extern const char kAutofillUploadEventsLastResetTimestamp[];
+@@ -47,6 +47,8 @@ extern const char kAutofillUploadEventsLastResetTimestamp[];
  extern const char kAutofillWalletImportEnabled[];
  extern const char kAutofillWalletImportStorageCheckboxState[];
  extern const char kAutocompleteLastVersionRetentionPolicy[];
 +extern const char kAutofillAndroidEnabled[];
++extern const char kAutofillAndroidIncognitoEnabled[];
  
  namespace sync_transport_opt_in {
  enum Flags {
@@ -485,6 +859,19 @@ diff --git a/ui/android/java/src/org/chromium/ui/base/ViewAndroidDelegate.java b
 +
 +    public void autofill(final SparseArray<AutofillValue> values) {}
  }
+diff --git a/weblayer/browser/tab_impl.cc b/weblayer/browser/tab_impl.cc
+--- a/weblayer/browser/tab_impl.cc
++++ b/weblayer/browser/tab_impl.cc
+@@ -1396,7 +1396,8 @@ void TabImpl::InitializeAutofillDriver() {
+   autofill::ContentAutofillDriverFactory::CreateForWebContentsAndDelegate(
+       web_contents, AutofillClientImpl::FromWebContents(web_contents),
+       i18n::GetApplicationLocale(), enable_autofill_download_manager,
+-      base::BindRepeating(&autofill::AndroidAutofillManager::Create));
++      base::BindRepeating(&autofill::AndroidAutofillManager::Create),
++      false);
+ }
+ 
+ #endif  // defined(OS_ANDROID)
 -- 
 2.20.1
 


### PR DESCRIPTION
I modified the patch to reactivate the browser autofill management together with the native one.
Some functions are in fact managed by the internal chromium manager.

Fix for #1534