### PR TITLE
Update zh_CN translations

### DIFF
--- a/build/patches/Update-i18n-zh_CN-support.patch
+++ b/build/patches/Update-i18n-zh_CN-support.patch
@@ -4,10 +4,10 @@ Subject: Update i18n zh_CN support
 
 ---
  .../resources/generated_resources_zh-CN.xtb   |  4 +-
- .../android_chrome_strings_zh-CN.xtb          | 43 ++++++++++++++++++-
- .../translations/browser_ui_strings_zh-CN.xtb | 17 +++++++-
- .../strings/components_strings_zh-CN.xtb      | 27 +++++++++++-
- 4 files changed, 87 insertions(+), 4 deletions(-)
+ .../android_chrome_strings_zh-CN.xtb          | 45 ++++++++++++++++++-
+ .../translations/browser_ui_strings_zh-CN.xtb | 17 ++++++-
+ .../strings/components_strings_zh-CN.xtb      | 27 ++++++++++-
+ 4 files changed, 89 insertions(+), 4 deletions(-)
 
 diff --git a/chrome/app/resources/generated_resources_zh-CN.xtb b/chrome/app/resources/generated_resources_zh-CN.xtb
 --- a/chrome/app/resources/generated_resources_zh-CN.xtb
@@ -24,7 +24,7 @@ diff --git a/chrome/app/resources/generated_resources_zh-CN.xtb b/chrome/app/res
 diff --git a/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb b/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb
 --- a/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb
 +++ b/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb
-@@ -1410,4 +1410,45 @@ Privacy Sandbox 试用版功能尚处于积极开发阶段，目前只能在部
+@@ -1410,4 +1410,47 @@ Privacy Sandbox 试用版功能尚处于积极开发阶段，目前只能在部
  <translation id="983192555821071799">关闭所有标签页</translation>
  <translation id="987264212798334818">常规</translation>
  <translation id="996149300115483134">动态卡片上的菜单已关闭</translation>
@@ -71,6 +71,8 @@ diff --git a/chrome/browser/ui/android/strings/translations/android_chrome_strin
 +<translation id="1097929346031108539">应用到新标签页</translation>
 +<translation id="5470135790064156005">启用无障碍服务</translation>
 +<translation id="8720137923785348165">激活或停用所有用户活动与无障碍服务之间的连接</translation>
++<translation id="8756661901992439764">允许检查更新</translation>
++<translation id="5950187951766574814">定期检查更新以提示新版本</translation>
 +</translationbundle>
 diff --git a/components/browser_ui/strings/android/translations/browser_ui_strings_zh-CN.xtb b/components/browser_ui/strings/android/translations/browser_ui_strings_zh-CN.xtb
 --- a/components/browser_ui/strings/android/translations/browser_ui_strings_zh-CN.xtb

--- a/build/patches/Update-i18n-zh_CN-support.patch
+++ b/build/patches/Update-i18n-zh_CN-support.patch
@@ -3,11 +3,11 @@ Date: Sun, 2 Aug 2020 00:37:49 +0800
 Subject: Update i18n zh_CN support
 
 ---
- .../resources/generated_resources_zh-CN.xtb   |  4 ++-
- .../android_chrome_strings_zh-CN.xtb          | 35 ++++++++++++++++++-
- .../translations/browser_ui_strings_zh-CN.xtb | 15 +++++++-
- .../strings/components_strings_zh-CN.xtb      |  5 ++-
- 4 files changed, 55 insertions(+), 4 deletions(-)
+ .../resources/generated_resources_zh-CN.xtb   |  4 +-
+ .../android_chrome_strings_zh-CN.xtb          | 43 ++++++++++++++++++-
+ .../translations/browser_ui_strings_zh-CN.xtb | 17 +++++++-
+ .../strings/components_strings_zh-CN.xtb      | 27 +++++++++++-
+ 4 files changed, 87 insertions(+), 4 deletions(-)
 
 diff --git a/chrome/app/resources/generated_resources_zh-CN.xtb b/chrome/app/resources/generated_resources_zh-CN.xtb
 --- a/chrome/app/resources/generated_resources_zh-CN.xtb
@@ -24,7 +24,7 @@ diff --git a/chrome/app/resources/generated_resources_zh-CN.xtb b/chrome/app/res
 diff --git a/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb b/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb
 --- a/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb
 +++ b/chrome/browser/ui/android/strings/translations/android_chrome_strings_zh-CN.xtb
-@@ -1410,4 +1410,37 @@ Privacy Sandbox 试用版功能尚处于积极开发阶段，目前只能在部
+@@ -1410,4 +1410,45 @@ Privacy Sandbox 试用版功能尚处于积极开发阶段，目前只能在部
  <translation id="983192555821071799">关闭所有标签页</translation>
  <translation id="987264212798334818">常规</translation>
  <translation id="996149300115483134">动态卡片上的菜单已关闭</translation>
@@ -45,7 +45,7 @@ diff --git a/chrome/browser/ui/android/strings/translations/android_chrome_strin
 +<translation id="560430187119032030">桌面版网站</translation>
 +<translation id="5926902521522105785">启用 Viewport 元标签解析</translation>
 +<translation id="7889537574758531583">无痕式标签页启用历史记录</translation>
-+<translation id="5713583121562162330">无痕模式下仍保存历史记录</translation>
++<translation id="5713583121562162330">无痕模式仍保存历史记录</translation>
 +<translation id="5078638979202084724">为所有标签页添加书签</translation>
 +<translation id="2664074085387024071">始终在无痕式标签页打开链接</translation>
 +<translation id="2299991736030477757">当您点击新标签页或链接时，在无痕式标签页打开链接</translation>
