### PR TITLE
Always incognito: added preference in native

### DIFF
--- a/build/patches/Add-an-always-incognito-mode.patch
+++ b/build/patches/Add-an-always-incognito-mode.patch
@@ -6,28 +6,35 @@ More specifically, add a preference that causes all new tabs and all
 clicked links to launch as incognito.
 Make sure initial incognito status is correctly recognized.
 Enable incognito custom tabs and fix crashes for incognito/custom tab intents (credits to @uazo)
+A flag for native management has been inserted
 ---
  chrome/android/chrome_java_sources.gni        |  1 +
  .../java/res/xml/privacy_preferences.xml      |  5 ++
- .../AlwaysIncognitoLinkInterceptor.java       | 80 +++++++++++++++++++
- .../chrome/browser/ChromeTabbedActivity.java  |  6 +-
- .../chrome/browser/app/ChromeActivity.java    |  4 +
- .../AppMenuPropertiesDelegateImpl.java        |  6 ++
- .../ChromeContextMenuPopulator.java           |  8 +-
- .../CustomTabActivityLifecycleUmaTracker.java | 25 ------
+ .../AlwaysIncognitoLinkInterceptor.java       | 52 +++++++++++++++++++
+ .../chrome/browser/ChromeTabbedActivity.java  |  6 ++-
+ .../chrome/browser/app/ChromeActivity.java    |  4 ++
+ .../AppMenuPropertiesDelegateImpl.java        |  8 +++
+ .../ChromeContextMenuPopulator.java           |  7 ++-
+ .../CustomTabActivityLifecycleUmaTracker.java | 25 ---------
  .../CustomTabIntentDataProvider.java          |  5 +-
- .../browser/init/StartupTabPreloader.java     | 14 +++-
- .../privacy/settings/PrivacySettings.java     | 37 ++++++++-
- .../browser/settings/SettingsActivity.java    |  4 +
- .../tabbed_mode/TabbedRootUiCoordinator.java  |  6 +-
- .../browser/tabmodel/ChromeTabCreator.java    | 16 +++-
- .../browser/tabmodel/TabPersistentStore.java  | 10 +++
- .../webapps/WebappIntentDataProvider.java     | 14 ++++
+ .../browser/init/StartupTabPreloader.java     | 14 +++--
+ .../privacy/settings/PrivacySettings.java     | 39 +++++++++++++-
+ .../browser/settings/SettingsActivity.java    |  4 ++
+ .../tabbed_mode/TabbedRootUiCoordinator.java  |  5 +-
+ .../browser/tabmodel/ChromeTabCreator.java    |  5 +-
+ .../tabmodel/TabModelSelectorImpl.java        |  3 ++
+ .../browser/tabmodel/TabPersistentStore.java  | 10 ++++
+ .../webapps/WebappIntentDataProvider.java     | 14 +++++
+ .../chrome_autocomplete_provider_client.cc    |  3 ++
+ .../host_content_settings_map_factory.cc      | 16 +++++-
  .../flags/android/chrome_feature_list.cc      |  2 +-
- .../strings/android_chrome_strings.grd        | 13 +++
+ chrome/browser/prefs/browser_prefs.cc         |  3 ++
+ .../strings/android_chrome_strings.grd        | 13 +++++
  chrome/browser/ui/messages/android/BUILD.gn   |  1 +
- .../snackbar/INeedSnackbarManager.java        | 27 +++++++
- 20 files changed, 248 insertions(+), 36 deletions(-)
+ .../snackbar/INeedSnackbarManager.java        | 27 ++++++++++
+ chrome/common/pref_names.cc                   |  4 ++
+ chrome/common/pref_names.h                    |  5 ++
+ 26 files changed, 244 insertions(+), 37 deletions(-)
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java
  create mode 100644 chrome/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/INeedSnackbarManager.java
 
@@ -61,7 +68,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognito
 new file mode 100644
 --- /dev/null
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java
-@@ -0,0 +1,80 @@
+@@ -0,0 +1,52 @@
 +/* This Source Code Form is subject to the terms of the Mozilla Public
 + * License, v. 2.0. If a copy of the MPL was not distributed with this
 + * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -69,76 +76,48 @@ new file mode 100644
 +package org.chromium.chrome.browser;
 +
 +import android.content.SharedPreferences;
++import org.chromium.base.ContextUtils;
 +
-+import org.chromium.chrome.browser.tab.EmptyTabObserver;
-+import org.chromium.chrome.browser.tab.Tab;
-+import org.chromium.chrome.browser.tab.TabImpl;
-+import org.chromium.chrome.browser.tabmodel.TabCreatorManager;
-+import org.chromium.chrome.browser.tab.TabLaunchType;
-+import org.chromium.chrome.browser.tabmodel.TabModel;
-+import org.chromium.content_public.browser.LoadUrlParams;
-+import org.chromium.url.GURL;
++import org.chromium.components.user_prefs.UserPrefs;
++import org.chromium.components.prefs.PrefService;
++import org.chromium.chrome.browser.profiles.Profile;
++import org.chromium.chrome.browser.preferences.Pref;
++import org.chromium.base.Log;
 +
-+import java.util.HashMap;
-+import java.util.HashSet;
-+import java.util.Map;
-+import java.util.Set;
++import androidx.annotation.Nullable;
++
 +/**
-+ * A {@link TabObserver} that implements the always-incognito preference behavior for links. When the preference is set
-+ * to true, it intercepts links opened within observed {@link Tab}s and opens them in new incognito <code>Tab</code>s instead.
++ * A {@link TabObserver} that implements the always-incognito preference behavior for links.
 + */
