### PR TITLE
Fix always incognito mode

### DIFF
--- a/build/patches/Add-an-always-incognito-mode.patch
+++ b/build/patches/Add-an-always-incognito-mode.patch
@@ -6,42 +6,34 @@ More specifically, add a preference that causes all new tabs and all
 clicked links to launch as incognito.
 Make sure initial incognito status is correctly recognized.
 Enable incognito custom tabs and fix crashes for incognito/custom tab intents (credits to @uazo)
+Added preference in native
+Modification of content settings allowed
 ---
- chrome/android/chrome_java_sources.gni        |  1 +
  .../java/res/xml/privacy_preferences.xml      |  5 ++
- .../AlwaysIncognitoLinkInterceptor.java       | 80 +++++++++++++++++++
- .../chrome/browser/ChromeTabbedActivity.java  |  6 +-
- .../chrome/browser/app/ChromeActivity.java    |  4 +
- .../AppMenuPropertiesDelegateImpl.java        |  6 ++
- .../ChromeContextMenuPopulator.java           |  8 +-
- .../CustomTabActivityLifecycleUmaTracker.java | 25 ------
+ .../chrome/browser/app/ChromeActivity.java    |  4 ++
+ .../AppMenuPropertiesDelegateImpl.java        | 12 +++++
+ .../ChromeContextMenuPopulator.java           | 10 +++-
+ .../CustomTabActivityLifecycleUmaTracker.java | 25 ----------
  .../CustomTabIntentDataProvider.java          |  5 +-
- .../browser/init/StartupTabPreloader.java     | 14 +++-
- .../privacy/settings/PrivacySettings.java     | 37 ++++++++-
- .../browser/settings/SettingsActivity.java    |  4 +
- .../tabbed_mode/TabbedRootUiCoordinator.java  |  6 +-
- .../browser/tabmodel/ChromeTabCreator.java    | 16 +++-
- .../browser/tabmodel/TabPersistentStore.java  | 10 +++
- .../webapps/WebappIntentDataProvider.java     | 14 ++++
+ .../browser/init/StartupTabPreloader.java     | 14 ++++--
+ .../privacy/settings/PrivacySettings.java     | 46 ++++++++++++++++++-
+ .../browser/settings/SettingsActivity.java    |  4 ++
+ .../tabbed_mode/TabbedRootUiCoordinator.java  |  8 +++-
+ .../browser/tabmodel/ChromeTabCreator.java    |  1 -
+ .../tabmodel/TabModelSelectorImpl.java        | 14 ++++++
+ .../browser/tabmodel/TabPersistentStore.java  | 14 ++++++
+ .../webapps/WebappIntentDataProvider.java     | 12 +++++
+ .../host_content_settings_map_factory.cc      | 18 +++++++-
  .../flags/android/chrome_feature_list.cc      |  2 +-
- .../strings/android_chrome_strings.grd        | 13 +++
+ chrome/browser/prefs/browser_prefs.cc         |  3 ++
+ .../strings/android_chrome_strings.grd        | 13 ++++++
  chrome/browser/ui/messages/android/BUILD.gn   |  1 +
- .../snackbar/INeedSnackbarManager.java        | 27 +++++++
- 20 files changed, 248 insertions(+), 36 deletions(-)
- create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java
+ .../snackbar/INeedSnackbarManager.java        | 27 +++++++++++
+ chrome/common/pref_names.cc                   |  5 ++
+ chrome/common/pref_names.h                    |  4 ++
+ 22 files changed, 210 insertions(+), 37 deletions(-)
  create mode 100644 chrome/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/INeedSnackbarManager.java
 
-diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java_sources.gni
---- a/chrome/android/chrome_java_sources.gni
-+++ b/chrome/android/chrome_java_sources.gni
-@@ -3,6 +3,7 @@
- # found in the LICENSE file.
- 
- chrome_java_sources = [
-+  "java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java",
-   "java/src/com/google/android/apps/chrome/appwidget/bookmarks/BookmarkThumbnailWidgetProvider.java",
-   "java/src/org/chromium/chrome/browser/ActivityTabProvider.java",
-   "java/src/org/chromium/chrome/browser/ActivityUtils.java",
 diff --git a/chrome/android/java/res/xml/privacy_preferences.xml b/chrome/android/java/res/xml/privacy_preferences.xml
 --- a/chrome/android/java/res/xml/privacy_preferences.xml
 +++ b/chrome/android/java/res/xml/privacy_preferences.xml
@@ -57,130 +49,15 @@ diff --git a/chrome/android/java/res/xml/privacy_preferences.xml b/chrome/androi
      <Preference
          android:fragment="org.chromium.chrome.browser.privacy.settings.DoNotTrackSettings"
          android:key="do_not_track"
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java b/chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java
-new file mode 100644
---- /dev/null
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java
-@@ -0,0 +1,80 @@
-+/* This Source Code Form is subject to the terms of the Mozilla Public
-+ * License, v. 2.0. If a copy of the MPL was not distributed with this
-+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-+
-+package org.chromium.chrome.browser;
-+
-+import android.content.SharedPreferences;
-+
-+import org.chromium.chrome.browser.tab.EmptyTabObserver;
-+import org.chromium.chrome.browser.tab.Tab;
-+import org.chromium.chrome.browser.tab.TabImpl;
-+import org.chromium.chrome.browser.tabmodel.TabCreatorManager;
-+import org.chromium.chrome.browser.tab.TabLaunchType;
-+import org.chromium.chrome.browser.tabmodel.TabModel;
-+import org.chromium.content_public.browser.LoadUrlParams;
-+import org.chromium.url.GURL;
-+
-+import java.util.HashMap;
-+import java.util.HashSet;
-+import java.util.Map;
-+import java.util.Set;
-+/**
-+ * A {@link TabObserver} that implements the always-incognito preference behavior for links. When the preference is set
-+ * to true, it intercepts links opened within observed {@link Tab}s and opens them in new incognito <code>Tab</code>s instead.
-+ */
-+public class AlwaysIncognitoLinkInterceptor extends EmptyTabObserver {
-+
-+    public static final String PREF_ALWAYS_INCOGNITO = "always_incognito";
-+
-+    private final SharedPreferences alwaysIncognitoContainer;
-+    private final Map<Tab, String> lastUrls;
-+    private final Set<Tab> revertingTabs;
-+
-+    public AlwaysIncognitoLinkInterceptor(final SharedPreferences alwaysIncognitoContainer) {
-+
-+        assert alwaysIncognitoContainer != null;
-+
-+        this.alwaysIncognitoContainer = alwaysIncognitoContainer;
-+        lastUrls = new HashMap<Tab, String>();
-+        revertingTabs = new HashSet<Tab>();
-+    }
-+
-+    @Override
-+    public void onDestroyed(final Tab tab)
-+    {
-+        lastUrls.remove(tab);
-+        revertingTabs.remove(tab);
-+    }
-+
-+    @Override
-+    public void onUpdateUrl(Tab tab, GURL gurl) {
-+
-+        if (tab == null) return;
-+        if (gurl == null) return;
-+        if (tab.isIncognito()) return;
-+        if (alwaysIncognitoContainer == null) return;
-+
-+        String spec = gurl.getValidSpecOrEmpty();
-+        if (spec == null) return;
-+
-+        final String lastUrl = lastUrls.put(tab, spec);
-+
-+        if (!alwaysIncognitoContainer.getBoolean(PREF_ALWAYS_INCOGNITO, false)) return;
-+        if (revertingTabs.contains(tab)) {
-+            revertingTabs.remove(tab);
-+            return;
-+        }
-+
-+        ((ChromeTabbedActivity)tab.getWindowAndroid().getActivity().get())
-+            .getTabCreator(true)
-+            .createNewTab(new LoadUrlParams(spec), TabLaunchType.FROM_LINK, tab);
-+
-+        if ((spec.equals(lastUrl)) || (!tab.canGoBack())) {
-+            // this call was triggered by a reload
-+        } else {
-+            revertingTabs.add(tab);
-+            tab.goBack();
-+        }
-+    }
-+}
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
---- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
-@@ -56,6 +56,7 @@ import org.chromium.base.supplier.UnownedUserDataSupplier;
- import org.chromium.base.task.PostTask;
- import org.chromium.cc.input.BrowserControlsState;
- import org.chromium.chrome.R;
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
- import org.chromium.chrome.browser.IntentHandler.IntentHandlerDelegate;
- import org.chromium.chrome.browser.IntentHandler.TabOpenType;
- import org.chromium.chrome.browser.accessibility_tab_switcher.OverviewListLayout;
-@@ -1770,8 +1771,9 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
-         Bundle savedInstanceState = getSavedInstanceState();
- 
-         // We determine the model as soon as possible so every systems get initialized coherently.
--        boolean startIncognito = savedInstanceState != null
--                && savedInstanceState.getBoolean(IS_INCOGNITO_SELECTED, false);
-+        boolean startIncognito = ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false)
-+                || (savedInstanceState != null
-+                && savedInstanceState.getBoolean(IS_INCOGNITO_SELECTED, false));
- 
-         mNextTabPolicySupplier = new ChromeNextTabPolicySupplier(mOverviewModeBehaviorSupplier);
- 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
-@@ -101,6 +101,7 @@ import org.chromium.chrome.browser.contextualsearch.ContextualSearchFieldTrial;
- import org.chromium.chrome.browser.contextualsearch.ContextualSearchManager;
- import org.chromium.chrome.browser.contextualsearch.ContextualSearchManager.ContextualSearchTabPromotionDelegate;
- import org.chromium.chrome.browser.dependency_injection.ChromeActivityCommonsModule;
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
- import org.chromium.chrome.browser.dependency_injection.ChromeActivityComponent;
- import org.chromium.chrome.browser.dependency_injection.ModuleFactoryOverrides;
- import org.chromium.chrome.browser.device.DeviceClassManager;
-@@ -1891,6 +1892,9 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
+@@ -1891,6 +1891,10 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
              throw new IllegalStateException(
                      "Attempting to access TabCreator before initialization");
          }
