### PR TITLE
Enable trivial auto var init

### DIFF
--- a/build/bromite_patches_list.txt
+++ b/build/bromite_patches_list.txt
@@ -5,6 +5,8 @@ exit-on-failure-of-inclusion.patch
 AV1-codec-support.patch
 Switch-to-fstack-protector-strong.patch
 Enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+enable-ftrivial-auto-var-init-zero.patch
+disable-broken-warning-for-auto-var-init.patch
 Bromite-package-name.patch
 Restore-classic-new-tab-page.patch
 Always-use-new-tab-page-for-default-home-page.patch

--- a/build/chromium_patches_list.txt
+++ b/build/chromium_patches_list.txt
@@ -5,5 +5,7 @@ do-not-hide-.orig-files.patch
 do-not-add-suffix-to-package-name.patch
 Switch-to-fstack-protector-strong.patch
 Enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+enable-ftrivial-auto-var-init-zero.patch
+disable-broken-warning-for-auto-var-init.patch
 Disable-feeds-support-by-default.patch
 Chromium-package-name.patch

--- a/build/patches/disable-broken-warning-for-auto-var-init.patch
+++ b/build/patches/disable-broken-warning-for-auto-var-init.patch
@@ -1,0 +1,21 @@
+From cfd733c6c50dfcd20d1bd359e2ca1dc4da039a4b Mon Sep 17 00:00:00 2001
+From: Daniel Micay <danielmicay@gmail.com>
+Date: Thu, 21 May 2020 14:07:54 -0400
+Subject: [PATCH] disable broken warning for auto var init
+
+---
+ build/config/compiler/BUILD.gn | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -355,7 +355,7 @@ config("compiler") {
+     }
+ 
+     if (is_clang) {
+-      cflags += [ "-ftrivial-auto-var-init=zero", "-enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang" ]
++      cflags += [ "-ftrivial-auto-var-init=zero", "-enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang", "-Wno-unused-command-line-argument" ]
+     }
+ 
+     # Linker warnings.

--- a/build/patches/enable-ftrivial-auto-var-init-zero.patch
+++ b/build/patches/enable-ftrivial-auto-var-init-zero.patch
@@ -1,0 +1,23 @@
+From e7eb1a78a4795ac2ece3c96a051b003be8b2cb71 Mon Sep 17 00:00:00 2001
+From: Daniel Micay <danielmicay@gmail.com>
+Date: Wed, 8 Apr 2020 20:48:17 -0400
+Subject: [PATCH] enable -ftrivial-auto-var-init=zero
+
+---
+ build/config/compiler/BUILD.gn | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -354,6 +354,10 @@ config("compiler") {
+       cflags += [ "-fwrapv" ]
+     }
+ 
++    if (is_clang) {
++      cflags += [ "-ftrivial-auto-var-init=zero", "-enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang" ]
++    }
++
+     # Linker warnings.
+     if (fatal_linker_warnings && !is_apple && current_os != "aix" &&
+         current_os != "zos") {


### PR DESCRIPTION
Build with '-ftrivial-auto-var-init=zero' ~~and enable 'Strict Origin Isolation' by default~~.

Fix for #1749