-+public class AlwaysIncognitoLinkInterceptor extends EmptyTabObserver {
++public class AlwaysIncognitoLinkInterceptor {
 +
 +    public static final String PREF_ALWAYS_INCOGNITO = "always_incognito";
 +
-+    private final SharedPreferences alwaysIncognitoContainer;
-+    private final Map<Tab, String> lastUrls;
-+    private final Set<Tab> revertingTabs;
++    private static @Nullable Boolean cachedIsAlwaysIncognito = null;
 +
-+    public AlwaysIncognitoLinkInterceptor(final SharedPreferences alwaysIncognitoContainer) {
-+
-+        assert alwaysIncognitoContainer != null;
-+
-+        this.alwaysIncognitoContainer = alwaysIncognitoContainer;
-+        lastUrls = new HashMap<Tab, String>();
-+        revertingTabs = new HashSet<Tab>();
++    public static boolean isAlwaysIncognito() {
++        if (cachedIsAlwaysIncognito != null) return cachedIsAlwaysIncognito;
++        cachedIsAlwaysIncognito = ContextUtils.getAppSharedPreferences()
++                                    .getBoolean(PREF_ALWAYS_INCOGNITO, false);
++        return cachedIsAlwaysIncognito;
 +    }
 +
-+    @Override
-+    public void onDestroyed(final Tab tab)
-+    {
-+        lastUrls.remove(tab);
-+        revertingTabs.remove(tab);
++    public static void setAlwaysIncognito(boolean enabled) {
++        UserPrefs.get(Profile.getLastUsedRegularProfile())
++            .setBoolean(Pref.ALWAYS_INCOGNITO_ENABLED, enabled);
++
++        SharedPreferences.Editor sharedPreferenceEditor = ContextUtils.getAppSharedPreferences().edit();
++        sharedPreferenceEditor.putBoolean("always_incognito", enabled);
++        sharedPreferenceEditor.apply();
 +    }
 +
-+    @Override
-+    public void onUpdateUrl(Tab tab, GURL gurl) {
-+
-+        if (tab == null) return;
-+        if (gurl == null) return;
-+        if (tab.isIncognito()) return;
-+        if (alwaysIncognitoContainer == null) return;
-+
-+        String spec = gurl.getValidSpecOrEmpty();
-+        if (spec == null) return;
-+
-+        final String lastUrl = lastUrls.put(tab, spec);
-+
-+        if (!alwaysIncognitoContainer.getBoolean(PREF_ALWAYS_INCOGNITO, false)) return;
-+        if (revertingTabs.contains(tab)) {
-+            revertingTabs.remove(tab);
-+            return;
-+        }
-+
-+        ((ChromeTabbedActivity)tab.getWindowAndroid().getActivity().get())
-+            .getTabCreator(true)
-+            .createNewTab(new LoadUrlParams(spec), TabLaunchType.FROM_LINK, tab);
-+
-+        if ((spec.equals(lastUrl)) || (!tab.canGoBack())) {
-+            // this call was triggered by a reload
-+        } else {
-+            revertingTabs.add(tab);
-+            tab.goBack();
++    public static void migrateSettingToNative() {
++        if (isAlwaysIncognito()) {
++            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
++            if(!prefService.getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED)) {
++                Log.i("BROMITE", "Migration: always incognito pref from java to native");
++                prefService.setBoolean(Pref.ALWAYS_INCOGNITO_ENABLED, true);
++            }
 +        }
 +    }
 +}
@@ -159,7 +138,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedAct
          // We determine the model as soon as possible so every systems get initialized coherently.
 -        boolean startIncognito = savedInstanceState != null
 -                && savedInstanceState.getBoolean(IS_INCOGNITO_SELECTED, false);
-+        boolean startIncognito = ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false)
++        boolean startIncognito = AlwaysIncognitoLinkInterceptor.isAlwaysIncognito()
 +                || (savedInstanceState != null
 +                && savedInstanceState.getBoolean(IS_INCOGNITO_SELECTED, false));
  
@@ -180,7 +159,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActiv
              throw new IllegalStateException(
                      "Attempting to access TabCreator before initialization");
          }
-+        if (ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false)) {
++        if (AlwaysIncognitoLinkInterceptor.isAlwaysIncognito()) {
 +            incognito = true;
 +        }
          return mTabCreatorManagerSupplier.get().getTabCreator(incognito);
@@ -189,11 +168,20 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActiv
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
-@@ -524,6 +524,12 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+@@ -34,6 +34,7 @@ import org.chromium.base.supplier.ObservableSupplier;
+ import org.chromium.base.supplier.OneshotSupplier;
+ import org.chromium.chrome.R;
+ import org.chromium.chrome.browser.ActivityTabProvider;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
+ import org.chromium.chrome.browser.banners.AppMenuVerbiage;
+ import org.chromium.chrome.browser.bookmarks.BookmarkBridge;
+ import org.chromium.chrome.browser.bookmarks.BookmarkFeatures;
+@@ -524,6 +525,13 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
      }
  
      private void prepareCommonMenuItems(Menu menu, @MenuGroup int menuGroup, boolean isIncognito) {
-+        if (ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
++        boolean always_incognito = AlwaysIncognitoLinkInterceptor.isAlwaysIncognito();
++        if (always_incognito) {
 +            final MenuItem newTabOption = menu.findItem(R.id.new_tab_menu_id);
 +            if (newTabOption != null)
 +                newTabOption.setVisible(false);
@@ -213,18 +201,17 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/Chr
  import org.chromium.chrome.browser.compositor.bottombar.ephemeraltab.EphemeralTabCoordinator;
  import org.chromium.chrome.browser.contextmenu.ChromeContextMenuItem.Item;
  import org.chromium.chrome.browser.contextmenu.ContextMenuCoordinator.ListItemType;
-@@ -408,6 +409,10 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -408,6 +409,9 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
          boolean hasSaveImage = false;
          mShowEphemeralTabNewLabel = null;
  
 +        boolean always_incognito =
-+            ContextUtils.getAppSharedPreferences().getBoolean(
-+                AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
++            AlwaysIncognitoLinkInterceptor.isAlwaysIncognito();
 +
          List<Pair<Integer, ModelList>> groupedItems = new ArrayList<>();
  
          if (mParams.isAnchor()) {
-@@ -426,6 +431,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -426,6 +430,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
                              linkGroup.add(createListItem(Item.OPEN_IN_NEW_TAB_IN_GROUP));
                          }
                      }
@@ -232,7 +219,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/Chr
                      if (!mItemDelegate.isIncognito() && mItemDelegate.isIncognitoSupported()) {
                          linkGroup.add(createListItem(Item.OPEN_IN_INCOGNITO_TAB));
                      }
-@@ -450,7 +456,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -450,7 +455,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
                  }
              }
              if (FirstRunStatus.getFirstRunFlowComplete()) {
@@ -294,7 +281,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/Cust
      @Override
      public boolean isIncognito() {
 -        return false;
-+        return ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
++        return AlwaysIncognitoLinkInterceptor.isAlwaysIncognito();
      }
  
      @Nullable
@@ -315,7 +302,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTab
          Intent intent = mIntentSupplier.get();
          GURL url = UrlFormatter.fixupUrl(getUrlFromIntent(intent));
  
-+        boolean isIncognito = ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
++        boolean isIncognito = AlwaysIncognitoLinkInterceptor.isAlwaysIncognito();
 +
 +        Profile profile = Profile.getLastUsedRegularProfile();
          ChromeTabCreator chromeTabCreator =
@@ -340,18 +327,19 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/init/StartupTab
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
-@@ -28,6 +28,10 @@ import org.chromium.chrome.browser.privacy_sandbox.PrivacySandboxSettingsFragmen
- import org.chromium.chrome.browser.profiles.Profile;
+@@ -29,6 +29,11 @@ import org.chromium.chrome.browser.profiles.Profile;
  import org.chromium.chrome.browser.settings.ChromeManagedPreferenceDelegate;
  import org.chromium.chrome.browser.settings.SettingsLauncherImpl;
+ import org.chromium.chrome.browser.signin.services.IdentityServicesProvider;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
 +import org.chromium.chrome.browser.ui.messages.snackbar.SnackbarManager;
 +import org.chromium.chrome.browser.ui.messages.snackbar.INeedSnackbarManager;
 +import org.chromium.chrome.browser.ui.messages.snackbar.Snackbar;
 +import org.chromium.chrome.browser.ApplicationLifetime;
- import org.chromium.chrome.browser.signin.services.IdentityServicesProvider;
  import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
  import org.chromium.components.browser_ui.settings.ManagedPreferenceDelegate;
-@@ -43,7 +47,12 @@ import org.chromium.ui.text.SpanApplier;
+ import org.chromium.components.browser_ui.settings.SettingsLauncher;
+@@ -43,7 +48,12 @@ import org.chromium.ui.text.SpanApplier;
   * Fragment to keep track of the all the privacy related preferences.
   */
  public class PrivacySettings
@@ -365,7 +353,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
      private static final String PREF_CAN_MAKE_PAYMENT = "can_make_payment";
      private static final String PREF_PRELOAD_PAGES = "preload_pages";
      private static final String PREF_HTTPS_FIRST_MODE = "https_first_mode";
-@@ -100,6 +109,25 @@ public class PrivacySettings
+@@ -100,6 +110,25 @@ public class PrivacySettings
                  (ChromeSwitchPreference) findPreference(PREF_CAN_MAKE_PAYMENT);
          canMakePaymentPref.setOnPreferenceChangeListener(this);
  
@@ -391,17 +379,18 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
          Preference preloadPagesPreference = findPreference(PREF_PRELOAD_PAGES);
          preloadPagesPreference.setSummary(
                  PreloadPagesSettingsFragment.getPreloadPagesSummaryString(getContext()));
-@@ -128,6 +156,9 @@ public class PrivacySettings
+@@ -125,6 +154,10 @@ public class PrivacySettings
+         if (PREF_CAN_MAKE_PAYMENT.equals(key)) {
+             UserPrefs.get(Profile.getLastUsedRegularProfile())
+                     .setBoolean(Pref.CAN_MAKE_PAYMENT_ENABLED, (boolean) newValue);
++        } else if (PREF_ALWAYS_INCOGNITO.equals(key)) {
++            AlwaysIncognitoLinkInterceptor.setAlwaysIncognito((boolean) newValue);
++            if (!mSnackbarManager.isShowing())
++                mSnackbarManager.showSnackbar(mSnackbar);
          } else if (PREF_HTTPS_FIRST_MODE.equals(key)) {
              UserPrefs.get(Profile.getLastUsedRegularProfile())
                      .setBoolean(Pref.HTTPS_ONLY_MODE_ENABLED, (boolean) newValue);
-+        } else if (PREF_ALWAYS_INCOGNITO.equals(key)) {
-+            if (!mSnackbarManager.isShowing())
-+                mSnackbarManager.showSnackbar(mSnackbar);
-         }
-         return true;
-     }
-@@ -201,4 +232,8 @@ public class PrivacySettings
+@@ -201,4 +234,8 @@ public class PrivacySettings
          }
          return false;
      }