-+        if (ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false)) {
++        if (UserPrefs.get(Profile.getLastUsedRegularProfile())
++                     .getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED)) {
 +            incognito = true;
 +        }
          return mTabCreatorManagerSupplier.get().getTabCreator(incognito);
@@ -189,11 +66,24 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActiv
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
-@@ -538,6 +538,12 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+@@ -86,6 +86,10 @@ import org.chromium.ui.modelutil.MVCListAdapter.ModelList;
+ import org.chromium.ui.modelutil.PropertyModel;
+ import org.chromium.url.GURL;
+ 
++import org.chromium.components.prefs.PrefService;
++import org.chromium.components.user_prefs.UserPrefs;
++import org.chromium.chrome.browser.preferences.Pref;
++
+ import java.lang.annotation.Retention;
+ import java.lang.annotation.RetentionPolicy;
+ import java.util.ArrayList;
+@@ -538,6 +542,14 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
      }
  
      private void prepareCommonMenuItems(Menu menu, @MenuGroup int menuGroup, boolean isIncognito) {
-+        if (ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
++        boolean always_incognito = UserPrefs.get(Profile.getLastUsedRegularProfile())
++            .getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED);
++        if (always_incognito) {
 +            final MenuItem newTabOption = menu.findItem(R.id.new_tab_menu_id);
 +            if (newTabOption != null)
 +                newTabOption.setVisible(false);
@@ -205,26 +95,28 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/App
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java b/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java
-@@ -31,6 +31,7 @@ import org.chromium.base.ContextUtils;
+@@ -31,6 +31,9 @@ import org.chromium.base.ContextUtils;
  import org.chromium.base.metrics.RecordHistogram;
  import org.chromium.base.supplier.Supplier;
  import org.chromium.chrome.R;
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
++import org.chromium.components.prefs.PrefService;
++import org.chromium.components.user_prefs.UserPrefs;
++import org.chromium.chrome.browser.preferences.Pref;
  import org.chromium.chrome.browser.compositor.bottombar.ephemeraltab.EphemeralTabCoordinator;
  import org.chromium.chrome.browser.contextmenu.ChromeContextMenuItem.Item;
  import org.chromium.chrome.browser.contextmenu.ContextMenuCoordinator.ListItemType;
-@@ -408,6 +409,10 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -408,6 +411,10 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
          boolean hasSaveImage = false;
          mShowEphemeralTabNewLabel = null;
  
 +        boolean always_incognito =
-+            ContextUtils.getAppSharedPreferences().getBoolean(
-+                AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
++            UserPrefs.get(Profile.getLastUsedRegularProfile())
++                .getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED);
 +
          List<Pair<Integer, ModelList>> groupedItems = new ArrayList<>();
  
          if (mParams.isAnchor()) {
-@@ -426,6 +431,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -426,6 +433,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
                              linkGroup.add(createListItem(Item.OPEN_IN_NEW_TAB_IN_GROUP));
                          }
                      }
@@ -232,7 +124,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/Chr
                      if (!mItemDelegate.isIncognito() && mItemDelegate.isIncognitoSupported()) {
                          linkGroup.add(createListItem(Item.OPEN_IN_INCOGNITO_TAB));
                      }
-@@ -450,7 +456,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -450,7 +458,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
                  }
              }
              if (FirstRunStatus.getFirstRunFlowComplete()) {
@@ -279,22 +171,22 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/Cust
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
-@@ -49,6 +49,9 @@ import org.chromium.components.browser_ui.widget.TintedDrawable;
+@@ -49,6 +49,8 @@ import org.chromium.components.browser_ui.widget.TintedDrawable;
  import org.chromium.components.embedder_support.util.UrlConstants;
  import org.chromium.device.mojom.ScreenOrientationLockType;
  
 +import org.chromium.base.ContextUtils;
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
 +
  import java.lang.annotation.Retention;
  import java.lang.annotation.RetentionPolicy;
  import java.util.ArrayList;
-@@ -726,7 +729,7 @@ public class CustomTabIntentDataProvider extends BrowserServicesIntentDataProvid
+@@ -726,7 +728,8 @@ public class CustomTabIntentDataProvider extends BrowserServicesIntentDataProvid
  
      @Override
      public boolean isIncognito() {
 -        return false;
-+        return ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
++        return ContextUtils.getAppSharedPreferences()
++                           .getBoolean("always_incognito", false);
      }
  
      @Nullable
@@ -305,9 +197,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTab
  import org.chromium.ui.base.WindowAndroid;
  import org.chromium.url.GURL;
  
-+import org.chromium.base.ContextUtils;
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
-+
++import org.chromium.components.user_prefs.UserPrefs;
++import org.chromium.components.prefs.PrefService;
++import org.chromium.chrome.browser.preferences.Pref;
  /**
   * This class attempts to preload the tab if the url is known from the intent when the profile
   * is created. This is done to improve startup latency.
@@ -315,9 +207,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTab
          Intent intent = mIntentSupplier.get();
          GURL url = UrlFormatter.fixupUrl(getUrlFromIntent(intent));
  
-+        boolean isIncognito = ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
-+
 +        Profile profile = Profile.getLastUsedRegularProfile();
++        boolean isIncognito = UserPrefs.get(profile)
++                                .getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED);
          ChromeTabCreator chromeTabCreator =
 -                (ChromeTabCreator) mTabCreatorManager.getTabCreator(false);
 +                (ChromeTabCreator) mTabCreatorManager.getTabCreator(isIncognito);
@@ -365,12 +257,14 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
      private static final String PREF_CAN_MAKE_PAYMENT = "can_make_payment";
      private static final String PREF_NETWORK_PREDICTIONS = "preload_pages";
      private static final String PREF_HTTPS_FIRST_MODE = "https_first_mode";
-@@ -96,6 +105,25 @@ public class PrivacySettings
+@@ -96,6 +105,27 @@ public class PrivacySettings
                  (ChromeSwitchPreference) findPreference(PREF_CAN_MAKE_PAYMENT);
          canMakePaymentPref.setOnPreferenceChangeListener(this);
  
 +        ChromeSwitchPreference alwaysIncognitoPref =
 +                (ChromeSwitchPreference) findPreference(PREF_ALWAYS_INCOGNITO);
++        alwaysIncognitoPref.setChecked(
++            UserPrefs.get(Profile.getLastUsedRegularProfile()).getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED));
 +        alwaysIncognitoPref.setOnPreferenceChangeListener(this);
 +
 +        mSnackbar = Snackbar.make(getActivity().getString(R.string.ui_relaunch_notice),
@@ -391,17 +285,24 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
          ChromeSwitchPreference networkPredictionPref =
                  (ChromeSwitchPreference) findPreference(PREF_NETWORK_PREDICTIONS);
          networkPredictionPref.setChecked(
-@@ -156,6 +184,9 @@ public class PrivacySettings
+@@ -156,6 +186,16 @@ public class PrivacySettings
          } else if (PREF_NETWORK_PREDICTIONS.equals(key)) {
              PrivacyPreferencesManagerImpl.getInstance().setNetworkPredictionEnabled(
                      (boolean) newValue);
 +        } else if (PREF_ALWAYS_INCOGNITO.equals(key)) {
++            UserPrefs.get(Profile.getLastUsedRegularProfile()).setBoolean(Pref.ALWAYS_INCOGNITO_ENABLED,
++                (boolean) newValue);
++
++            SharedPreferences.Editor sharedPreferenceEditor = ContextUtils.getAppSharedPreferences().edit();
++            sharedPreferenceEditor.putBoolean("always_incognito", (boolean) newValue);
++            sharedPreferenceEditor.apply();
++
 +            if (!mSnackbarManager.isShowing())
 +                mSnackbarManager.showSnackbar(mSnackbar);
          } else if (PREF_HTTPS_FIRST_MODE.equals(key)) {
              UserPrefs.get(Profile.getLastUsedRegularProfile())
                      .setBoolean(Pref.HTTPS_ONLY_MODE_ENABLED, (boolean) newValue);
-@@ -238,4 +269,8 @@ public class PrivacySettings
+@@ -238,4 +278,8 @@ public class PrivacySettings
          }
          return false;
      }
@@ -434,21 +335,23 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/Settin
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java b/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
-@@ -121,6 +121,8 @@ import org.chromium.ui.base.DeviceFormFactor;
+@@ -121,7 +121,9 @@ import org.chromium.ui.base.DeviceFormFactor;
  import org.chromium.ui.base.IntentRequestTracker;
  import org.chromium.ui.modaldialog.ModalDialogManager;
  import org.chromium.ui.util.TokenHolder;
-+import org.chromium.base.ContextUtils;
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
- 
+-
++import org.chromium.components.prefs.PrefService;
++import org.chromium.components.user_prefs.UserPrefs;
++import org.chromium.chrome.browser.preferences.Pref;
  /**
   * A {@link RootUiCoordinator} variant that controls tabbed-mode specific UI.
+  */
 @@ -483,11 +485,13 @@ public class TabbedRootUiCoordinator extends RootUiCoordinator {
  
          // TODO(twellington): Supply TabModelSelector as well and move initialization earlier.
          if (DeviceFormFactor.isNonMultiDisplayContextOnTablet(mActivity)) {
-+            boolean tabModel = ContextUtils.getAppSharedPreferences().getBoolean(
-+                        AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
++            boolean tabModel = UserPrefs.get(Profile.getLastUsedRegularProfile())
++                .getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED);
              AppMenuHandler appMenuHandler =
                      mAppMenuCoordinator == null ? null : mAppMenuCoordinator.getAppMenuHandler();
              mEmptyBackgroundViewWrapper = new EmptyBackgroundViewWrapper(
@@ -461,55 +364,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/Tab
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/ChromeTabCreator.java b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/ChromeTabCreator.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/ChromeTabCreator.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/ChromeTabCreator.java
-@@ -44,6 +44,10 @@ import org.chromium.url.GURL;
- 
- import java.nio.ByteBuffer;
- 
-+import org.chromium.base.ContextUtils;
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
-+import org.chromium.chrome.browser.tab.TabObserver;
-+
- /**
-  * This class creates various kinds of new tabs and adds them to the right {@link TabModel}.
-  */
-@@ -74,6 +78,7 @@ public class ChromeTabCreator extends TabCreator {
-     private final Activity mActivity;
-     private final StartupTabPreloader mStartupTabPreloader;
-     private final boolean mIncognito;
-+    private final TabObserver mExtraLogic;
- 
-     private WindowAndroid mNativeWindow;
-     private TabModel mTabModel;
-@@ -96,6 +101,10 @@ public class ChromeTabCreator extends TabCreator {
-         mNativeWindow = nativeWindow;
-         mTabDelegateFactorySupplier = tabDelegateFactory;
-         mIncognito = incognito;
-+        if (!mIncognito)
-+            mExtraLogic = new AlwaysIncognitoLinkInterceptor(ContextUtils.getAppSharedPreferences());
-+        else
-+            mExtraLogic = null;
-         mOverviewNTPCreator = overviewNTPCreator;
-         mAsyncTabParamsManager = asyncTabParamsManager;
-         mTabModelSelectorSupplier = tabModelSelectorSupplier;
-@@ -259,6 +268,8 @@ public class ChromeTabCreator extends TabCreator {
-             if (creationState == TabCreationState.LIVE_IN_FOREGROUND && !openInForeground) {
-                 creationState = TabCreationState.LIVE_IN_BACKGROUND;
-             }
-+            if (mExtraLogic != null)
-+                tab.addObserver(mExtraLogic);
-             mTabModel.addTab(tab, position, type, creationState);
-             return tab;
-         } finally {
-@@ -293,6 +304,8 @@ public class ChromeTabCreator extends TabCreator {
-         @TabCreationState
-         int creationState = openInForeground ? TabCreationState.LIVE_IN_FOREGROUND
-                                              : TabCreationState.LIVE_IN_BACKGROUND;
-+        if (mExtraLogic != null)
-+            tab.addObserver(mExtraLogic);
-         mTabModel.addTab(tab, position, type, creationState);
-         return true;
-     }
-@@ -333,7 +346,6 @@ public class ChromeTabCreator extends TabCreator {
+@@ -333,7 +333,6 @@ public class ChromeTabCreator extends TabCreator {
      // TODO(crbug.com/1081924): Clean up the launches from SearchActivity/Chrome.
      public Tab launchUrlFromExternalApp(
              LoadUrlParams loadUrlParams, String appId, boolean forceNewTab, Intent intent) {
@@ -517,15 +372,37 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/Chrome
          // Don't re-use tabs for intents from Chrome. Note that this can be spoofed so shouldn't be
          // relied on for anything security sensitive.
          boolean isLaunchedFromChrome = TextUtils.equals(appId, mActivity.getPackageName());
-@@ -428,6 +440,8 @@ public class ChromeTabCreator extends TabCreator {
-                           .setSerializedCriticalPersistedTabData(serializedCriticalPersistedTabData)
-                           .build();
-         }
-+        if (mExtraLogic != null)
-+            tab.addObserver(mExtraLogic);
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorImpl.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorImpl.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorImpl.java
+@@ -23,6 +23,12 @@ import org.chromium.chrome.browser.tabmodel.NextTabPolicy.NextTabPolicySupplier;
+ import org.chromium.ui.base.WindowAndroid;
+ import org.chromium.url.GURL;
  
-         if (isIncognito != mIncognito) {
-             throw new IllegalStateException("Incognito state mismatch. TabState: "
++import org.chromium.base.ContextUtils;
++import org.chromium.chrome.browser.preferences.Pref;
++import org.chromium.components.user_prefs.UserPrefs;
++import org.chromium.components.prefs.PrefService;
++import org.chromium.base.Log;
++
+ import java.util.concurrent.atomic.AtomicBoolean;
+ 
+ /**
+@@ -111,6 +117,14 @@ public class TabModelSelectorImpl extends TabModelSelectorBase implements TabMod
+                 (ChromeTabCreator) getTabCreatorManager().getTabCreator(false);
+         ChromeTabCreator incognitoTabCreator =
+                 (ChromeTabCreator) getTabCreatorManager().getTabCreator(true);
++        if (ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
++            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
++            if(!prefService.getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED)) {
++                Log.i("BROMITE", "Migration: always incognito pref from java to native");
++                prefService.setBoolean(Pref.ALWAYS_INCOGNITO_ENABLED, true);
++            }
++            regularTabCreator = incognitoTabCreator;
++        }
+         TabModelImpl normalModel = new TabModelImpl(Profile.getLastUsedRegularProfile(),
+                 mActivityType, regularTabCreator, incognitoTabCreator, mOrderController,
+                 mTabContentManager, mNextTabPolicySupplier, mAsyncTabParamsManager, this,
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
@@ -537,20 +414,24 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPer
  import org.chromium.base.Log;
  import org.chromium.base.ObserverList;
  import org.chromium.base.StreamUtil;
-@@ -55,6 +56,8 @@ import org.chromium.content_public.browser.LoadUrlParams;
+@@ -55,6 +56,11 @@ import org.chromium.content_public.browser.LoadUrlParams;
  import org.chromium.content_public.browser.UiThreadTaskTraits;
  import org.chromium.url.GURL;
  
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
++import org.chromium.chrome.browser.profiles.Profile;
++import org.chromium.components.prefs.PrefService;
++import org.chromium.chrome.browser.preferences.Pref;
++import org.chromium.components.user_prefs.UserPrefs;
 +
  import java.io.BufferedInputStream;
  import java.io.ByteArrayInputStream;
  import java.io.ByteArrayOutputStream;
-@@ -643,6 +646,13 @@ public class TabPersistentStore {
+@@ -643,6 +649,14 @@ public class TabPersistentStore {
                  }
              }
          }
-+        if (ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false)) {
++        if (UserPrefs.get(Profile.getLastUsedRegularProfile())
++                .getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED)) {
 +            if (!isIncognito) {
 +                Log.w(TAG, "Failed to restore tab: not in incognito mode.");
 +                return;
@@ -563,17 +444,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPer
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappIntentDataProvider.java b/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappIntentDataProvider.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappIntentDataProvider.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappIntentDataProvider.java
-@@ -29,6 +29,9 @@ import org.chromium.chrome.browser.flags.ActivityType;
- import org.chromium.components.browser_ui.widget.TintedDrawable;
- import org.chromium.device.mojom.ScreenOrientationLockType;
- 
-+import org.chromium.base.ContextUtils;
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
-+
- /**
-  * Stores info about a web app.
-  */
-@@ -42,6 +45,8 @@ public class WebappIntentDataProvider extends BrowserServicesIntentDataProvider
+@@ -42,6 +42,8 @@ public class WebappIntentDataProvider extends BrowserServicesIntentDataProvider
      private final Intent mIntent;
      private final ColorProviderImpl mColorProvider;
  
@@ -582,18 +453,19 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappI
      /**
       * Returns the toolbar color to use if a custom color is not specified by the webapp.
       */
-@@ -63,6 +68,10 @@ public class WebappIntentDataProvider extends BrowserServicesIntentDataProvider
+@@ -63,6 +65,11 @@ public class WebappIntentDataProvider extends BrowserServicesIntentDataProvider
          mWebappExtras = webappExtras;
          mWebApkExtras = webApkExtras;
          mActivityType = (webApkExtras != null) ? ActivityType.WEB_APK : ActivityType.WEBAPP;
 +
-+        if (ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false)) {
++        if (ContextUtils.getAppSharedPreferences()
++                .getBoolean("always_incognito", false)) {
 +            mIsIncognito = true;
 +        }
      }
  
      @Override
-@@ -151,6 +160,11 @@ public class WebappIntentDataProvider extends BrowserServicesIntentDataProvider
+@@ -151,6 +158,11 @@ public class WebappIntentDataProvider extends BrowserServicesIntentDataProvider
          return mWebApkExtras;
      }
  
@@ -605,6 +477,51 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappI
      @Override
      public @ScreenOrientationLockType.EnumType int getDefaultOrientation() {
          return mWebappExtras.orientation;
+diff --git a/chrome/browser/content_settings/host_content_settings_map_factory.cc b/chrome/browser/content_settings/host_content_settings_map_factory.cc
+--- a/chrome/browser/content_settings/host_content_settings_map_factory.cc
++++ b/chrome/browser/content_settings/host_content_settings_map_factory.cc
+@@ -22,6 +22,7 @@
+ #include "content/public/browser/browser_thread.h"
+ #include "extensions/buildflags/buildflags.h"
+ #include "ui/webui/webui_allowlist_provider.h"
++#include "chrome/common/pref_names.h"
+ 
+ #if BUILDFLAG(ENABLE_EXTENSIONS)
+ #include "base/trace_event/trace_event.h"
+@@ -88,11 +89,21 @@ scoped_refptr<RefcountedKeyedService>
+   if (profile->IsOffTheRecord() && !profile->IsGuestSession())
+     GetForProfile(original_profile);
+ 
++  bool always_incognito_enabled = false;
++
++#if defined(ALWAYS_INCOGNITO_ENABLED)
++  PrefService* prefService = original_profile->GetPrefs();
++  if (prefService->GetBoolean(prefs::kAlwaysIncognitoEnabled)) {
++    profile = original_profile;
++    always_incognito_enabled = true;
++  }
++#endif
++
+   scoped_refptr<HostContentSettingsMap> settings_map(new HostContentSettingsMap(
+       profile->GetPrefs(),
+-      profile->IsOffTheRecord() || profile->IsGuestSession(),
++      !always_incognito_enabled && (profile->IsOffTheRecord() || profile->IsGuestSession()),
+       /*store_last_modified=*/true,
+-      profile->ShouldRestoreOldSessionCookies()));
++      !always_incognito_enabled && profile->ShouldRestoreOldSessionCookies()));
+ 
+   auto allowlist_provider = std::make_unique<WebUIAllowlistProvider>(
+       WebUIAllowlist::GetOrCreate(profile));
+@@ -110,6 +121,9 @@ scoped_refptr<RefcountedKeyedService>
+         std::move(one_time_geolocation_provider));
+   }
+ 
++  if (always_incognito_enabled)
++    return settings_map;
++
+ #if BUILDFLAG(ENABLE_EXTENSIONS)
+   // These must be registered before before the HostSettings are passed over to
+   // the IOThread.  Simplest to do this on construction.
 diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
 --- a/chrome/browser/flags/android/chrome_feature_list.cc
 +++ b/chrome/browser/flags/android/chrome_feature_list.cc
@@ -617,6 +534,19 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browse
  
  const base::Feature kCCTPostMessageAPI{"CCTPostMessageAPI",
                                         base::FEATURE_ENABLED_BY_DEFAULT};
+diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browser_prefs.cc
+--- a/chrome/browser/prefs/browser_prefs.cc
++++ b/chrome/browser/prefs/browser_prefs.cc
+@@ -1255,6 +1255,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
+   variations::VariationsService::RegisterProfilePrefs(registry);
+   video_tutorials::RegisterPrefs(registry);
+   feed::prefs::RegisterFeedSharedProfilePrefs(registry);
++  // register incognito pref
++  registry->RegisterBooleanPref(prefs::kAlwaysIncognitoEnabled,
++                              /*default_value=*/false);
+   feed::RegisterProfilePrefs(registry);
+ #else  // defined(OS_ANDROID)
+   AppShortcutManager::RegisterProfilePrefs(registry);
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
@@ -683,6 +613,35 @@ new file mode 100644
 +public interface INeedSnackbarManager {
 +    void setSnackbarManager(SnackbarManager manager);
 +}
+diff --git a/chrome/common/pref_names.cc b/chrome/common/pref_names.cc
+--- a/chrome/common/pref_names.cc
++++ b/chrome/common/pref_names.cc
+@@ -3273,6 +3273,11 @@ const char kShowCaretBrowsingDialog[] =
+ const char kLacrosLaunchSwitch[] = "lacros_launch_switch";
+ #endif
+ 
++#if defined(OS_ANDROID)
++const char kAlwaysIncognitoEnabled[] =
++    "always_incognito_enabled";
++#endif
++
+ #if BUILDFLAG(IS_CHROMEOS_ASH)
+ // String enum pref determining what should happen when a user who authenticates
+ // via a security token is removing this token. "IGNORE" - nothing happens
+diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
+--- a/chrome/common/pref_names.h
++++ b/chrome/common/pref_names.h
+@@ -1200,6 +1200,10 @@ extern const char kLastWhatsNewVersion[];
+ extern const char kLensRegionSearchEnabled[];
+ #endif
+ 
++#if defined(OS_ANDROID)
++#define ALWAYS_INCOGNITO_ENABLED
++extern const char kAlwaysIncognitoEnabled[];
++#endif
+ }  // namespace prefs
+ 
+ #endif  // CHROME_COMMON_PREF_NAMES_H_
 -- 
 2.20.1
 

--- a/build/patches/Add-history-support-in-incognito-mode.patch
+++ b/build/patches/Add-history-support-in-incognito-mode.patch
@@ -8,23 +8,26 @@ flag turned on.
 IncognitoPlaceholder is also deactivated, both in the phone and tablet version.
 The relative tests are also present.
 
+Use native preference for always incognito mode
+
 See also: https://github.com/bromite/bromite/pull/1427
 ---
  .../chrome_junit_test_java_sources.gni        |   4 +
  chrome/android/chrome_test_java_sources.gni   |   6 +
  .../java/res/xml/privacy_preferences.xml      |   5 +
- .../AppMenuPropertiesDelegateImpl.java        |  29 +-
- .../CustomTabAppMenuPropertiesDelegate.java   |   3 +
+ .../AppMenuPropertiesDelegateImpl.java        |  22 +-
+ .../CustomTabAppMenuPropertiesDelegate.java   |   9 +
  .../browser/download/DownloadUtils.java       |  16 +-
  .../browser/history/HistoryManager.java       |  17 +-
  .../chrome/browser/history/HistoryPage.java   |  15 +
+ .../native_page/NativePageFactory.java        |   6 +-
  .../chrome/browser/ntp/RecentTabsManager.java |   8 +-
  .../privacy/settings/PrivacySettings.java     |  18 +
  .../browser/tab/HistoricalTabSaver.java       |  12 +-
  .../browser/tabmodel/TabPersistentStore.java  |   5 +-
- .../history/Bromite_HistoryManagerTest.java   | 112 ++++++
+ .../history/Bromite_HistoryManagerTest.java   | 107 ++++++
  ...FragmentTest_HistoryInAlwaysIncognito.java | 120 +++++++
- ...ite_AppMenuPropertiesDelegateUnitTest.java | 323 ++++++++++++++++++
+ ...ite_AppMenuPropertiesDelegateUnitTest.java | 321 ++++++++++++++++++
  .../tab/HistoricalTabSaverUnitTest.java       |  16 +-
  .../browser/android/historical_tab_saver.cc   |  28 +-
  chrome/browser/android/historical_tab_saver.h |  27 ++
@@ -40,13 +43,13 @@ See also: https://github.com/bromite/bromite/pull/1427
  .../request_coordinator_factory.h             |   2 +
  chrome/browser/prefs/browser_prefs.cc         |   3 +
  .../browser/ui/android/native_page/BUILD.gn   |   2 +
- .../browser/ui/native_page/NativePage.java    |   6 +-
- .../ui/native_page/NativePageTest.java        |  26 ++
+ .../browser/ui/native_page/NativePage.java    |  10 +-
+ .../ui/native_page/NativePageTest.java        |  21 ++
  .../strings/android_chrome_strings.grd        |   6 +
- chrome/common/pref_names.cc                   |   5 +
- chrome/common/pref_names.h                    |   4 +
+ chrome/common/pref_names.cc                   |   2 +
+ chrome/common/pref_names.h                    |   2 +
  chrome/test/BUILD.gn                          |   5 +
- 36 files changed, 1045 insertions(+), 38 deletions(-)
+ 37 files changed, 1034 insertions(+), 41 deletions(-)
  create mode 100644 chrome/android/javatests/src/org/chromium/chrome/browser/history/Bromite_HistoryManagerTest.java
  create mode 100644 chrome/android/javatests/src/org/chromium/chrome/browser/privacy/settings/Bromite_PrivacySettingsFragmentTest_HistoryInAlwaysIncognito.java
  create mode 100644 chrome/android/junit/src/org/chromium/chrome/browser/app/appmenu/Bromite_AppMenuPropertiesDelegateUnitTest.java
@@ -96,18 +99,7 @@ diff --git a/chrome/android/java/res/xml/privacy_preferences.xml b/chrome/androi
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
-@@ -92,6 +92,10 @@ import java.util.ArrayList;
- import java.util.List;
- import java.util.Map;
- 
-+import org.chromium.components.prefs.PrefService;
-+import org.chromium.components.user_prefs.UserPrefs;
-+import org.chromium.chrome.browser.preferences.Pref;
-+
- /**
-  * Base implementation of {@link AppMenuPropertiesDelegate} that handles hiding and showing menu
-  * items based on activity state.
-@@ -153,6 +157,13 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+@@ -157,6 +157,13 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
      protected BookmarkBridge mBookmarkBridge;
      protected Runnable mAppMenuInvalidator;
  
@@ -121,17 +113,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/App
      /**
       * Construct a new {@link AppMenuPropertiesDelegateImpl}.
       * @param context The activity context.
-@@ -539,7 +550,8 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
-     }
- 
-     private void prepareCommonMenuItems(Menu menu, @MenuGroup int menuGroup, boolean isIncognito) {
--        if (ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
-+        boolean always_incognito = ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false);
-+        if (always_incognito) {
-             final MenuItem newTabOption = menu.findItem(R.id.new_tab_menu_id);
-             if (newTabOption != null)
-                 newTabOption.setVisible(false);
-@@ -601,7 +613,15 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+@@ -607,7 +614,15 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
              }
  
              if (item.getItemId() == R.id.recent_tabs_menu_id) {
@@ -148,26 +130,39 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/App
              }
              if (item.getItemId() == R.id.menu_group_tabs) {
                  item.setVisible(isMenuGroupTabsVisible);
-@@ -811,7 +831,10 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+@@ -817,7 +832,10 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
          //                is not persisted when adding to the homescreen.
          // * If creating shortcuts it not supported by the current home screen.
          return WebappsUtils.isAddToHomeIntentSupported() && !isChromeScheme && !isFileScheme
 -                && !isContentScheme && !isIncognito && !url.isEmpty();
 +                && !isContentScheme && !url.isEmpty()
 +                && (!isIncognito ||
-+                    ContextUtils.getAppSharedPreferences().getBoolean(
-+                        "always_incognito", false));
++                    UserPrefs.get(Profile.getLastUsedRegularProfile())
++                        .getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED));
      }
  
      /**
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabAppMenuPropertiesDelegate.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabAppMenuPropertiesDelegate.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabAppMenuPropertiesDelegate.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabAppMenuPropertiesDelegate.java
-@@ -170,6 +170,9 @@ public class CustomTabAppMenuPropertiesDelegate extends AppMenuPropertiesDelegat
+@@ -42,6 +42,11 @@ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
+ 
++import org.chromium.chrome.browser.profiles.Profile;
++import org.chromium.components.prefs.PrefService;
++import org.chromium.components.user_prefs.UserPrefs;
++import org.chromium.chrome.browser.preferences.Pref;
++
+ /**
+  * App menu properties delegate for {@link CustomTabActivity}.
+  */
+@@ -170,6 +175,10 @@ public class CustomTabAppMenuPropertiesDelegate extends AppMenuPropertiesDelegat
                  downloadItemVisible = false;
                  openInChromeItemVisible = false;
              }
-+            if (ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
++            if (UserPrefs.get(Profile.getLastUsedRegularProfile())
++                         .getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED)) {
 +                downloadItemVisible = true;
 +            }
  
@@ -192,10 +187,10 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/download/Downlo
          // OfflinePageBridge.getForProfile because OfflinePageBridge instance will not be found
          // for incognito profile.
 -        if (tab.isIncognito()) return false;
++        PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
 +        boolean always_incognito =
-+            ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false);
++            prefService.getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED);
 +        if (always_incognito) {
-+            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
 +            boolean historyEnabledInIncognito =
 +                prefService.getBoolean(Pref.INCOGNITO_TAB_HISTORY_ENABLED);
 +            if (historyEnabledInIncognito == false)
@@ -230,9 +225,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/History
 +    public boolean isIncognito() { return mIsIncognito; }
 +
 +    public boolean shouldShowIncognitoPlaceholder() {
++        PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
 +        if (mIsIncognito &&
-+                ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
-+            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
++                prefService.getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED)) {
 +            boolean historyEnabledInIncognito =
 +                prefService.getBoolean(Pref.INCOGNITO_TAB_HISTORY_ENABLED);
 +            if (historyEnabledInIncognito) return false;
@@ -260,9 +255,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/History
              boolean isIncognito, Supplier<Tab> tabSupplier) {
          super(host);
  
++        PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
 +        if (isIncognito &&
-+                ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
-+            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
++                prefService.getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED)) {
 +            boolean historyEnabledInIncognito =
 +                prefService.getBoolean(Pref.INCOGNITO_TAB_HISTORY_ENABLED);
 +            if (historyEnabledInIncognito == true) isIncognito = false;
@@ -274,6 +269,29 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/History
          mTitle = host.getContext().getResources().getString(R.string.menu_history);
  
          initWithView(mHistoryManager.getView());
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/native_page/NativePageFactory.java b/chrome/android/java/src/org/chromium/chrome/browser/native_page/NativePageFactory.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/native_page/NativePageFactory.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/native_page/NativePageFactory.java
+@@ -51,6 +51,8 @@ import org.chromium.content_public.browser.LoadUrlParams;
+ import org.chromium.ui.base.DeviceFormFactor;
+ import org.chromium.ui.base.WindowAndroid;
+ import org.chromium.ui.util.ColorUtils;
++import org.chromium.components.user_prefs.UserPrefs;
++import org.chromium.chrome.browser.preferences.Pref;
+ /**
+  * Creates NativePage objects to show chrome-native:// URLs using the native Android view system.
+  */
+@@ -243,7 +245,9 @@ public class NativePageFactory {
+             String url, NativePage candidatePage, Tab tab, boolean isIncognito) {
+         NativePage page;
+ 
+-        switch (NativePage.nativePageType(url, candidatePage, isIncognito)) {
++        boolean isAlwaysIncognito = UserPrefs.get(Profile.getLastUsedRegularProfile())
++            .getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED);
++        switch (NativePage.nativePageType(url, candidatePage, isIncognito, isAlwaysIncognito)) {
+             case NativePageType.NONE:
+                 return null;
+             case NativePageType.CANDIDATE:
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java b/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java
@@ -308,7 +326,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
  import org.chromium.chrome.R;
  import org.chromium.chrome.browser.feedback.HelpAndFeedbackLauncherImpl;
  import org.chromium.chrome.browser.flags.ChromeFeatureList;
-@@ -149,6 +150,11 @@ public class PrivacySettings
+@@ -151,6 +152,11 @@ public class PrivacySettings
          Preference secureDnsPref = findPreference(PREF_SECURE_DNS);
          secureDnsPref.setVisible(SecureDnsSettings.isUiEnabled());
  
@@ -320,7 +338,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
          updatePreferences();
      }
  
-@@ -203,11 +209,16 @@ public class PrivacySettings
+@@ -212,11 +218,16 @@ public class PrivacySettings
          } else if (PREF_INCOGNITO_LOCK.equals(key)) {
              UserPrefs.get(Profile.getLastUsedRegularProfile())
                      .setBoolean(Pref.INCOGNITO_REAUTHENTICATION_FOR_ANDROID, (boolean) newValue);
@@ -337,7 +355,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
      @Override
      public void onResume() {
          super.onResume();
-@@ -249,6 +260,13 @@ public class PrivacySettings
+@@ -258,6 +269,13 @@ public class PrivacySettings
          closeTabsOnExitPref.setOnPreferenceChangeListener(this);
          closeTabsOnExitPref.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
  
@@ -392,13 +410,13 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/HistoricalT
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
-@@ -150,7 +150,10 @@ public class TabPersistentStore {
+@@ -153,7 +153,10 @@ public class TabPersistentStore {
              @Override
              public void didCloseTab(Tab tab) {
                  PersistedTabData.onTabClose(tab);
 -                if (!tab.isIncognito()) HistoricalTabSaver.createHistoricalTab(tab);
 +                boolean is_always_incognito =
-+                    ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
++                    UserPrefs.get(Profile.getLastUsedRegularProfile()).getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED);
 +                if (!tab.isIncognito() || is_always_incognito)
 +                        HistoricalTabSaver.createHistoricalTab(tab, is_always_incognito);
                  removeTabFromQueues(tab);
@@ -408,7 +426,7 @@ diff --git a/chrome/android/javatests/src/org/chromium/chrome/browser/history/Br
 new file mode 100644
 --- /dev/null
 +++ b/chrome/android/javatests/src/org/chromium/chrome/browser/history/Bromite_HistoryManagerTest.java
-@@ -0,0 +1,112 @@
+@@ -0,0 +1,107 @@
 +/*
 +    This file is part of Bromite.
 +
@@ -452,7 +470,6 @@ new file mode 100644
 +import org.chromium.components.prefs.PrefService;
 +import org.chromium.components.user_prefs.UserPrefs;
 +import org.chromium.chrome.browser.preferences.Pref;
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
 +import android.content.SharedPreferences;
 +
 +import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
@@ -482,10 +499,8 @@ new file mode 100644
 +            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
 +            prefService.clearPref(Pref.INCOGNITO_TAB_HISTORY_ENABLED);
 +
-+            SharedPreferences prefs = ContextUtils.getAppSharedPreferences();
-+            SharedPreferences.Editor editor = prefs.edit();
-+            editor.putBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
-+            editor.apply();
++            UserPrefs.get(Profile.getLastUsedRegularProfile()
++                .setBoolean(Pref.ALWAYS_INCOGNITO_ENABLED, false);
 +        });
 +    }
 +
@@ -505,10 +520,8 @@ new file mode 100644
 +
 +        TestThreadUtils.runOnUiThreadBlocking(() -> {
 +            // set always incognito on
-+            SharedPreferences prefs = ContextUtils.getAppSharedPreferences();
-+            SharedPreferences.Editor editor = prefs.edit();
-+            editor.putBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, true);
-+            editor.apply();
++            UserPrefs.get(Profile.getLastUsedRegularProfile()
++                .setBoolean(Pref.ALWAYS_INCOGNITO_ENABLED, true);
 +
 +            // set INCOGNITO_TAB_HISTORY_ENABLED on
 +            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
@@ -650,7 +663,7 @@ diff --git a/chrome/android/junit/src/org/chromium/chrome/browser/app/appmenu/Br
 new file mode 100644
 --- /dev/null
 +++ b/chrome/android/junit/src/org/chromium/chrome/browser/app/appmenu/Bromite_AppMenuPropertiesDelegateUnitTest.java
-@@ -0,0 +1,323 @@
+@@ -0,0 +1,321 @@
 +/*
 +    This file is part of Bromite.
 +
@@ -737,7 +750,6 @@ new file mode 100644
 +import java.util.ArrayList;
 +import java.util.List;
 +
-+import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
 +import android.content.SharedPreferences;
 +
 +/**
@@ -838,9 +850,8 @@ new file mode 100644
 +    }
 +
 +    private void setUpTestPrefs(SharedPreferences prefs, boolean always_incognito) {
-+        SharedPreferences.Editor editor = prefs.edit();
-+        editor.putBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, always_incognito);
-+        editor.apply();
++        UserPrefs.get(Profile.getLastUsedRegularProfile()
++            .setBoolean(Pref.ALWAYS_INCOGNITO_ENABLED, always_incognito);
 +    }
 +
 +    @Test
@@ -1580,10 +1591,10 @@ diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browse
  #include "chrome/browser/android/bookmarks/partner_bookmarks_shim.h"
  #include "chrome/browser/android/explore_sites/history_statistics_reporter.h"
  #include "chrome/browser/android/ntp/recent_tabs_page_prefs.h"
-@@ -1259,6 +1261,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
-   variations::VariationsService::RegisterProfilePrefs(registry);
-   video_tutorials::RegisterPrefs(registry);
-   feed::prefs::RegisterFeedSharedProfilePrefs(registry);
+@@ -1262,6 +1264,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
+   // register incognito pref
+   registry->RegisterBooleanPref(prefs::kAlwaysIncognitoEnabled,
+                               /*default_value=*/false);
 +  HistoryTabHelper::RegisterProfilePrefs(registry);
    feed::RegisterProfilePrefs(registry);
  #else  // defined(OS_ANDROID)
@@ -1605,23 +1616,38 @@ diff --git a/chrome/browser/ui/android/native_page/BUILD.gn b/chrome/browser/ui/
 diff --git a/chrome/browser/ui/android/native_page/java/src/org/chromium/chrome/browser/ui/native_page/NativePage.java b/chrome/browser/ui/android/native_page/java/src/org/chromium/chrome/browser/ui/native_page/NativePage.java
 --- a/chrome/browser/ui/android/native_page/java/src/org/chromium/chrome/browser/ui/native_page/NativePage.java
 +++ b/chrome/browser/ui/android/native_page/java/src/org/chromium/chrome/browser/ui/native_page/NativePage.java
-@@ -16,6 +16,8 @@ import org.chromium.url.GURL;
- import java.lang.annotation.Retention;
- import java.lang.annotation.RetentionPolicy;
+@@ -120,12 +120,12 @@ public interface NativePage {
+      */
+     @Deprecated // Use GURL-variant instead.
+     public static boolean isNativePageUrl(String url, boolean isIncognito) {
+-        return nativePageType(url, null, isIncognito) != NativePageType.NONE;
++        return nativePageType(url, null, isIncognito, isIncognito) != NativePageType.NONE;
+     }
  
-+import org.chromium.base.ContextUtils;
-+
- /**
-  * An interface for pages that will be using Android views instead of html/rendered Web content.
-  */
-@@ -158,7 +160,9 @@ public interface NativePage {
+     public static boolean isNativePageUrl(GURL url, boolean isIncognito) {
+         return url != null
+-                && nativePageType(url.getSpec(), null, isIncognito) != NativePageType.NONE;
++                && nativePageType(url.getSpec(), null, isIncognito, isIncognito) != NativePageType.NONE;
+     }
+ 
+     /**
+@@ -136,7 +136,8 @@ public interface NativePage {
+      */
+     // TODO(crbug/783819) - Convert to using GURL.
+     public static @NativePageType int nativePageType(
+-            String url, NativePage candidatePage, boolean isIncognito) {
++            String url, NativePage candidatePage, boolean isIncognito,
++            boolean isAlwaysIncognito) {
+         if (url == null) return NativePageType.NONE;
+ 
+         Uri uri = Uri.parse(url);
+@@ -158,7 +159,8 @@ public interface NativePage {
              return NativePageType.DOWNLOADS;
          } else if (UrlConstants.HISTORY_HOST.equals(host)) {
              return NativePageType.HISTORY;
 -        } else if (UrlConstants.RECENT_TABS_HOST.equals(host) && !isIncognito) {
 +        } else if (UrlConstants.RECENT_TABS_HOST.equals(host) &&
-+                  (!isIncognito ||
-+                    ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false))) {
++                  (!isIncognito || isAlwaysIncognito)) {
              return NativePageType.RECENT_TABS;
          } else if (UrlConstants.EXPLORE_HOST.equals(host)) {
              return NativePageType.EXPLORE;
@@ -1639,28 +1665,23 @@ diff --git a/chrome/browser/ui/android/native_page/java/src/org/chromium/chrome/
  /**
   * Tests public methods in NativePage.
   */
-@@ -91,4 +95,26 @@ public class NativePageTest {
+@@ -91,4 +95,21 @@ public class NativePageTest {
              Assert.assertFalse(invalidUrl, NativePage.isNativePageUrl(invalidUrl, true));
          }
      }
 +
 +    @Test
 +    public void Bromite_testNativePage_RecentTabsInAlwaysIncognito() {
-+        SharedPreferences prefs = ContextUtils.getAppSharedPreferences();
-+        SharedPreferences.Editor editor = prefs.edit();
-+
 +        String url = "chrome-native://recent-tabs";
 +
-+        editor.putBoolean(/*AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO*/
-+                          "always_incognito", false);
-+        editor.apply();
++        UserPrefs.get(Profile.getLastUsedRegularProfile()
++            .setBoolean(Pref.ALWAYS_INCOGNITO_ENABLED, false);
 +
 +        Assert.assertEquals(NativePageType.NONE,
 +            NativePage.nativePageType(url, null, /*isIncognito*/true));
 +
-+        editor.putBoolean(/*AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO*/
-+                          "always_incognito", true);
-+        editor.apply();
++        UserPrefs.get(Profile.getLastUsedRegularProfile()
++            .setBoolean(Pref.ALWAYS_INCOGNITO_ENABLED, true);
 +
 +        Assert.assertEquals(NativePageType.RECENT_TABS,
 +            NativePage.nativePageType(url, null, /*isIncognito*/true));
@@ -1685,28 +1706,24 @@ diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chro
 diff --git a/chrome/common/pref_names.cc b/chrome/common/pref_names.cc
 --- a/chrome/common/pref_names.cc
 +++ b/chrome/common/pref_names.cc
-@@ -3276,6 +3276,11 @@ const char kShowCaretBrowsingDialog[] =
- const char kLacrosLaunchSwitch[] = "lacros_launch_switch";
- #endif
- 
-+#if defined(OS_ANDROID)
+@@ -3279,6 +3279,8 @@ const char kLacrosLaunchSwitch[] = "lacros_launch_switch";
+ #if defined(OS_ANDROID)
+ const char kAlwaysIncognitoEnabled[] =
+     "always_incognito_enabled";
 +const char kIncognitoTabHistoryEnabled[] =
 +    "incognito_tab_history_enabled";
-+#endif
-+
+ #endif
+ 
  #if BUILDFLAG(IS_CHROMEOS_ASH)
- // String enum pref determining what should happen when a user who authenticates
- // via a security token is removing this token. "IGNORE" - nothing happens
 diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1201,6 +1201,10 @@ extern const char kLastWhatsNewVersion[];
- extern const char kLensRegionSearchEnabled[];
- #endif
- 
-+#if defined(OS_ANDROID)
+@@ -1204,7 +1204,9 @@ extern const char kLensRegionSearchEnabled[];
+ #if defined(OS_ANDROID)
+ #define ALWAYS_INCOGNITO_ENABLED
+ extern const char kAlwaysIncognitoEnabled[];
 +extern const char kIncognitoTabHistoryEnabled[];
-+#endif
+ #endif
 +
  }  // namespace prefs
  

--- a/build/patches/Enable-share-intent.patch
+++ b/build/patches/Enable-share-intent.patch
@@ -5,6 +5,8 @@ Subject: Enable share intent
 This patch allows to activate the management of android.intent.action.SEND
 with new flag "shared-intent-ui" default active.
 
+Removed incognito if always incognito mode is enabled
+
 See also: https://github.com/bromite/bromite/issues/1062
 ---
  chrome/android/chrome_java_resources.gni      |   1 +
@@ -12,7 +14,7 @@ See also: https://github.com/bromite/bromite/issues/1062
  chrome/android/java/AndroidManifest.xml       |  18 +++
  .../res/layout/sharing_intent_content.xml     |  83 +++++++++++++
  .../init/ProcessInitializationHandler.java    |   3 +
- .../SharedIntentShareActivity.java            | 114 ++++++++++++++++++
+ .../SharedIntentShareActivity.java            | 117 ++++++++++++++++++
  chrome/browser/about_flags.cc                 |   4 +
  chrome/browser/flag_descriptions.cc           |   5 +
  chrome/browser/flag_descriptions.h            |   3 +
@@ -20,7 +22,7 @@ See also: https://github.com/bromite/bromite/issues/1062
  .../flags/android/chrome_feature_list.h       |   1 +
  .../browser/flags/ChromeFeatureList.java      |   1 +
  .../strings/android_chrome_strings.grd        |  13 ++
- 13 files changed, 251 insertions(+)
+ 13 files changed, 254 insertions(+)
  create mode 100644 chrome/android/java/res/layout/sharing_intent_content.xml
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/sharing/shared_intent/SharedIntentShareActivity.java
 
@@ -38,7 +40,7 @@ diff --git a/chrome/android/chrome_java_resources.gni b/chrome/android/chrome_ja
 diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java_sources.gni
 --- a/chrome/android/chrome_java_sources.gni
 +++ b/chrome/android/chrome_java_sources.gni
-@@ -1048,6 +1048,7 @@ chrome_java_sources = [
+@@ -1047,6 +1047,7 @@ chrome_java_sources = [
    "java/src/org/chromium/chrome/browser/sharing/shared_clipboard/SharedClipboardMessageHandler.java",
    "java/src/org/chromium/chrome/browser/sharing/shared_clipboard/SharedClipboardMetrics.java",
    "java/src/org/chromium/chrome/browser/sharing/shared_clipboard/SharedClipboardShareActivity.java",
@@ -186,7 +188,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/sharing/shared_
 new file mode 100644
 --- /dev/null
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/sharing/shared_intent/SharedIntentShareActivity.java
-@@ -0,0 +1,114 @@
+@@ -0,0 +1,117 @@
 +// Copyright 2019 The Chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -292,6 +294,9 @@ new file mode 100644
 +            LaunchIntentDispatcher.dispatch(this, chromeIntent);
 +            finish();
 +        });
++
++        if (ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false))
++            open_url_incognito_button.setVisibility(View.GONE);
 +
 +        onInitialLayoutInflationComplete();
 +    }


### PR DESCRIPTION
this is the most complex, fixes #1496 

I moved the preference from java to native, at the first start it brings the current value, but unfortunately I was not able to completely eliminate the use of SharedPreferences because there are points (when managing intents) where I need the value but the native is not yet initialized.
The native flag was needed for the content settings, which can now be changed.

I changed the incognito history patch in the same way.