@@ -58,16 +58,24 @@ diff --git a/chrome/browser/ui/android/strings/translations/android_chrome_strin
 +<translation id="9148058034647219655">退出</translation>
 +<translation id="8082300724182262861">允许自定义标签页意图</translation>
 +<translation id="3872079764041807613">允许应用打开自定义标签页意图，类似 WebView</translation>
++<translation id="2791404607207277079">无痕模式打开外部链接</translation>
++<translation id="301512112618062870">强制所有外部链接在无痕模式打开</translation>
++<translation id="3142455651440468550">其它服务</translation>
 +<translation id="5334844597069022743">查看源代码</translation>
 +<translation id="6199737228675124545">以平板模式打开 Bromite</translation>
 +<translation id="8538054130673254553">强制使用平板模式</translation>
 +<translation id="8275038454117074363">导入</translation>
 +<translation id="42126664696688958">导出</translation>
++<translation id="2044573217492678822">启用系统自动补全</translation>
++<translation id="8214645082903074334">无痕模式启用系统自动补全</translation>
++<translation id="1097929346031108539">应用到新标签页</translation>
++<translation id="5470135790064156005">启用无障碍服务</translation>
++<translation id="8720137923785348165">激活或停用所有用户活动与无障碍服务之间的连接</translation>
 +</translationbundle>
 diff --git a/components/browser_ui/strings/android/translations/browser_ui_strings_zh-CN.xtb b/components/browser_ui/strings/android/translations/browser_ui_strings_zh-CN.xtb
 --- a/components/browser_ui/strings/android/translations/browser_ui_strings_zh-CN.xtb
 +++ b/components/browser_ui/strings/android/translations/browser_ui_strings_zh-CN.xtb
-@@ -330,4 +330,17 @@
+@@ -330,4 +330,19 @@
  <translation id="9162462602695099906">这是一个危险网页</translation>
  <translation id="930525582205581608">移除此网站？</translation>
  <translation id="967624055006145463">已存储的数据</translation>
@@ -86,11 +94,13 @@ diff --git a/components/browser_ui/strings/android/translations/browser_ui_strin
 +<translation id="6417992177946378347">随机（每个页面）</translation>
 +<translation id="7031009175502351997">选择时区...</translation>
 +<translation id="7755920346053173182">选择时区</translation>
++<translation id="9219103736887031265">图片</translation>
++<translation id="7232255641409319872">允许特定网站显示图片</translation>
 +</translationbundle>
 diff --git a/components/strings/components_strings_zh-CN.xtb b/components/strings/components_strings_zh-CN.xtb
 --- a/components/strings/components_strings_zh-CN.xtb
 +++ b/components/strings/components_strings_zh-CN.xtb
-@@ -2509,4 +2509,7 @@
+@@ -2509,4 +2509,29 @@
      &lt;/ul&gt;</translation>
  <translation id="994346157028146140">JIS B1</translation>
  <translation id="997986563973421916">来自 Google Pay</translation>
@@ -99,6 +109,28 @@ diff --git a/components/strings/components_strings_zh-CN.xtb b/components/string
 +<translation id="410351446219883937">自动播放</translation>
 +<translation id="4554660614737153151">标签页收藏</translation>
 +<translation id="9025994914956303635">标签页收藏</translation>
++<translation id="3743203980988005072">未保存</translation>
++<translation id="2882401588417060602">未保存，或已忽略</translation>
++<translation id="1120902422582551571">已保存</translation>
++<translation id="2631006050119455616">已保存</translation>
++<translation id="8719254670702170418">已保存的崩溃报告文件：</translation>
++<translation id="2471417644829303302">保存时间：</translation>
++<translation id="5582222851885298063">开始保存崩溃数据</translation>
++<translation id="1069722914611137577">立即保存</translation>
++<translation id="119944043368869598">清空</translation>
++<translation id="3750232884974956046">生成报告</translation>
++<translation id="8677659652102671482">用户脚本</translation>
++<translation id="5387227673092839387">激活用户脚本</translation>
++<translation id="1181384281493298884">启用</translation>
++<translation id="600555505907290313">关闭</translation>
++<translation id="5679989071017888358">添加脚本</translation>
++<translation id="3421511728817915523">实验性支持 Greasemonkey 类型的用户脚本</translation>
++<translation id="3324175644148454298">文件：</translation>
++<translation id="3163871304881977747">网址：</translation>
++<translation id="5334844597069022743">查看源代码</translation>
++<translation id="2942674521516286270">建议只安装已验证安全的用户脚本，攻击者可能会利用脚本窃取您的证书和个人信息。
++
++要安装 <ph name="FILE" /> 吗？</translation>
 +</translationbundle>
 -- 
 2.20.1


### PR DESCRIPTION
Changes:
- update translations for `Add-custom-tab-intents-privacy-option.patch`
- add translations for
  - Move-some-account-settings-back-to-privacy-settings.patch
  - Enable-native-Android-autofill.patch
  - Add-option-to-use-home-page-as-NTP.patch
  - Disable-Accessibility-service-by-default.patch
  - Site-setting-for-images.patch
  - Logcat-crash-reports-UI.patch
  - Experimental-user-scripts-support.patch
 
Update: add translations for `Bromite-auto-updater.patch`
