### PR TITLE
Proposal: complete disabling of client hints

### DIFF
--- a/build/patches/Client-hints-overrides.patch
+++ b/build/patches/Client-hints-overrides.patch
@@ -6,11 +6,30 @@ Disable critical client hints
 Hard-code model to SAMSUNG SM-G960U
 use Google Chrome branding for client hints
 ---
- components/embedder_support/user_agent_utils.cc | 4 +---
- content/common/user_agent.cc                    | 7 +------
- content/public/common/content_features.cc       | 2 +-
- 3 files changed, 3 insertions(+), 10 deletions(-)
+ chrome/browser/prefs/browser_prefs.cc                      | 2 +-
+ components/embedder_support/user_agent_utils.cc            | 4 +---
+ content/browser/client_hints/client_hints.cc               | 1 +
+ content/common/user_agent.cc                               | 7 +------
+ content/public/common/content_features.cc                  | 2 +-
+ services/network/public/cpp/client_hints.cc                | 1 +
+ services/network/public/cpp/features.cc                    | 2 +-
+ third_party/blink/common/client_hints/client_hints.cc      | 1 +
+ .../blink/common/client_hints/enabled_client_hints.cc      | 4 +++-
+ third_party/blink/common/features.cc                       | 4 ++--
+ 10 files changed, 13 insertions(+), 15 deletions(-)
 
+diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browser_prefs.cc
+--- a/chrome/browser/prefs/browser_prefs.cc
++++ b/chrome/browser/prefs/browser_prefs.cc
+@@ -716,7 +716,7 @@ void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {
+   registry->RegisterIntegerPref(kStabilityDebuggerPresent, 0);
+   registry->RegisterIntegerPref(kStabilityDebuggerNotPresent, 0);
+ 
+-  registry->RegisterBooleanPref(kUserAgentClientHintsEnabled, true);
++  registry->RegisterBooleanPref(kUserAgentClientHintsEnabled, false);
+ 
+   registry->RegisterBooleanPref(kCloudPolicyOverridesPlatformPolicy, false);
+ 
 diff --git a/components/embedder_support/user_agent_utils.cc b/components/embedder_support/user_agent_utils.cc
 --- a/components/embedder_support/user_agent_utils.cc
 +++ b/components/embedder_support/user_agent_utils.cc
@@ -25,6 +44,17 @@ diff --git a/components/embedder_support/user_agent_utils.cc b/components/embedd
    absl::optional<std::string> maybe_brand_override =
        base::GetFieldTrialParamValueByFeature(features::kGreaseUACH,
                                               "brand_override");
+diff --git a/content/browser/client_hints/client_hints.cc b/content/browser/client_hints/client_hints.cc
+--- a/content/browser/client_hints/client_hints.cc
++++ b/content/browser/client_hints/client_hints.cc
+@@ -421,6 +421,7 @@ void AddPrefersColorSchemeHeader(net::HttpRequestHeaders* headers,
+ }
+ 
+ bool IsValidURLForClientHints(const GURL& url) {
++  if ((true)) return false;
+   if (!url.is_valid() || !url.SchemeIsHTTPOrHTTPS() ||
+       (url.SchemeIs(url::kHttpScheme) && !net::IsLocalhost(url)))
+     return false;
 diff --git a/content/common/user_agent.cc b/content/common/user_agent.cc
 --- a/content/common/user_agent.cc
 +++ b/content/common/user_agent.cc
@@ -54,5 +84,88 @@ diff --git a/content/public/common/content_features.cc b/content/public/common/c
  
  // Enable cross-origin sharing of WebAssembly modules.
  const base::Feature kCrossOriginWebAssemblyModuleSharingEnabled{
+diff --git a/services/network/public/cpp/client_hints.cc b/services/network/public/cpp/client_hints.cc
+--- a/services/network/public/cpp/client_hints.cc
++++ b/services/network/public/cpp/client_hints.cc
+@@ -93,6 +93,7 @@ const DecodeMap& GetDecodeMap() {
+ 
+ absl::optional<std::vector<network::mojom::WebClientHintsType>>
+ ParseClientHintsHeader(const std::string& header) {
++  if ((true)) return absl::nullopt;
+   // Accept-CH is an sh-list of tokens; see:
+   // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-header-structure-19#section-3.1
+   absl::optional<net::structured_headers::List> maybe_list =
+diff --git a/services/network/public/cpp/features.cc b/services/network/public/cpp/features.cc
+--- a/services/network/public/cpp/features.cc
++++ b/services/network/public/cpp/features.cc
+@@ -195,7 +195,7 @@ const base::Feature kWebSocketReassembleShortMessages{
+ // See:
+ // https://tools.ietf.org/html/draft-davidben-http-client-hint-reliability-02#section-4.3
+ const base::Feature kAcceptCHFrame{"AcceptCHFrame",
+-                                   base::FEATURE_ENABLED_BY_DEFAULT};
++                                   base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ const base::Feature kSCTAuditingRetryAndPersistReports{
+     "SCTAuditingRetryAndPersistReports", base::FEATURE_DISABLED_BY_DEFAULT};
+diff --git a/third_party/blink/common/client_hints/client_hints.cc b/third_party/blink/common/client_hints/client_hints.cc
+--- a/third_party/blink/common/client_hints/client_hints.cc
++++ b/third_party/blink/common/client_hints/client_hints.cc
+@@ -93,6 +93,7 @@ const size_t kWebEffectiveConnectionTypeMappingCount =
+     base::size(kWebEffectiveConnectionTypeMapping);
+ 
+ bool IsClientHintSentByDefault(network::mojom::WebClientHintsType type) {
++  if ((true)) return false;
+   switch (type) {
+     case network::mojom::WebClientHintsType::kUA:
+     case network::mojom::WebClientHintsType::kUAMobile:
+diff --git a/third_party/blink/common/client_hints/enabled_client_hints.cc b/third_party/blink/common/client_hints/enabled_client_hints.cc
+--- a/third_party/blink/common/client_hints/enabled_client_hints.cc
++++ b/third_party/blink/common/client_hints/enabled_client_hints.cc
+@@ -21,6 +21,7 @@ namespace {
+ using ::network::mojom::WebClientHintsType;
+ 
+ bool IsDisabledByFeature(const WebClientHintsType type) {
++  if ((true)) return true;
+   switch (type) {
+     case WebClientHintsType::kUA:
+     case WebClientHintsType::kUAArch:
+@@ -128,7 +129,7 @@ bool IsUaReducedClientHintEnabled(
+ }  // namespace
+ 
+ bool EnabledClientHints::IsEnabled(const WebClientHintsType type) const {
+-  return enabled_types_[static_cast<int>(type)];
++  return false;
+ }
+ 
+ void EnabledClientHints::SetIsEnabled(const WebClientHintsType type,
+@@ -153,6 +154,7 @@ void EnabledClientHints::SetIsEnabled(
+ 
+ std::vector<WebClientHintsType> EnabledClientHints::GetEnabledHints() const {
+   std::vector<WebClientHintsType> hints;
++  if ((true)) return hints;
+   for (const auto& elem : network::GetClientHintToNameMap()) {
+     const auto& type = elem.first;
+     if (IsEnabled(type))
+diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
+--- a/third_party/blink/common/features.cc
++++ b/third_party/blink/common/features.cc
+@@ -137,7 +137,7 @@ const base::Feature kMixedContentAutoupgrade{"AutoupgradeMixedContent",
+ // An experimental replacement for the `User-Agent` header, defined in
+ // https://tools.ietf.org/html/draft-west-ua-client-hints.
+ const base::Feature kUserAgentClientHint{"UserAgentClientHint",
+-                                         base::FEATURE_ENABLED_BY_DEFAULT};
++                                         base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ // Enable `sec-ch-ua-full-version-list` client hint.
+ const base::Feature kUserAgentClientHintFullVersionList{
+@@ -719,7 +719,7 @@ const base::Feature kResamplingScrollEvents{"ResamplingScrollEvents",
+ const base::Feature kAllowClientHintsToThirdParty {
+   "AllowClientHintsToThirdParty",
+ #if defined(OS_ANDROID)
+-      base::FEATURE_ENABLED_BY_DEFAULT
++      base::FEATURE_DISABLED_BY_DEFAULT
+ #else
+       base::FEATURE_DISABLED_BY_DEFAULT
+ #endif
 --
 2.25.1


### PR DESCRIPTION
I make you the proposal to completely disable client hints, since they would make it possible to make the purposes of the ua reduction ineffective.
in particular, the management of accept ch in the always incognito mode, which by keeping the requests of the sites in the content settings, would allow to know if a user has already visited the site in the same session.
currently the management of client hints is under development and therefore it could be possible that the patch will need to be revised over time.