@@ -443,12 +432,11 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/Tab
  
  /**
   * A {@link RootUiCoordinator} variant that controls tabbed-mode specific UI.
-@@ -489,11 +491,13 @@ public class TabbedRootUiCoordinator extends RootUiCoordinator {
+@@ -489,11 +491,12 @@ public class TabbedRootUiCoordinator extends RootUiCoordinator {
  
          // TODO(twellington): Supply TabModelSelector as well and move initialization earlier.
          if (DeviceFormFactor.isNonMultiDisplayContextOnTablet(mActivity)) {
-+            boolean tabModel = ContextUtils.getAppSharedPreferences().getBoolean(
-+                        AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
++            boolean tabModel = AlwaysIncognitoLinkInterceptor.isAlwaysIncognito();
              AppMenuHandler appMenuHandler =
                      mAppMenuCoordinator == null ? null : mAppMenuCoordinator.getAppMenuHandler();
              mEmptyBackgroundViewWrapper = new EmptyBackgroundViewWrapper(
@@ -472,44 +460,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/Chrome
  /**
   * This class creates various kinds of new tabs and adds them to the right {@link TabModel}.
   */
-@@ -74,6 +78,7 @@ public class ChromeTabCreator extends TabCreator {
-     private final Activity mActivity;
-     private final StartupTabPreloader mStartupTabPreloader;
-     private final boolean mIncognito;
-+    private final TabObserver mExtraLogic;
- 
-     private WindowAndroid mNativeWindow;
-     private TabModel mTabModel;
-@@ -96,6 +101,10 @@ public class ChromeTabCreator extends TabCreator {
-         mNativeWindow = nativeWindow;
-         mTabDelegateFactorySupplier = tabDelegateFactory;
-         mIncognito = incognito;
-+        if (!mIncognito)
-+            mExtraLogic = new AlwaysIncognitoLinkInterceptor(ContextUtils.getAppSharedPreferences());
-+        else
-+            mExtraLogic = null;
-         mOverviewNTPCreator = overviewNTPCreator;
-         mAsyncTabParamsManager = asyncTabParamsManager;
-         mTabModelSelectorSupplier = tabModelSelectorSupplier;
-@@ -259,6 +268,8 @@ public class ChromeTabCreator extends TabCreator {
-             if (creationState == TabCreationState.LIVE_IN_FOREGROUND && !openInForeground) {
-                 creationState = TabCreationState.LIVE_IN_BACKGROUND;
-             }
-+            if (mExtraLogic != null)
-+                tab.addObserver(mExtraLogic);
-             mTabModel.addTab(tab, position, type, creationState);
-             return tab;
-         } finally {
-@@ -293,6 +304,8 @@ public class ChromeTabCreator extends TabCreator {
-         @TabCreationState
-         int creationState = openInForeground ? TabCreationState.LIVE_IN_FOREGROUND
-                                              : TabCreationState.LIVE_IN_BACKGROUND;
-+        if (mExtraLogic != null)
-+            tab.addObserver(mExtraLogic);
-         mTabModel.addTab(tab, position, type, creationState);
-         return true;
-     }
-@@ -333,7 +346,6 @@ public class ChromeTabCreator extends TabCreator {
+@@ -333,7 +337,6 @@ public class ChromeTabCreator extends TabCreator {
      // TODO(crbug.com/1081924): Clean up the launches from SearchActivity/Chrome.
      public Tab launchUrlFromExternalApp(
              LoadUrlParams loadUrlParams, String appId, boolean forceNewTab, Intent intent) {
@@ -517,15 +468,26 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/Chrome
          // Don't re-use tabs for intents from Chrome. Note that this can be spoofed so shouldn't be
          // relied on for anything security sensitive.
          boolean isLaunchedFromChrome = TextUtils.equals(appId, mActivity.getPackageName());
-@@ -428,6 +440,8 @@ public class ChromeTabCreator extends TabCreator {
-                           .setSerializedCriticalPersistedTabData(serializedCriticalPersistedTabData)
-                           .build();
-         }
-+        if (mExtraLogic != null)
-+            tab.addObserver(mExtraLogic);
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorImpl.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorImpl.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorImpl.java
+@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
+ import androidx.annotation.VisibleForTesting;
  
-         if (isIncognito != mIncognito) {
-             throw new IllegalStateException("Incognito state mismatch. TabState: "
+ import org.chromium.base.supplier.Supplier;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
+ import org.chromium.chrome.browser.compositor.layouts.content.TabContentManager;
+ import org.chromium.chrome.browser.flags.ActivityType;
+ import org.chromium.chrome.browser.profiles.Profile;
+@@ -107,6 +108,8 @@ public class TabModelSelectorImpl extends TabModelSelectorBase implements TabMod
+     public void onNativeLibraryReady(TabContentManager tabContentProvider) {
+         assert mTabContentManager == null : "onNativeLibraryReady called twice!";
+ 
++        AlwaysIncognitoLinkInterceptor.migrateSettingToNative();
++
+         ChromeTabCreator regularTabCreator =
+                 (ChromeTabCreator) getTabCreatorManager().getTabCreator(false);
+         ChromeTabCreator incognitoTabCreator =
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
@@ -550,7 +512,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPer
                  }
              }
          }
-+        if (ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false)) {
++        if (AlwaysIncognitoLinkInterceptor.isAlwaysIncognito()) {
 +            if (!isIncognito) {
 +                Log.w(TAG, "Failed to restore tab: not in incognito mode.");
 +                return;
@@ -587,7 +549,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappI
          mWebApkExtras = webApkExtras;
          mActivityType = (webApkExtras != null) ? ActivityType.WEB_APK : ActivityType.WEBAPP;
 +
-+        if (ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false)) {
++        if (AlwaysIncognitoLinkInterceptor.isAlwaysIncognito()) {
 +            mIsIncognito = true;
 +        }
      }
@@ -605,6 +567,61 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappI
      @Override
      public @ScreenOrientationLockType.EnumType int getDefaultOrientation() {
          return mWebappExtras.orientation;
+diff --git a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc b/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
+--- a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
++++ b/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
+@@ -305,6 +305,9 @@ signin::IdentityManager* ChromeAutocompleteProviderClient::GetIdentityManager()
+ }
+ 
+ bool ChromeAutocompleteProviderClient::IsOffTheRecord() const {
++  if (profile_->GetPrefs()->GetBoolean(prefs::kAlwaysIncognitoEnabled)) {
++    return false;
++  }
+   return profile_->IsOffTheRecord();
+ }
+ 
+diff --git a/chrome/browser/content_settings/host_content_settings_map_factory.cc b/chrome/browser/content_settings/host_content_settings_map_factory.cc
+--- a/chrome/browser/content_settings/host_content_settings_map_factory.cc
++++ b/chrome/browser/content_settings/host_content_settings_map_factory.cc
+@@ -15,6 +15,7 @@
+ #include "chrome/browser/profiles/profile.h"
+ #include "chrome/browser/search_engines/template_url_service_factory.h"
+ #include "chrome/common/buildflags.h"
++#include "chrome/common/pref_names.h"
+ #include "components/content_settings/core/browser/content_settings_pref_provider.h"
+ #include "components/content_settings/core/browser/host_content_settings_map.h"
+ #include "components/keyed_service/content/browser_context_dependency_manager.h"
+@@ -96,9 +97,19 @@ scoped_refptr<RefcountedKeyedService>
+   if (profile->IsOffTheRecord() && !profile->IsGuestSession())
+     GetForProfile(original_profile);
+ 
++  bool always_incognito_enabled = false;
++
++#if defined(ALWAYS_INCOGNITO_ENABLED)
++  PrefService* prefService = original_profile->GetPrefs();
++  if (prefService->GetBoolean(prefs::kAlwaysIncognitoEnabled)) {
++    profile = original_profile;
++    always_incognito_enabled = true;
++  }
++#endif
++
+   scoped_refptr<HostContentSettingsMap> settings_map(new HostContentSettingsMap(
+       profile->GetPrefs(),
+-      profile->IsOffTheRecord() || profile->IsGuestSession(),
++      !always_incognito_enabled && (profile->IsOffTheRecord() || profile->IsGuestSession()),
+       /*store_last_modified=*/true,
+       profile->ShouldRestoreOldSessionCookies()));
+ 
+@@ -108,6 +119,9 @@ scoped_refptr<RefcountedKeyedService>
+       HostContentSettingsMap::WEBUI_ALLOWLIST_PROVIDER,
+       std::move(allowlist_provider));
+ 
++  if (always_incognito_enabled)
++    return settings_map;
++
+   if (base::FeatureList::IsEnabled(
+           permissions::features::kOneTimeGeolocationPermission)) {
+     auto one_time_geolocation_provider =
 diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
 --- a/chrome/browser/flags/android/chrome_feature_list.cc
 +++ b/chrome/browser/flags/android/chrome_feature_list.cc
@@ -617,6 +634,19 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browse
  
  const base::Feature kCCTPostMessageAPI{"CCTPostMessageAPI",
                                         base::FEATURE_ENABLED_BY_DEFAULT};
+diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browser_prefs.cc
+--- a/chrome/browser/prefs/browser_prefs.cc
++++ b/chrome/browser/prefs/browser_prefs.cc
+@@ -1261,6 +1261,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
+   variations::VariationsService::RegisterProfilePrefs(registry);
+   video_tutorials::RegisterPrefs(registry);
+   feed::prefs::RegisterFeedSharedProfilePrefs(registry);
++  // register incognito pref
++  registry->RegisterBooleanPref(prefs::kAlwaysIncognitoEnabled,
++                              /*default_value=*/false);
+   feed::RegisterProfilePrefs(registry);
+ #else   // defined(OS_ANDROID)
+   AppShortcutManager::RegisterProfilePrefs(registry);
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
@@ -683,5 +713,34 @@ new file mode 100644
 +public interface INeedSnackbarManager {
 +    void setSnackbarManager(SnackbarManager manager);
 +}
+diff --git a/chrome/common/pref_names.cc b/chrome/common/pref_names.cc
+--- a/chrome/common/pref_names.cc
++++ b/chrome/common/pref_names.cc
+@@ -3284,6 +3284,10 @@ const char kShowCaretBrowsingDialog[] =
+ const char kLacrosLaunchSwitch[] = "lacros_launch_switch";
+ #endif
+ 
++#if defined(OS_ANDROID)
++const char kAlwaysIncognitoEnabled[] = "always_incognito_enabled";
++#endif
++
+ #if BUILDFLAG(IS_CHROMEOS_ASH)
+ // String enum pref determining what should happen when a user who authenticates
+ // via a security token is removing this token. "IGNORE" - nothing happens
+diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
+--- a/chrome/common/pref_names.h
++++ b/chrome/common/pref_names.h
+@@ -1198,6 +1198,11 @@ extern const char kLastWhatsNewVersion[];
+ extern const char kLensRegionSearchEnabled[];
+ #endif
+ 
++#if defined(OS_ANDROID)
++#define ALWAYS_INCOGNITO_ENABLED
++extern const char kAlwaysIncognitoEnabled[];
++#endif
++
+ extern const char kPrivacyReviewShowWelcomeCard[];
+ extern const char kPrivacyGuideViewed[];
+ 
 --
 2.25.1

--- a/build/patches/Add-an-always-incognito-mode.patch
+++ b/build/patches/Add-an-always-incognito-mode.patch
@@ -10,7 +10,7 @@ A flag for native management has been inserted
 ---
  chrome/android/chrome_java_sources.gni        |  1 +
  .../java/res/xml/privacy_preferences.xml      |  5 ++
- .../AlwaysIncognitoLinkInterceptor.java       | 52 +++++++++++++++++++
+ .../AlwaysIncognitoLinkInterceptor.java       | 53 +++++++++++++++++++
  .../chrome/browser/ChromeTabbedActivity.java  |  6 ++-
  .../chrome/browser/app/ChromeActivity.java    |  4 ++
  .../AppMenuPropertiesDelegateImpl.java        |  8 +++
@@ -25,7 +25,8 @@ A flag for native management has been inserted
  .../tabmodel/TabModelSelectorImpl.java        |  3 ++
  .../browser/tabmodel/TabPersistentStore.java  | 10 ++++
  .../webapps/WebappIntentDataProvider.java     | 14 +++++
- .../chrome_autocomplete_provider_client.cc    |  3 ++
+ .../chrome_autocomplete_provider_client.cc    |  7 +++
+ .../chrome_autocomplete_provider_client.h     |  1 +
  .../host_content_settings_map_factory.cc      | 16 +++++-
  .../flags/android/chrome_feature_list.cc      |  2 +-
  chrome/browser/prefs/browser_prefs.cc         |  3 ++
@@ -34,7 +35,11 @@ A flag for native management has been inserted
  .../snackbar/INeedSnackbarManager.java        | 27 ++++++++++
  chrome/common/pref_names.cc                   |  4 ++
  chrome/common/pref_names.h                    |  5 ++
- 26 files changed, 244 insertions(+), 37 deletions(-)
+ .../browser/autocomplete_provider_client.cc   |  4 ++
+ .../browser/autocomplete_provider_client.h    |  1 +
+ .../omnibox/browser/base_search_provider.cc   |  2 +-
+ components/omnibox/browser/search_provider.cc |  4 +-
+ 31 files changed, 259 insertions(+), 39 deletions(-)
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java
  create mode 100644 chrome/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/INeedSnackbarManager.java
 
@@ -68,7 +73,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognito
 new file mode 100644
 --- /dev/null
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,53 @@
 +/* This Source Code Form is subject to the terms of the Mozilla Public
 + * License, v. 2.0. If a copy of the MPL was not distributed with this
 + * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -91,6 +96,7 @@ new file mode 100644
 + */
 +public class AlwaysIncognitoLinkInterceptor {
 +
++    private static final String TAG = "AlwaysIncognito";
 +    public static final String PREF_ALWAYS_INCOGNITO = "always_incognito";
 +
 +    private static @Nullable Boolean cachedIsAlwaysIncognito = null;
@@ -115,7 +121,7 @@ new file mode 100644
 +        if (isAlwaysIncognito()) {
 +            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
 +            if(!prefService.getBoolean(Pref.ALWAYS_INCOGNITO_ENABLED)) {
-+                Log.i("BROMITE", "Migration: always incognito pref from java to native");
++                Log.i(TAG, "Pref migration from java to native");
 +                prefService.setBoolean(Pref.ALWAYS_INCOGNITO_ENABLED, true);
 +            }
 +        }
@@ -570,16 +576,31 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappI
 diff --git a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc b/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
 --- a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
 +++ b/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
-@@ -305,6 +305,9 @@ signin::IdentityManager* ChromeAutocompleteProviderClient::GetIdentityManager()
+@@ -304,6 +304,13 @@ signin::IdentityManager* ChromeAutocompleteProviderClient::GetIdentityManager()
+   return IdentityManagerFactory::GetForProfile(profile_);
  }
  
- bool ChromeAutocompleteProviderClient::IsOffTheRecord() const {
++bool ChromeAutocompleteProviderClient::IsAlwaysIncognitoEnabled() const {
 +  if (profile_->GetPrefs()->GetBoolean(prefs::kAlwaysIncognitoEnabled)) {
-+    return false;
++    return true;
 +  }
++  return false;
++}
++
+ bool ChromeAutocompleteProviderClient::IsOffTheRecord() const {
    return profile_->IsOffTheRecord();
  }
- 
+diff --git a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.h b/chrome/browser/autocomplete/chrome_autocomplete_provider_client.h
+--- a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.h
++++ b/chrome/browser/autocomplete/chrome_autocomplete_provider_client.h
+@@ -77,6 +77,7 @@ class ChromeAutocompleteProviderClient : public AutocompleteProviderClient {
+       const override;
+   signin::IdentityManager* GetIdentityManager() const override;
+   bool IsOffTheRecord() const override;
++  bool IsAlwaysIncognitoEnabled() const override;
+   bool SearchSuggestEnabled() const override;
+   bool AllowDeletingBrowserHistory() const override;
+   bool IsPersonalizedUrlDataCollectionActive() const override;
 diff --git a/chrome/browser/content_settings/host_content_settings_map_factory.cc b/chrome/browser/content_settings/host_content_settings_map_factory.cc
 --- a/chrome/browser/content_settings/host_content_settings_map_factory.cc
 +++ b/chrome/browser/content_settings/host_content_settings_map_factory.cc
@@ -742,5 +763,53 @@ diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
  extern const char kPrivacyReviewShowWelcomeCard[];
  extern const char kPrivacyGuideViewed[];
  
+diff --git a/components/omnibox/browser/autocomplete_provider_client.cc b/components/omnibox/browser/autocomplete_provider_client.cc
+--- a/components/omnibox/browser/autocomplete_provider_client.cc
++++ b/components/omnibox/browser/autocomplete_provider_client.cc
+@@ -29,3 +29,7 @@ bool AutocompleteProviderClient::IsIncognitoModeAvailable() const {
+ bool AutocompleteProviderClient::IsSharingHubAvailable() const {
+   return false;
+ }
++
++bool AutocompleteProviderClient::IsAlwaysIncognitoEnabled() const {
++  return false;
++}
+diff --git a/components/omnibox/browser/autocomplete_provider_client.h b/components/omnibox/browser/autocomplete_provider_client.h
+--- a/components/omnibox/browser/autocomplete_provider_client.h
++++ b/components/omnibox/browser/autocomplete_provider_client.h
+@@ -130,6 +130,7 @@ class AutocompleteProviderClient : public OmniboxAction::Client {
+   virtual signin::IdentityManager* GetIdentityManager() const = 0;
+ 
+   virtual bool IsOffTheRecord() const = 0;
++  virtual bool IsAlwaysIncognitoEnabled() const = 0;
+   virtual bool SearchSuggestEnabled() const = 0;
+ 
+   // True for almost all users except ones with a specific enterprise policy.
+diff --git a/components/omnibox/browser/base_search_provider.cc b/components/omnibox/browser/base_search_provider.cc
+--- a/components/omnibox/browser/base_search_provider.cc
++++ b/components/omnibox/browser/base_search_provider.cc
+@@ -415,7 +415,7 @@ bool BaseSearchProvider::CanSendURL(
+     return false;
+ 
+   // Don't run if in incognito mode.
+-  if (client->IsOffTheRecord())
++  if (client->IsOffTheRecord() && client->IsAlwaysIncognitoEnabled() == false)
+     return false;
+ 
+   // Don't run if we can't get preferences or search suggest is not enabled.
+diff --git a/components/omnibox/browser/search_provider.cc b/components/omnibox/browser/search_provider.cc
+--- a/components/omnibox/browser/search_provider.cc
++++ b/components/omnibox/browser/search_provider.cc
+@@ -770,7 +770,9 @@ bool SearchProvider::IsQuerySuitableForSuggest(bool* query_is_private) const {
+   // keyword input to a keyword suggest server, if any.)
+   const TemplateURL* default_url = providers_.GetDefaultProviderURL();
+   const TemplateURL* keyword_url = providers_.GetKeywordProviderURL();
+-  return !client()->IsOffTheRecord() && client()->SearchSuggestEnabled() &&
++  return (client()->IsOffTheRecord() == false ||
++                client()->IsAlwaysIncognitoEnabled() == true) &&
++         client()->SearchSuggestEnabled() &&
+          ((default_url && !default_url->suggestions_url().empty() &&
+            !*query_is_private) ||
+           (keyword_url && !keyword_url->suggestions_url().empty()));
 --
 2.25.1

--- a/build/patches/Add-history-support-in-incognito-mode.patch
+++ b/build/patches/Add-history-support-in-incognito-mode.patch
@@ -13,13 +13,14 @@ See also: https://github.com/bromite/bromite/pull/1427
  .../chrome_junit_test_java_sources.gni        |   4 +
  chrome/android/chrome_test_java_sources.gni   |   6 +
  .../java/res/xml/privacy_preferences.xml      |   5 +
- .../AppMenuPropertiesDelegateImpl.java        |  29 +-
- .../CustomTabAppMenuPropertiesDelegate.java   |   3 +
+ .../AppMenuPropertiesDelegateImpl.java        |  25 +-
+ .../CustomTabAppMenuPropertiesDelegate.java   |   4 +
  .../browser/download/DownloadUtils.java       |  16 +-
- .../browser/history/HistoryManager.java       |  17 +-
- .../chrome/browser/history/HistoryPage.java   |  15 +
+ .../browser/history/HistoryManager.java       |  18 +-
+ .../chrome/browser/history/HistoryPage.java   |  16 +
+ .../native_page/NativePageFactory.java        |   4 +-
  .../chrome/browser/ntp/RecentTabsManager.java |   8 +-
- .../privacy/settings/PrivacySettings.java     |  16 +
+ .../privacy/settings/PrivacySettings.java     |  18 +
  .../browser/tab/HistoricalTabSaver.java       |  12 +-
  .../browser/tabmodel/TabPersistentStore.java  |   5 +-
  .../history/Bromite_HistoryManagerTest.java   | 112 ++++++
@@ -40,13 +41,13 @@ See also: https://github.com/bromite/bromite/pull/1427
  .../request_coordinator_factory.h             |   2 +
  chrome/browser/prefs/browser_prefs.cc         |   3 +
  .../browser/ui/android/native_page/BUILD.gn   |   2 +
- .../browser/ui/native_page/NativePage.java    |   6 +-
+ .../browser/ui/native_page/NativePage.java    |  12 +-
  .../ui/native_page/NativePageTest.java        |  26 ++
  .../strings/android_chrome_strings.grd        |   6 +
- chrome/common/pref_names.cc                   |   5 +
+ chrome/common/pref_names.cc                   |   2 +
  chrome/common/pref_names.h                    |   4 +
  chrome/test/BUILD.gn                          |   5 +
- 36 files changed, 1043 insertions(+), 38 deletions(-)
+ 37 files changed, 1048 insertions(+), 41 deletions(-)
  create mode 100644 chrome/android/javatests/src/org/chromium/chrome/browser/history/Bromite_HistoryManagerTest.java
  create mode 100644 chrome/android/javatests/src/org/chromium/chrome/browser/privacy/settings/Bromite_PrivacySettingsFragmentTest_HistoryInAlwaysIncognito.java
  create mode 100644 chrome/android/junit/src/org/chromium/chrome/browser/app/appmenu/Bromite_AppMenuPropertiesDelegateUnitTest.java
@@ -96,7 +97,7 @@ diff --git a/chrome/android/java/res/xml/privacy_preferences.xml b/chrome/androi
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
-@@ -96,6 +96,10 @@ import java.util.ArrayList;
+@@ -97,6 +97,10 @@ import java.util.ArrayList;
  import java.util.List;
  import java.util.Map;
  
@@ -107,7 +108,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/App
  /**
   * Base implementation of {@link AppMenuPropertiesDelegate} that handles hiding and showing menu
   * items based on activity state.
-@@ -156,6 +160,13 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+@@ -157,6 +161,13 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
      private @StartSurfaceState int mStartSurfaceState;
      protected Runnable mAppMenuInvalidator;
  
@@ -121,17 +122,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/App
      /**
       * Construct a new {@link AppMenuPropertiesDelegateImpl}.
       * @param context The activity context.
-@@ -525,7 +536,8 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
-     }
- 
-     private void prepareCommonMenuItems(Menu menu, @MenuGroup int menuGroup, boolean isIncognito) {
--        if (ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
-+        boolean always_incognito = ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false);
-+        if (always_incognito) {
-             final MenuItem newTabOption = menu.findItem(R.id.new_tab_menu_id);
-             if (newTabOption != null)
-                 newTabOption.setVisible(false);
-@@ -587,7 +599,15 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+@@ -589,7 +600,15 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
              }
  
              if (item.getItemId() == R.id.recent_tabs_menu_id) {
@@ -148,26 +139,33 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/App
              }
              if (item.getItemId() == R.id.menu_group_tabs) {
                  item.setVisible(isMenuGroupTabsVisible);
-@@ -824,7 +844,10 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+@@ -826,7 +845,9 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
          //                is not persisted when adding to the homescreen.
          // * If creating shortcuts it not supported by the current home screen.
          return WebappsUtils.isAddToHomeIntentSupported() && !isChromeScheme && !isFileScheme
 -                && !isContentScheme && !isIncognito && !url.isEmpty();
 +                && !isContentScheme && !url.isEmpty()
 +                && (!isIncognito ||
-+                    ContextUtils.getAppSharedPreferences().getBoolean(
-+                        "always_incognito", false));
++                    AlwaysIncognitoLinkInterceptor.isAlwaysIncognito());
      }
  
      /**
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabAppMenuPropertiesDelegate.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabAppMenuPropertiesDelegate.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabAppMenuPropertiesDelegate.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabAppMenuPropertiesDelegate.java
-@@ -168,6 +168,9 @@ public class CustomTabAppMenuPropertiesDelegate extends AppMenuPropertiesDelegat
+@@ -20,6 +20,7 @@ import org.chromium.base.ContextUtils;
+ import org.chromium.base.supplier.ObservableSupplier;
+ import org.chromium.chrome.R;
+ import org.chromium.chrome.browser.ActivityTabProvider;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
+ import org.chromium.chrome.browser.DefaultBrowserInfo;
+ import org.chromium.chrome.browser.app.appmenu.AppMenuPropertiesDelegateImpl;
+ import org.chromium.chrome.browser.bookmarks.BookmarkBridge;
+@@ -168,6 +169,9 @@ public class CustomTabAppMenuPropertiesDelegate extends AppMenuPropertiesDelegat
                  downloadItemVisible = false;
                  openInChromeItemVisible = false;
              }
-+            if (ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
++            if (AlwaysIncognitoLinkInterceptor.isAlwaysIncognito()) {
 +                downloadItemVisible = true;
 +            }
  
@@ -176,7 +174,15 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/Cust
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadUtils.java b/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadUtils.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadUtils.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadUtils.java
-@@ -71,6 +71,10 @@ import org.chromium.ui.widget.Toast;
+@@ -34,6 +34,7 @@ import org.chromium.base.annotations.NativeMethods;
+ import org.chromium.base.metrics.RecordHistogram;
+ import org.chromium.base.metrics.RecordUserAction;
+ import org.chromium.chrome.R;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
+ import org.chromium.chrome.browser.ChromeTabbedActivity;
+ import org.chromium.chrome.browser.IntentHandler;
+ import org.chromium.chrome.browser.download.items.OfflineContentAggregatorFactory;
+@@ -71,6 +72,10 @@ import org.chromium.ui.widget.Toast;
  
  import java.io.File;
  
@@ -187,13 +193,12 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/download/Downlo
  /**
   * A class containing some utility static methods.
   */
-@@ -311,7 +315,17 @@ public class DownloadUtils {
+@@ -311,7 +316,16 @@ public class DownloadUtils {
          // Offline pages isn't supported in Incognito. This should be checked before calling
          // OfflinePageBridge.getForProfile because OfflinePageBridge instance will not be found
          // for incognito profile.
 -        if (tab.isIncognito()) return false;
-+        boolean always_incognito =
-+            ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false);
++        boolean always_incognito = AlwaysIncognitoLinkInterceptor.isAlwaysIncognito();
 +        if (always_incognito) {
 +            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
 +            boolean historyEnabledInIncognito =
@@ -209,7 +214,15 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/download/Downlo
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryManager.java b/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryManager.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryManager.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryManager.java
-@@ -41,6 +41,12 @@ import org.chromium.ui.base.Clipboard;
+@@ -22,6 +22,7 @@ import org.chromium.base.metrics.RecordHistogram;
+ import org.chromium.base.metrics.RecordUserAction;
+ import org.chromium.base.supplier.Supplier;
+ import org.chromium.chrome.R;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
+ import org.chromium.chrome.browser.browsing_data.ClearBrowsingDataTabsFragment;
+ import org.chromium.chrome.browser.flags.ChromeFeatureList;
+ import org.chromium.chrome.browser.preferences.ChromePreferenceKeys;
+@@ -41,6 +42,12 @@ import org.chromium.ui.base.Clipboard;
  
  import java.util.List;
  
@@ -222,7 +235,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/History
  /**
   * Combines and manages the different UI components of browsing history.
   */
-@@ -213,7 +219,16 @@ public class HistoryManager implements OnMenuItemClickListener, SelectionObserve
+@@ -213,7 +220,16 @@ public class HistoryManager implements OnMenuItemClickListener, SelectionObserve
                                                  : mSelectableListLayout;
      }
  
@@ -231,7 +244,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/History
 +
 +    public boolean shouldShowIncognitoPlaceholder() {
 +        if (mIsIncognito &&
-+                ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
++                AlwaysIncognitoLinkInterceptor.isAlwaysIncognito()) {
 +            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
 +            boolean historyEnabledInIncognito =
 +                prefService.getBoolean(Pref.INCOGNITO_TAB_HISTORY_ENABLED);
@@ -243,7 +256,14 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/History
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryPage.java b/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryPage.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryPage.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryPage.java
-@@ -16,6 +16,12 @@ import org.chromium.chrome.browser.ui.native_page.BasicNativePage;
+@@ -10,12 +10,19 @@ import androidx.annotation.VisibleForTesting;
+ 
+ import org.chromium.base.supplier.Supplier;
+ import org.chromium.chrome.R;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
+ import org.chromium.chrome.browser.tab.Tab;
+ import org.chromium.chrome.browser.ui.messages.snackbar.SnackbarManager;
+ import org.chromium.chrome.browser.ui.native_page.BasicNativePage;
  import org.chromium.chrome.browser.ui.native_page.NativePageHost;
  import org.chromium.components.embedder_support.util.UrlConstants;
  
@@ -256,12 +276,12 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/History
  /**
   * Native page for managing browsing history.
   */
-@@ -37,8 +43,17 @@ public class HistoryPage extends BasicNativePage {
+@@ -37,8 +44,17 @@ public class HistoryPage extends BasicNativePage {
              boolean isIncognito, Supplier<Tab> tabSupplier) {
          super(host);
  
 +        if (isIncognito &&
-+                ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false)) {
++                AlwaysIncognitoLinkInterceptor.isAlwaysIncognito()) {
 +            PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
 +            boolean historyEnabledInIncognito =
 +                prefService.getBoolean(Pref.INCOGNITO_TAB_HISTORY_ENABLED);
@@ -274,6 +294,27 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/History
          mTitle = host.getContext().getResources().getString(R.string.menu_history);
  
          initWithView(mHistoryManager.getView());
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/native_page/NativePageFactory.java b/chrome/android/java/src/org/chromium/chrome/browser/native_page/NativePageFactory.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/native_page/NativePageFactory.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/native_page/NativePageFactory.java
+@@ -15,6 +15,7 @@ import org.chromium.base.jank_tracker.JankTracker;
+ import org.chromium.base.supplier.BooleanSupplier;
+ import org.chromium.base.supplier.DestroyableObservableSupplier;
+ import org.chromium.base.supplier.Supplier;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
+ import org.chromium.chrome.browser.app.ChromeActivity;
+ import org.chromium.chrome.browser.bookmarks.BookmarkPage;
+ import org.chromium.chrome.browser.browser_controls.BrowserControlsMarginSupplier;
+@@ -243,7 +244,8 @@ public class NativePageFactory {
+             String url, NativePage candidatePage, Tab tab, boolean isIncognito) {
+         NativePage page;
+ 
+-        switch (NativePage.nativePageType(url, candidatePage, isIncognito)) {
++        boolean isAlwaysIncognito = AlwaysIncognitoLinkInterceptor.isAlwaysIncognito();
++        switch (NativePage.nativePageType(url, candidatePage, isIncognito, isAlwaysIncognito)) {
+             case NativePageType.NONE:
+                 return null;
+             case NativePageType.CANDIDATE:
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java b/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java
@@ -300,7 +341,15 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsM
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
-@@ -150,6 +150,11 @@ public class PrivacySettings
+@@ -18,6 +18,7 @@ import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
+ 
+ import org.chromium.base.ContextUtils;
+ import org.chromium.base.BuildInfo;
++import org.chromium.base.Log;
+ import org.chromium.chrome.R;
+ import org.chromium.chrome.browser.feedback.HelpAndFeedbackLauncherImpl;
+ import org.chromium.chrome.browser.flags.ChromeFeatureList;
+@@ -151,6 +152,11 @@ public class PrivacySettings
          Preference secureDnsPref = findPreference(PREF_SECURE_DNS);
          secureDnsPref.setVisible(SecureDnsSettings.isUiEnabled());
  
@@ -312,27 +361,25 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
          updatePreferences();
      }
  
-@@ -166,6 +171,9 @@ public class PrivacySettings
+@@ -171,10 +177,15 @@ public class PrivacySettings
          } else if (PREF_HTTPS_FIRST_MODE.equals(key)) {
              UserPrefs.get(Profile.getLastUsedRegularProfile())
                      .setBoolean(Pref.HTTPS_ONLY_MODE_ENABLED, (boolean) newValue);
 +        } else if (PREF_INCOGNITO_TAB_HISTORY_ENABLED.equals(key)) {
 +            UserPrefs.get(Profile.getLastUsedRegularProfile())
 +                    .setBoolean(Pref.INCOGNITO_TAB_HISTORY_ENABLED, (boolean) newValue);
-         } else if (PREF_ALWAYS_INCOGNITO.equals(key)) {
-             if (!mSnackbarManager.isShowing())
-                 mSnackbarManager.showSnackbar(mSnackbar);
-@@ -173,6 +181,7 @@ public class PrivacySettings
+         }
          return true;
      }
  
 +    public static final String PREF_INCOGNITO_TAB_HISTORY_ENABLED = "incognito_history_enabled";
++
      @Override
      public void onResume() {
          super.onResume();
-@@ -214,6 +223,13 @@ public class PrivacySettings
-                     PrivacySandboxSettingsFragment.getStatusString(getContext()));
-         }
+@@ -205,6 +216,13 @@ public class PrivacySettings
+         closeTabsOnExitPref.setOnPreferenceChangeListener(this);
+         closeTabsOnExitPref.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
  
 +        ChromeSwitchPreference historyInIncognitoPref =
 +                (ChromeSwitchPreference) findPreference(PREF_INCOGNITO_TAB_HISTORY_ENABLED);
@@ -341,9 +388,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
 +                    prefService.getBoolean(Pref.INCOGNITO_TAB_HISTORY_ENABLED));
 +        }
 +
-         mIncognitoLockSettings.updateIncognitoReauthPreferenceIfNeeded(getActivity());
-     }
- 
+         Preference secureDnsPref = findPreference(PREF_SECURE_DNS);
+         if (secureDnsPref != null && secureDnsPref.isVisible()) {
+             secureDnsPref.setSummary(SecureDnsSettings.getSummary(getContext()));
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/HistoricalTabSaver.java b/chrome/android/java/src/org/chromium/chrome/browser/tab/HistoricalTabSaver.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tab/HistoricalTabSaver.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tab/HistoricalTabSaver.java
@@ -391,7 +438,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPer
                  PersistedTabData.onTabClose(tab);
 -                if (!tab.isIncognito()) HistoricalTabSaver.createHistoricalTab(tab);
 +                boolean is_always_incognito =
-+                    ContextUtils.getAppSharedPreferences().getBoolean(AlwaysIncognitoLinkInterceptor.PREF_ALWAYS_INCOGNITO, false);
++                    AlwaysIncognitoLinkInterceptor.isAlwaysIncognito();
 +                if (!tab.isIncognito() || is_always_incognito)
 +                        HistoricalTabSaver.createHistoricalTab(tab, is_always_incognito);
                  removeTabFromQueues(tab);
@@ -1573,10 +1620,10 @@ diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browse
  #include "chrome/browser/android/bookmarks/partner_bookmarks_shim.h"
  #include "chrome/browser/android/explore_sites/history_statistics_reporter.h"
  #include "chrome/browser/android/ntp/recent_tabs_page_prefs.h"
-@@ -1265,6 +1267,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
-   variations::VariationsService::RegisterProfilePrefs(registry);
-   video_tutorials::RegisterPrefs(registry);
-   feed::prefs::RegisterFeedSharedProfilePrefs(registry);
+@@ -1268,6 +1270,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
+   // register incognito pref
+   registry->RegisterBooleanPref(prefs::kAlwaysIncognitoEnabled,
+                               /*default_value=*/false);
 +  HistoryTabHelper::RegisterProfilePrefs(registry);
    feed::RegisterProfilePrefs(registry);
  #else   // defined(OS_ANDROID)
@@ -1607,14 +1654,38 @@ diff --git a/chrome/browser/ui/android/native_page/java/src/org/chromium/chrome/
  /**
   * An interface for pages that will be using Android views instead of html/rendered Web content.
   */
-@@ -158,7 +160,9 @@ public interface NativePage {
+@@ -120,12 +122,12 @@ public interface NativePage {
+      */
+     @Deprecated // Use GURL-variant instead.
+     public static boolean isNativePageUrl(String url, boolean isIncognito) {
+-        return nativePageType(url, null, isIncognito) != NativePageType.NONE;
++        return nativePageType(url, null, isIncognito, false) != NativePageType.NONE;
+     }
+ 
+     public static boolean isNativePageUrl(GURL url, boolean isIncognito) {
+         return url != null
+-                && nativePageType(url.getSpec(), null, isIncognito) != NativePageType.NONE;
++                && nativePageType(url.getSpec(), null, isIncognito, false) != NativePageType.NONE;
+     }
+ 
+     /**
+@@ -136,7 +138,8 @@ public interface NativePage {
+      */
+     // TODO(crbug/783819) - Convert to using GURL.
+     public static @NativePageType int nativePageType(
+-            String url, NativePage candidatePage, boolean isIncognito) {
++            String url, NativePage candidatePage, boolean isIncognito,
++            boolean isAlwaysIncognito) {
+         if (url == null) return NativePageType.NONE;
+ 
+         Uri uri = Uri.parse(url);
+@@ -158,7 +161,8 @@ public interface NativePage {
              return NativePageType.DOWNLOADS;
          } else if (UrlConstants.HISTORY_HOST.equals(host)) {
              return NativePageType.HISTORY;
 -        } else if (UrlConstants.RECENT_TABS_HOST.equals(host) && !isIncognito) {
 +        } else if (UrlConstants.RECENT_TABS_HOST.equals(host) &&
-+                  (!isIncognito ||
-+                    ContextUtils.getAppSharedPreferences().getBoolean("always_incognito", false))) {
++                  (!isIncognito || isAlwaysIncognito)) {
              return NativePageType.RECENT_TABS;
          } else if (UrlConstants.EXPLORE_HOST.equals(host)) {
              return NativePageType.EXPLORE;
@@ -1678,22 +1749,19 @@ diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chro
 diff --git a/chrome/common/pref_names.cc b/chrome/common/pref_names.cc
 --- a/chrome/common/pref_names.cc
 +++ b/chrome/common/pref_names.cc
-@@ -3287,6 +3287,11 @@ const char kShowCaretBrowsingDialog[] =
- const char kLacrosLaunchSwitch[] = "lacros_launch_switch";
- #endif
+@@ -3289,6 +3289,8 @@ const char kLacrosLaunchSwitch[] = "lacros_launch_switch";
  
-+#if defined(OS_ANDROID)
+ #if defined(OS_ANDROID)
+ const char kAlwaysIncognitoEnabled[] = "always_incognito_enabled";
 +const char kIncognitoTabHistoryEnabled[] =
 +    "incognito_tab_history_enabled";
-+#endif
-+
+ #endif
+ 
  #if BUILDFLAG(IS_CHROMEOS_ASH)
- // String enum pref determining what should happen when a user who authenticates
- // via a security token is removing this token. "IGNORE" - nothing happens
 diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1204,6 +1204,10 @@ extern const char kPrivacyGuideViewed[];
+@@ -1209,6 +1209,10 @@ extern const char kPrivacyGuideViewed[];
  
  extern const char kCorsNonWildcardRequestHeadersSupport[];
  

--- a/build/patches/Enable-share-intent.patch
+++ b/build/patches/Enable-share-intent.patch
@@ -10,9 +10,9 @@ See also: https://github.com/bromite/bromite/issues/1062
  chrome/android/chrome_java_resources.gni      |   1 +
  chrome/android/chrome_java_sources.gni        |   1 +
  chrome/android/java/AndroidManifest.xml       |  18 +++
- .../res/layout/sharing_intent_content.xml     |  83 +++++++++++++
+ .../res/layout/sharing_intent_content.xml     |  83 ++++++++++++
  .../init/ProcessInitializationHandler.java    |   3 +
- .../SharedIntentShareActivity.java            | 114 ++++++++++++++++++
+ .../SharedIntentShareActivity.java            | 118 ++++++++++++++++++
  chrome/browser/about_flags.cc                 |   4 +
  chrome/browser/flag_descriptions.cc           |   5 +
  chrome/browser/flag_descriptions.h            |   3 +
@@ -20,7 +20,7 @@ See also: https://github.com/bromite/bromite/issues/1062
  .../flags/android/chrome_feature_list.h       |   1 +
  .../browser/flags/ChromeFeatureList.java      |   1 +
  .../strings/android_chrome_strings.grd        |  13 ++
- 13 files changed, 251 insertions(+)
+ 13 files changed, 255 insertions(+)
  create mode 100644 chrome/android/java/res/layout/sharing_intent_content.xml
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/sharing/shared_intent/SharedIntentShareActivity.java
 
@@ -186,7 +186,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/sharing/shared_
 new file mode 100644
 --- /dev/null
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/sharing/shared_intent/SharedIntentShareActivity.java
-@@ -0,0 +1,114 @@
+@@ -0,0 +1,118 @@
 +// Copyright 2019 The Chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -210,6 +210,7 @@ new file mode 100644
 +import org.chromium.base.task.PostTask;
 +import org.chromium.base.task.TaskTraits;
 +import org.chromium.chrome.R;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
 +import org.chromium.chrome.browser.flags.ChromeFeatureList;
 +import org.chromium.chrome.browser.init.AsyncInitializationActivity;
 +import org.chromium.chrome.browser.LaunchIntentDispatcher;
@@ -292,6 +293,9 @@ new file mode 100644
 +            LaunchIntentDispatcher.dispatch(this, chromeIntent);
 +            finish();
 +        });
++
++       if (AlwaysIncognitoLinkInterceptor.isAlwaysIncognito())
++            open_url_incognito_button.setVisibility(View.GONE);
 +
 +        onInitialLayoutInflationComplete();
 +    }


### PR DESCRIPTION
I changed the navigation patch always incognito:

- general code cleanup, removing useless code in `AlwaysIncognitoLinkInterceptor`
- removal of all `always_incognito` constants used and use of a single point of truth
- added preference in native with automatic migration on first startup, the modification allows me to fix #1496
- added the ability to enable auto-completion of searches in always incognito mode

the patch `Add history support in incognito mode` has been modified accordingly.
the patch `Enable share intent` has been modified accordingly to fix #1568