### PR TITLE
Minor changes to v98 patches

### DIFF
--- a/build/patches/Add-a-proxy-configuration-page.patch
+++ b/build/patches/Add-a-proxy-configuration-page.patch
@@ -70,7 +70,7 @@ diff --git a/chrome/android/java/res/xml/privacy_preferences.xml b/chrome/androi
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
-@@ -52,6 +52,7 @@ import org.chromium.ui.text.SpanApplier;
+@@ -53,6 +53,7 @@ import org.chromium.ui.text.SpanApplier;
  public class PrivacySettings
          extends PreferenceFragmentCompat implements Preference.OnPreferenceChangeListener,
                                                      INeedSnackbarManager {
@@ -153,14 +153,14 @@ diff --git a/chrome/browser/net/proxy_service_factory.cc b/chrome/browser/net/pr
 diff --git a/chrome/browser/net/proxy_service_factory.h b/chrome/browser/net/proxy_service_factory.h
 --- a/chrome/browser/net/proxy_service_factory.h
 +++ b/chrome/browser/net/proxy_service_factory.h
-@@ -8,6 +8,7 @@
+@@ -6,6 +6,7 @@
+ #define CHROME_BROWSER_NET_PROXY_SERVICE_FACTORY_H_
+ 
  #include <memory>
++#include "components/prefs/pref_registry_simple.h"
  
  class PrefProxyConfigTracker;
-+#include "components/prefs/pref_registry_simple.h"
  class PrefService;
- class Profile;
- 
 @@ -35,6 +36,8 @@ class ProxyServiceFactory {
    CreatePrefProxyConfigTrackerOfProfile(PrefService* profile_prefs,
                                          PrefService* local_state_prefs);

--- a/build/patches/Add-bookmark-import-export-actions.patch
+++ b/build/patches/Add-bookmark-import-export-actions.patch
@@ -14,14 +14,14 @@ Completely remove contacts picker permission from the file dialog
  .../browser/TabbedModeTabDelegateFactory.java |   5 +-
  .../browser/bookmarks/BookmarkActionBar.java  |  12 +
  .../browser/bookmarks/BookmarkActivity.java   |  30 ++
- .../browser/bookmarks/BookmarkBridge.java     | 279 +++++++++++++++++
+ .../browser/bookmarks/BookmarkBridge.java     | 278 +++++++++++++++++
  .../browser/bookmarks/BookmarkDelegate.java   |  10 +
  .../browser/bookmarks/BookmarkManager.java    |  22 ++
  .../browser/bookmarks/BookmarkPage.java       |   8 +-
  .../native_page/NativePageFactory.java        |  11 +-
  chrome/browser/BUILD.gn                       |  11 +-
  chrome/browser/about_flags.cc                 |   6 +
- .../android/bookmarks/bookmark_bridge.cc      | 284 ++++++++++++++++++
+ .../android/bookmarks/bookmark_bridge.cc      | 283 ++++++++++++++++++
  .../android/bookmarks/bookmark_bridge.h       |  30 +-
  .../browser/bookmarks/bookmark_html_writer.cc |   8 +-
  .../dialogs/DownloadLocationCustomView.java   |   8 +-
@@ -44,7 +44,7 @@ Completely remove contacts picker permission from the file dialog
  ui/shell_dialogs/select_file_dialog.h         |   2 +
  .../select_file_dialog_android.cc             |   6 +
  ui/shell_dialogs/select_file_dialog_android.h |   2 +
- 38 files changed, 894 insertions(+), 29 deletions(-)
+ 38 files changed, 892 insertions(+), 29 deletions(-)
 
 diff --git a/base/android/content_uri_utils.cc b/base/android/content_uri_utils.cc
 --- a/base/android/content_uri_utils.cc
@@ -330,7 +330,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
  import android.text.TextUtils;
  import android.util.Pair;
  
-@@ -45,6 +58,33 @@ import java.util.HashMap;
+@@ -45,6 +58,32 @@ import java.util.HashMap;
  import java.util.HashSet;
  import java.util.List;
  
@@ -360,11 +360,10 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
 +
 +import java.io.File;
 +
-+
  /**
   * Provides the communication channel for Android to fetch and manipulate the
   * bookmark model stored in native.
-@@ -733,6 +773,209 @@ public class BookmarkBridge {
+@@ -733,6 +772,209 @@ public class BookmarkBridge {
                  mNativeBookmarkBridge, BookmarkBridge.this, id.getId(), id.getType());
      }
  
@@ -574,7 +573,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
      /**
       * Synchronously gets a list of bookmarks that match the specified search query.
       * @param query Keyword used for searching bookmarks.
-@@ -1301,6 +1544,39 @@ public class BookmarkBridge {
+@@ -1301,6 +1543,39 @@ public class BookmarkBridge {
          depthList.add(depth);
      }
  
@@ -614,7 +613,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
      private static List<Pair<Integer, Integer>> createPairsList(int[] left, int[] right) {
          List<Pair<Integer, Integer>> pairList = new ArrayList<Pair<Integer, Integer>>();
          for (int i = 0; i < left.length; i++) {
-@@ -1371,6 +1647,9 @@ public class BookmarkBridge {
+@@ -1371,6 +1646,9 @@ public class BookmarkBridge {
          int getChildCount(long nativeBookmarkBridge, BookmarkBridge caller, long id, int type);
          void getChildIDs(long nativeBookmarkBridge, BookmarkBridge caller, long id, int type,
                  List<BookmarkId> bookmarksList);
@@ -863,7 +862,7 @@ diff --git a/chrome/browser/android/bookmarks/bookmark_bridge.cc b/chrome/browse
  using base::android::AttachCurrentThread;
  using base::android::ConvertUTF8ToJavaString;
  using base::android::ConvertUTF16ToJavaString;
-@@ -72,8 +91,93 @@ using bookmarks::BookmarkNode;
+@@ -72,8 +91,92 @@ using bookmarks::BookmarkNode;
  using bookmarks::BookmarkType;
  using content::BrowserThread;
  
@@ -953,11 +952,10 @@ diff --git a/chrome/browser/android/bookmarks/bookmark_bridge.cc b/chrome/browse
 +  const std::string export_path_;
 +};
 +
-+
  class BookmarkTitleComparer {
   public:
    explicit BookmarkTitleComparer(BookmarkBridge* bookmark_bridge,
-@@ -160,6 +264,10 @@ BookmarkBridge::~BookmarkBridge() {
+@@ -160,6 +263,10 @@ BookmarkBridge::~BookmarkBridge() {
    if (partner_bookmarks_shim_)
      partner_bookmarks_shim_->RemoveObserver(this);
    reading_list_manager_->RemoveObserver(this);
@@ -968,7 +966,7 @@ diff --git a/chrome/browser/android/bookmarks/bookmark_bridge.cc b/chrome/browse
  }
  
  void BookmarkBridge::Destroy(JNIEnv*, const JavaParamRef<jobject>&) {
-@@ -577,6 +685,182 @@ jint BookmarkBridge::GetTotalBookmarkCount(
+@@ -577,6 +684,182 @@ jint BookmarkBridge::GetTotalBookmarkCount(
    return count;
  }
  

--- a/build/patches/Add-menu-item-to-bookmark-all-tabs.patch
+++ b/build/patches/Add-menu-item-to-bookmark-all-tabs.patch
@@ -122,7 +122,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
  import org.chromium.components.bookmarks.BookmarkId;
  import org.chromium.components.bookmarks.BookmarkType;
  import org.chromium.components.commerce.PriceTracking.ProductPrice;
-@@ -90,6 +95,7 @@ import java.io.File;
+@@ -89,6 +94,7 @@ import java.io.File;
   * bookmark model stored in native.
   */
  public class BookmarkBridge {
@@ -130,7 +130,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
      private final Profile mProfile;
      private boolean mIsDestroyed;
      private boolean mIsDoingExtensiveChanges;
-@@ -630,6 +636,16 @@ public class BookmarkBridge {
+@@ -629,6 +635,16 @@ public class BookmarkBridge {
                  mNativeBookmarkBridge, BookmarkBridge.this);
      }
  
@@ -147,7 +147,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
      /**
       * @return Id representing the special "other" folder from bookmark model.
       */
-@@ -1341,6 +1357,49 @@ public class BookmarkBridge {
+@@ -1340,6 +1356,49 @@ public class BookmarkBridge {
                  mNativeBookmarkBridge, BookmarkBridge.this, title, url);
      }
  
@@ -197,7 +197,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
      /**
       * @param url The URL of the reading list item.
       * @return The reading list item with the URL, or null if no such reading list item.
-@@ -1638,6 +1697,7 @@ public class BookmarkBridge {
+@@ -1637,6 +1696,7 @@ public class BookmarkBridge {
          void getAllFoldersWithDepths(long nativeBookmarkBridge, BookmarkBridge caller,
                  List<BookmarkId> folderList, List<Integer> depthList);
          BookmarkId getRootFolderId(long nativeBookmarkBridge, BookmarkBridge caller);
@@ -229,7 +229,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
 diff --git a/chrome/browser/android/bookmarks/bookmark_bridge.cc b/chrome/browser/android/bookmarks/bookmark_bridge.cc
 --- a/chrome/browser/android/bookmarks/bookmark_bridge.cc
 +++ b/chrome/browser/android/bookmarks/bookmark_bridge.cc
-@@ -435,6 +435,11 @@ void BookmarkBridge::GetTopLevelFolderIDs(
+@@ -434,6 +434,11 @@ void BookmarkBridge::GetTopLevelFolderIDs(
          top_level_folders.push_back(node.get());
      }
  
@@ -241,7 +241,7 @@ diff --git a/chrome/browser/android/bookmarks/bookmark_bridge.cc b/chrome/browse
      for (const auto& node : bookmark_model_->bookmark_bar_node()->children()) {
        if (node->is_folder())
          top_level_folders.push_back(node.get());
-@@ -483,6 +488,7 @@ void BookmarkBridge::GetAllFoldersWithDepths(
+@@ -482,6 +487,7 @@ void BookmarkBridge::GetAllFoldersWithDepths(
    // Vector to temporarily contain all child bookmarks at same level for sorting
    std::vector<const BookmarkNode*> bookmarks = {
        bookmark_model_->mobile_node(),
@@ -249,7 +249,7 @@ diff --git a/chrome/browser/android/bookmarks/bookmark_bridge.cc b/chrome/browse
        bookmark_model_->bookmark_bar_node(),
        bookmark_model_->other_node(),
    };
-@@ -537,6 +543,17 @@ ScopedJavaLocalRef<jobject> BookmarkBridge::GetMobileFolderId(
+@@ -536,6 +542,17 @@ ScopedJavaLocalRef<jobject> BookmarkBridge::GetMobileFolderId(
    return folder_id_obj;
  }
  
@@ -606,7 +606,7 @@ diff --git a/components/bookmarks/browser/bookmark_model.h b/components/bookmark
    raw_ptr<BookmarkPermanentNode> bookmark_bar_node_ = nullptr;
    raw_ptr<BookmarkPermanentNode> other_node_ = nullptr;
    raw_ptr<BookmarkPermanentNode> mobile_node_ = nullptr;
-+  BookmarkPermanentNode* tabs_collection_node_ = nullptr;
++  raw_ptr<BookmarkPermanentNode> tabs_collection_node_ = nullptr;
  
    // The maximum ID assigned to the bookmark nodes in the model.
    int64_t next_node_id_ = 1;

--- a/build/patches/Bromite-AdBlockUpdaterService.patch
+++ b/build/patches/Bromite-AdBlockUpdaterService.patch
@@ -24,7 +24,7 @@ Fix RestoreForeignSessionTab by recreating the tab (issue #681)
  chrome/browser/browser_process.h              |   6 +
  chrome/browser/browser_process_impl.cc        |  20 ++
  chrome/browser/browser_process_impl.h         |   2 +
- chrome/browser/chrome_browser_main.cc         |   2 +
+ chrome/browser/chrome_browser_main.cc         |   3 +
  .../flags/android/cached_feature_flags.cc     |  11 +
  .../browser/flags/CachedFeatureFlags.java     |  10 +
  .../net/system_network_context_manager.cc     |   4 +
@@ -45,7 +45,7 @@ Fix RestoreForeignSessionTab by recreating the tab (issue #681)
  .../browser/subresource_filter_features.cc    | 113 +-------
  .../core/common/indexed_ruleset.cc            |   5 +-
  .../navigation_throttle_runner.cc             |   5 -
- 36 files changed, 1157 insertions(+), 124 deletions(-)
+ 36 files changed, 1158 insertions(+), 124 deletions(-)
  create mode 100644 chrome/android/java/res/layout/adblock_editor.xml
  create mode 100644 chrome/android/java/res/xml/adblock_preferences.xml
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/settings/AdBlockEditor.java
@@ -542,15 +542,16 @@ diff --git a/chrome/browser/browser_process_impl.h b/chrome/browser/browser_proc
 diff --git a/chrome/browser/chrome_browser_main.cc b/chrome/browser/chrome_browser_main.cc
 --- a/chrome/browser/chrome_browser_main.cc
 +++ b/chrome/browser/chrome_browser_main.cc
-@@ -1714,6 +1714,8 @@ int ChromeBrowserMainParts::PreMainMessageLoopRunImpl() {
-     browser_process_->StartAutoupdateTimer();
- #endif  // defined(OS_WIN) || (defined(OS_LINUX) ||
-         // BUILDFLAG(IS_CHROMEOS_LACROS))
-+    // force AdBlock updater initialisation
-+    g_browser_process->adblock_updater();
+@@ -1681,6 +1681,9 @@ int ChromeBrowserMainParts::PreMainMessageLoopRunImpl() {
+   // will be initialized when the app enters foreground mode.
+   variations_service->set_policy_pref_service(profile_->GetPrefs());
  
- // TODO(crbug.com/1052397): Revisit the macro expression once build flag switch
- // of lacros-chrome is complete.
++  // force AdBlock updater initialisation
++  g_browser_process->adblock_updater();
++
+ #else
+   // We are in regular browser boot sequence. Open initial tabs and enter the
+   // main message loop.
 diff --git a/chrome/browser/flags/android/cached_feature_flags.cc b/chrome/browser/flags/android/cached_feature_flags.cc
 --- a/chrome/browser/flags/android/cached_feature_flags.cc
 +++ b/chrome/browser/flags/android/cached_feature_flags.cc

--- a/build/patches/Disable-privacy-sandbox.patch
+++ b/build/patches/Disable-privacy-sandbox.patch
@@ -26,7 +26,7 @@ diff --git a/chrome/android/java/res/xml/privacy_preferences.xml b/chrome/androi
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
-@@ -72,7 +72,6 @@ public class PrivacySettings
+@@ -74,7 +74,6 @@ public class PrivacySettings
      private static final String PREF_SECURE_DNS = "secure_dns";
      private static final String PREF_DO_NOT_TRACK = "do_not_track";
      private static final String PREF_CLEAR_BROWSING_DATA = "clear_browsing_data";
@@ -34,7 +34,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
      private static final String PREF_PRIVACY_REVIEW = "privacy_review";
      private static final String PREF_INCOGNITO_LOCK = "incognito_lock";
  
-@@ -104,18 +103,6 @@ public class PrivacySettings
+@@ -106,18 +105,6 @@ public class PrivacySettings
          SettingsUtils.addPreferencesFromResource(this, R.xml.privacy_preferences);
          getActivity().setTitle(R.string.prefs_privacy_security);
  
@@ -53,24 +53,19 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
          Preference privacyReviewPreference = findPreference(PREF_PRIVACY_REVIEW);
          if (!ChromeFeatureList.isEnabled(ChromeFeatureList.PRIVACY_REVIEW)) {
              getPreferenceScreen().removePreference(privacyReviewPreference);
-@@ -296,17 +283,11 @@ public class PrivacySettings
-             secureDnsPref.setSummary(SecureDnsSettings.getSummary(getContext()));
-         }
- 
--        Preference privacySandboxPreference = findPreference(PREF_PRIVACY_SANDBOX);
--        if (privacySandboxPreference != null) {
-         ChromeSwitchPreference forceNoJit =
-                 (ChromeSwitchPreference) findPreference(PREF_FORCE_NO_JIT);
+@@ -312,12 +299,6 @@ public class PrivacySettings
          forceNoJit.setOnPreferenceChangeListener(this);
          forceNoJit.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
  
+-        Preference privacySandboxPreference = findPreference(PREF_PRIVACY_SANDBOX);
+-        if (privacySandboxPreference != null) {
 -            privacySandboxPreference.setSummary(
 -                    PrivacySandboxSettingsFragment.getStatusString(getContext()));
 -        }
 -
-         ChromeSwitchPreference historyInIncognitoPref =
-                 (ChromeSwitchPreference) findPreference(PREF_INCOGNITO_TAB_HISTORY_ENABLED);
-         if (historyInIncognitoPref != null) {
+         mIncognitoLockSettings.updateIncognitoReauthPreferenceIfNeeded(getActivity());
+     }
+ 
 diff --git a/chrome/browser/privacy_sandbox/privacy_sandbox_settings.cc b/chrome/browser/privacy_sandbox/privacy_sandbox_settings.cc
 --- a/chrome/browser/privacy_sandbox/privacy_sandbox_settings.cc
 +++ b/chrome/browser/privacy_sandbox/privacy_sandbox_settings.cc

--- a/build/patches/JIT-less-toggle.patch
+++ b/build/patches/JIT-less-toggle.patch
@@ -36,7 +36,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
  import android.os.Build;
  import android.content.SharedPreferences;
  import android.os.Bundle;
-@@ -82,6 +83,7 @@ public class PrivacySettings
+@@ -84,6 +85,7 @@ public class PrivacySettings
      private static final String PREF_SEARCH_SUGGESTIONS = "search_suggestions";
      private static final String PREF_CONTEXTUAL_SEARCH = "contextual_search";
      public static final String PREF_AUTOFILL_ASSISTANT = "autofill_assistant";
@@ -44,7 +44,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
      private ChromeSwitchPreference mSearchSuggestions;
      private @Nullable ChromeSwitchPreference mAutofillAssistant;
      private @Nullable Preference mContextualSearch;
-@@ -214,6 +216,10 @@ public class PrivacySettings
+@@ -220,6 +222,10 @@ public class PrivacySettings
          } else if (PREF_SEARCH_SUGGESTIONS.equals(key)) {
              UserPrefs.get(Profile.getLastUsedRegularProfile())
                      .setBoolean(Pref.SEARCH_SUGGEST_ENABLED, (boolean) newValue);
@@ -55,18 +55,18 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
          } else if (PREF_AUTOFILL_ASSISTANT.equals(key)) {
              mSharedPreferencesManager.writeBoolean(
                   ChromePreferenceKeys.AUTOFILL_ASSISTANT_ENABLED, (boolean) newValue);
-@@ -268,6 +274,11 @@ public class PrivacySettings
+@@ -277,6 +283,11 @@ public class PrivacySettings
+             secureDnsPref.setSummary(SecureDnsSettings.getSummary(getContext()));
+         }
  
-         Preference privacySandboxPreference = findPreference(PREF_PRIVACY_SANDBOX);
-         if (privacySandboxPreference != null) {
 +        ChromeSwitchPreference forceNoJit =
 +                (ChromeSwitchPreference) findPreference(PREF_FORCE_NO_JIT);
 +        forceNoJit.setOnPreferenceChangeListener(this);
 +        forceNoJit.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
 +
+         Preference privacySandboxPreference = findPreference(PREF_PRIVACY_SANDBOX);
+         if (privacySandboxPreference != null) {
              privacySandboxPreference.setSummary(
-                     PrivacySandboxSettingsFragment.getStatusString(getContext()));
-         }
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd

--- a/build/patches/Remove-binary-blob-integrations.patch
+++ b/build/patches/Remove-binary-blob-integrations.patch
@@ -24,6 +24,7 @@ Parts of this patch were developed by csagan5, uazo and others.
  ...em_webview_bundle.AndroidManifest.expected |   5 -
  chrome/android/BUILD.gn                       |  37 --
  chrome/android/chrome_java_sources.gni        |   5 -
+ .../features/cablev2_authenticator/BUILD.gn   |   5 -
  chrome/android/java/AndroidManifest.xml       |  68 ---
  .../org/chromium/chrome/browser/AppHooks.java |  14 +-
  .../browser/PlayServicesVersionInfo.java      |  12 +-
@@ -35,6 +36,7 @@ Parts of this patch were developed by csagan5, uazo and others.
  .../browser/omaha/UpdateStatusProvider.java   |  10 +-
  .../modules/chrome_feature_modules.gni        |   3 -
  chrome/browser/BUILD.gn                       |   2 -
+ .../chromium/chrome/browser/gsa/GSAState.java |   4 +-
  chrome/browser/language/android/BUILD.gn      |   2 -
  .../language/AppLanguagePromoDialog.java      |  23 -
  .../AppLanguagePreferenceDelegate.java        |   8 -
@@ -55,6 +57,7 @@ Parts of this patch were developed by csagan5, uazo and others.
  components/externalauth/android/BUILD.gn      |   3 -
  .../externalauth/ExternalAuthUtils.java       |  18 +-
  .../UserRecoverableErrorHandler.java          |   7 -
+ .../gcm_driver/GoogleCloudMessagingV2.java    |   2 +
  components/gcm_driver/gcm_client_impl.cc      |   4 +
  .../gcm_driver/instance_id/android/BUILD.gn   |   3 -
  .../instance_id/InstanceIDBridge.java         |  47 +-
@@ -94,7 +97,7 @@ Parts of this patch were developed by csagan5, uazo and others.
  third_party/android_deps/BUILD.gn             | 540 +-----------------
  .../preconditions/javatests/BUILD.gn          |   1 -
  .../gms/ChromiumPlayServicesAvailability.java |  10 +-
- 73 files changed, 63 insertions(+), 2300 deletions(-)
+ 76 files changed, 67 insertions(+), 2307 deletions(-)
  delete mode 100644 components/background_task_scheduler/internal/android/java/src/org/chromium/components/background_task_scheduler/internal/BackgroundTaskGcmTaskService.java
  delete mode 100644 components/background_task_scheduler/internal/android/java/src/org/chromium/components/background_task_scheduler/internal/BackgroundTaskSchedulerGcmNetworkManager.java
 
@@ -261,6 +264,21 @@ diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java
    "java/src/org/chromium/chrome/browser/settings/MainSettings.java",
    "java/src/org/chromium/chrome/browser/settings/SettingsActivity.java",
    "java/src/org/chromium/chrome/browser/settings/SettingsLauncherImpl.java",
+diff --git a/chrome/android/features/cablev2_authenticator/BUILD.gn b/chrome/android/features/cablev2_authenticator/BUILD.gn
+--- a/chrome/android/features/cablev2_authenticator/BUILD.gn
++++ b/chrome/android/features/cablev2_authenticator/BUILD.gn
+@@ -16,11 +16,6 @@ android_library("java") {
+   deps = [
+     ":java_resources",
+     ":logging_java",
+-    "$google_play_services_package:google_play_services_base_java",
+-    "$google_play_services_package:google_play_services_fido_java",
+-    "$google_play_services_package:google_play_services_tasks_java",
+-    "$google_play_services_package:google_play_services_vision_common_java",
+-    "$google_play_services_package:google_play_services_vision_java",
+     "//base:base_java",
+     "//chrome/browser/webauthn/android:java_resources",
+     "//content/public/android:content_java",
 diff --git a/chrome/android/java/AndroidManifest.xml b/chrome/android/java/AndroidManifest.xml
 --- a/chrome/android/java/AndroidManifest.xml
 +++ b/chrome/android/java/AndroidManifest.xml
@@ -867,6 +885,27 @@ diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
        "offline_pages/prefetch/offline_metrics_collector_impl.cc",
        "offline_pages/prefetch/offline_metrics_collector_impl.h",
        "offline_pages/prefetch/offline_prefetch_download_client.cc",
+diff --git a/chrome/browser/gsa/java/src/org/chromium/chrome/browser/gsa/GSAState.java b/chrome/browser/gsa/java/src/org/chromium/chrome/browser/gsa/GSAState.java
+--- a/chrome/browser/gsa/java/src/org/chromium/chrome/browser/gsa/GSAState.java
++++ b/chrome/browser/gsa/java/src/org/chromium/chrome/browser/gsa/GSAState.java
+@@ -82,7 +82,7 @@ public class GSAState {
+     /**
+      * Caches the result of a computation on whether GSA is available.
+      */
+-    private Boolean mGsaAvailable;
++    private Boolean mGsaAvailable = false;
+ 
+     /**
+      * The Google account email address being used by GSA according to the latest update we have
+@@ -106,7 +106,7 @@ public class GSAState {
+      * @return Whether the given package name is the package name for Google Search App.
+      */
+     public static boolean isGsaPackageName(String packageName) {
+-        return SEARCH_INTENT_PACKAGE.equals(packageName);
++        return false;
+     }
+ 
+     /* Private constructor, since this is a singleton */
 diff --git a/chrome/browser/language/android/BUILD.gn b/chrome/browser/language/android/BUILD.gn
 --- a/chrome/browser/language/android/BUILD.gn
 +++ b/chrome/browser/language/android/BUILD.gn
@@ -1739,6 +1778,18 @@ diff --git a/components/externalauth/android/java/src/org/chromium/components/ex
              }
              // This can happen if |errorCode| is ConnectionResult.SERVICE_INVALID.
              if (mDialog != null && !mDialog.isShowing()) {
+diff --git a/components/gcm_driver/android/java/src/org/chromium/components/gcm_driver/GoogleCloudMessagingV2.java b/components/gcm_driver/android/java/src/org/chromium/components/gcm_driver/GoogleCloudMessagingV2.java
+--- a/components/gcm_driver/android/java/src/org/chromium/components/gcm_driver/GoogleCloudMessagingV2.java
++++ b/components/gcm_driver/android/java/src/org/chromium/components/gcm_driver/GoogleCloudMessagingV2.java
+@@ -129,6 +129,8 @@ public class GoogleCloudMessagingV2 implements GoogleCloudMessagingSubscriber {
+     }
+ 
+     private Intent registerRpc(Bundle data) throws IOException {
++        if ((true))
++            throw new IOException("Google Play Services missing");
+         if (Looper.getMainLooper() == Looper.myLooper()) {
+             throw new IOException(ERROR_MAIN_THREAD);
+         }
 diff --git a/components/gcm_driver/gcm_client_impl.cc b/components/gcm_driver/gcm_client_impl.cc
 --- a/components/gcm_driver/gcm_client_impl.cc
 +++ b/components/gcm_driver/gcm_client_impl.cc

--- a/build/patches/Remove-signin-and-data-saver-integrations.patch
+++ b/build/patches/Remove-signin-and-data-saver-integrations.patch
@@ -34,7 +34,7 @@ ld.lld: error: undefined symbol: notifier::NotifierOptions::NotifierOptions()
  .../chrome/browser/app/ChromeActivity.java    |  75 --------
  .../AutofillAssistantPreferenceFragment.java  |  12 --
  .../bookmarks/BookmarkItemsAdapter.java       |  47 +----
- .../bookmarks/BookmarkPromoHeader.java        | 182 +-----------------
+ .../bookmarks/BookmarkPromoHeader.java        | 181 +-----------------
  .../ClearBrowsingDataFragmentBasic.java       |   5 +-
  .../contextualsearch/ContextualSearchUma.java |   5 -
  .../browser/customtabs/CustomTabActivity.java |   3 -
@@ -75,7 +75,7 @@ ld.lld: error: undefined symbol: notifier::NotifierOptions::NotifierOptions()
  .../signin/SystemAccountManagerDelegate.java  |  25 +--
  .../net/HttpNegotiateAuthenticator.java       |  88 +--------
  .../chromoting/base/OAuthTokenFetcher.java    |   2 -
- 56 files changed, 53 insertions(+), 1292 deletions(-)
+ 56 files changed, 52 insertions(+), 1292 deletions(-)
 
 diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
 --- a/chrome/android/BUILD.gn
@@ -967,7 +967,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/BookmarkPromoHeader.java b/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/BookmarkPromoHeader.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/BookmarkPromoHeader.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/BookmarkPromoHeader.java
-@@ -18,42 +18,23 @@ import org.chromium.chrome.R;
+@@ -18,42 +18,22 @@ import org.chromium.chrome.R;
  import org.chromium.chrome.browser.preferences.ChromePreferenceKeys;
  import org.chromium.chrome.browser.preferences.SharedPreferencesManager;
  import org.chromium.chrome.browser.profiles.Profile;
@@ -986,7 +986,6 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
 -import org.chromium.components.signin.AccountsChangeObserver;
 -import org.chromium.components.signin.identitymanager.ConsentLevel;
 -import org.chromium.components.signin.metrics.SigninAccessPoint;
-+
  
  /**
   * Class that manages all the logic and UI behind the signin promo header in the bookmark
@@ -1012,7 +1011,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
  
      /**
       * Initializes the class. Note that this will start listening to signin related events and
-@@ -62,42 +43,12 @@ class BookmarkPromoHeader implements SyncService.SyncStateChangedListener, SignI
+@@ -62,42 +42,12 @@ class BookmarkPromoHeader implements SyncService.SyncStateChangedListener, SignI
      BookmarkPromoHeader(Context context, Runnable promoHeaderChangeAction) {
          mContext = context;
          mPromoHeaderChangeAction = promoHeaderChangeAction;
@@ -1055,7 +1054,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
      }
  
      /**
-@@ -108,58 +59,11 @@ class BookmarkPromoHeader implements SyncService.SyncStateChangedListener, SignI
+@@ -108,58 +58,11 @@ class BookmarkPromoHeader implements SyncService.SyncStateChangedListener, SignI
          return mPromoState;
      }
  
@@ -1115,7 +1114,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/bookmarks/Bookm
      }
  
      private @SyncPromoState int calculatePromoState() {
-@@ -167,90 +71,10 @@ class BookmarkPromoHeader implements SyncService.SyncStateChangedListener, SignI
+@@ -167,90 +70,10 @@ class BookmarkPromoHeader implements SyncService.SyncStateChangedListener, SignI
              return sPromoStateForTests;
          }
  


### PR DESCRIPTION
no functionality changed.

small changes:
- elimination of excess blank lines
- moving the position of `g_browser_process->adblock_updater();` in `Bromite AdBlockUpdaterService` 
- fix overlap between `Disable privacy sandbox` and `JIT-less toggle`
- changed to `raw_ptr<BookmarkPermanentNode> tabs_collection_node_ = nullptr`
- removed last `$google_play_services_package` in `Remove binary blob integrations`
 