### PR TITLE
Make image shields more useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Bromite - Take back your browser
-
-<img src="https://www.bromite.org/release.svg" alt="current Bromite release" title="current Bromite release" /> <img src="https://www.bromite.org/license.svg" alt="GNU GPL v3" title="GNU VPL v3" />
-
-<img title="Bromite - take back your browser!" src="https://www.bromite.org/android-icon-192x192.png" width="96" alt="Bromite" />
+<a href="https://github.com/bromite/bromite/releases/latest">
+  <img src="https://www.bromite.org/release.svg" alt="current Bromite release" title="current Bromite release" /> </a>
+<a href="https://github.com/bromite/bromite/blob/master/LICENSE">
+  <img src="https://www.bromite.org/license.svg" alt="GNU GPL v3" title="GNU VPL v3" />
+</a> <br>
+<a href="https://www.bromite.org">
+  <img title="Bromite - take back your browser!" src="https://www.bromite.org/android-icon-192x192.png" width="96" alt="Bromite" />
+</a>
 
 Bromite is a [Chromium](https://www.chromium.org/Home) fork with support for ad blocking and enhanced privacy.
 


### PR DESCRIPTION
Images used as shields are expected to work as hyperlinks to relevant urls.
They weren't.
Now they should be.
Alternative: Use shields.io, they provide high-res, auto-updated shield images.
Try the below:
[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/bromite/bromite?logo=github)](https://github.com/bromite/bromite/releases/latest) [![GitHub license](https://img.shields.io/github/license/bromite/bromite)](https://github.com/bromite/bromite/blob/master/LICENSE)

Downside is, without adding Shields.io app to the project, you might hit GitHub rate limits. By adding it it can be mitigated freely.
Note that Shields.io itself is also an opensource project without any tracking, so that won't be much of a problem.