### PR TITLE
Fix another way to activate origin trials

### DIFF
--- a/build/patches/Disable-third-party-origin-trials.patch
+++ b/build/patches/Disable-third-party-origin-trials.patch
@@ -3,16 +3,16 @@ Date: Thu, 4 Nov 2021 09:19:24 +0100
 Subject: Disable third-party origin trials
 
 ---
- .../origin_trials/origin_trial_policy_impl.cc   |  7 ++++---
- .../origin_trials/origin_trial_policy_impl.h    |  2 +-
- .../browser/renderer_host/navigation_request.cc |  1 -
- content/renderer/render_frame_impl.cc           | 17 +----------------
- .../shell/common/shell_origin_trial_policy.cc   | 10 ++++------
- .../renderer/core/loader/document_loader.cc     | 17 -----------------
- .../blink/renderer/core/loader/http_equiv.cc    | 14 ++------------
- .../core/origin_trials/origin_trial_context.cc  | 12 +++---------
- .../platform/runtime_enabled_features.json5     |  4 ++++
- 9 files changed, 19 insertions(+), 65 deletions(-)
+ .../origin_trials/origin_trial_policy_impl.cc |  7 ++++---
+ .../origin_trials/origin_trial_policy_impl.h  |  2 +-
+ .../renderer_host/navigation_request.cc       |  1 -
+ content/renderer/render_frame_impl.cc         | 17 +----------------
+ .../shell/common/shell_origin_trial_policy.cc | 10 ++++------
+ .../origin_trials/trial_token_validator.cc    |  1 +
+ .../renderer/core/loader/document_loader.cc   | 17 -----------------
+ .../blink/renderer/core/loader/http_equiv.cc  | 19 -------------------
+ .../origin_trials/origin_trial_context.cc     |  9 ---------
+ 9 files changed, 11 insertions(+), 72 deletions(-)
 
 diff --git a/components/embedder_support/origin_trials/origin_trial_policy_impl.cc b/components/embedder_support/origin_trials/origin_trial_policy_impl.cc
 --- a/components/embedder_support/origin_trials/origin_trial_policy_impl.cc
@@ -144,6 +144,17 @@ diff --git a/content/shell/common/shell_origin_trial_policy.cc b/content/shell/c
  }
  
  const std::vector<blink::OriginTrialPublicKey>&
+diff --git a/third_party/blink/common/origin_trials/trial_token_validator.cc b/third_party/blink/common/origin_trials/trial_token_validator.cc
+--- a/third_party/blink/common/origin_trials/trial_token_validator.cc
++++ b/third_party/blink/common/origin_trials/trial_token_validator.cc
+@@ -205,6 +205,7 @@ TrialTokenValidator::GetValidTokens(const url::Origin& origin,
+ 
+ // static
+ bool TrialTokenValidator::IsTrialPossibleOnOrigin(const GURL& url) {
++  if ((true)) return false;
+   OriginTrialPolicy* policy = PolicyGetter().Run();
+   return policy && policy->IsOriginTrialsSupported() &&
+          policy->IsOriginSecure(url);
 diff --git a/third_party/blink/renderer/core/loader/document_loader.cc b/third_party/blink/renderer/core/loader/document_loader.cc
 --- a/third_party/blink/renderer/core/loader/document_loader.cc
 +++ b/third_party/blink/renderer/core/loader/document_loader.cc
@@ -193,44 +204,36 @@ diff --git a/third_party/blink/renderer/core/loader/document_loader.cc b/third_p
 diff --git a/third_party/blink/renderer/core/loader/http_equiv.cc b/third_party/blink/renderer/core/loader/http_equiv.cc
 --- a/third_party/blink/renderer/core/loader/http_equiv.cc
 +++ b/third_party/blink/renderer/core/loader/http_equiv.cc
-@@ -106,23 +106,13 @@ void HttpEquiv::ProcessHttpEquivOriginTrial(LocalDOMWindow* window,
+@@ -104,25 +104,6 @@ void HttpEquiv::ProcessHttpEquivDefaultStyle(Document& document,
+ 
+ void HttpEquiv::ProcessHttpEquivOriginTrial(LocalDOMWindow* window,
                                              const AtomicString& content) {
-   if (!window)
-     return;
+-  if (!window)
+-    return;
 -  // For meta tags injected by script, process the token with the origin of the
 -  // external script, if available.
 -  // NOTE: The external script origin is not considered security-critical. See
 -  // the comment thread in the design doc for details:
 -  // https://docs.google.com/document/d/1xALH9W7rWmX0FpjudhDeS2TNTEOXuPn4Tlc9VmuPdHA/edit?disco=AAAAJyG8StI
 -  KURL external_script_url(GetCurrentScriptUrl(/*max_stack_depth=*/1));
- 
+-
 -  if (external_script_url.IsValid()) {
 -    scoped_refptr<SecurityOrigin> external_origin =
 -        SecurityOrigin::Create(external_script_url);
 -    window->GetOriginTrialContext()->AddTokenFromExternalScript(
 -        content, external_origin.get());
-+  if (!RuntimeEnabledFeatures::ThirdPartyOriginTrialsEnabled())
-     return;
+-    return;
 -  }
- 
-   // Process token as usual, without an external script origin.
-   window->GetOriginTrialContext()->AddToken(content);
-+
+-
+-  // Process token as usual, without an external script origin.
+-  window->GetOriginTrialContext()->AddToken(content);
  }
  
  void HttpEquiv::ProcessHttpEquivRefresh(LocalDOMWindow* window,
 diff --git a/third_party/blink/renderer/core/origin_trials/origin_trial_context.cc b/third_party/blink/renderer/core/origin_trials/origin_trial_context.cc
 --- a/third_party/blink/renderer/core/origin_trials/origin_trial_context.cc
 +++ b/third_party/blink/renderer/core/origin_trials/origin_trial_context.cc
-@@ -30,6 +30,7 @@
- #include "third_party/blink/renderer/platform/bindings/origin_trial_features.h"
- #include "third_party/blink/renderer/platform/bindings/script_state.h"
- #include "third_party/blink/renderer/platform/instrumentation/histogram.h"
-+#include "third_party/blink/renderer/platform/runtime_enabled_features.h"
- #include "third_party/blink/renderer/platform/weborigin/security_origin.h"
- #include "third_party/blink/renderer/platform/wtf/text/string_builder.h"
- #include "third_party/blink/renderer/platform/wtf/text/string_utf8_adaptor.h"
-@@ -277,13 +278,8 @@ void OriginTrialContext::AddToken(const String& token) {
+@@ -277,13 +277,6 @@ void OriginTrialContext::AddToken(const String& token) {
  void OriginTrialContext::AddTokenFromExternalScript(
      const String& token,
      const SecurityOrigin* origin) {
@@ -241,12 +244,10 @@ diff --git a/third_party/blink/renderer/core/origin_trials/origin_trial_context.
 -  }
 -  AddTokenInternal(token, GetSecurityOrigin(), IsSecureContext(), origin,
 -                   is_script_origin_secure);
-+  AddTokenInternal(token, GetSecurityOrigin(), IsSecureContext(), nullptr,
-+                   false /* is_script_origin_secure */);
  }
  
  void OriginTrialContext::AddTokenInternal(const String& token,
-@@ -395,8 +391,6 @@ bool OriginTrialContext::InstallSettingFeature(
+@@ -395,8 +388,6 @@ bool OriginTrialContext::InstallSettingFeature(
  }
  
  void OriginTrialContext::AddFeature(OriginTrialFeature feature) {
@@ -255,19 +256,5 @@ diff --git a/third_party/blink/renderer/core/origin_trials/origin_trial_context.
  }
  
  bool OriginTrialContext::IsFeatureEnabled(OriginTrialFeature feature) const {
-diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 b/third_party/blink/renderer/platform/runtime_enabled_features.json5
---- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
-+++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
-@@ -2272,6 +2272,10 @@
-       name: "TextFragmentTapOpensContextMenu",
-       status: {"Android": "stable"},
-     },
-+    {
-+      name: "ThirdPartyOriginTrials",
-+      status: "stable",
-+    },
-     {
-       name: "ThrottleDisplayNoneAndVisibilityHiddenCrossOriginIframes",
-       status: "experimental",
 --
 2.25.1


### PR DESCRIPTION
based on the research I have done, unfortunately it is still possible to activate origin trials.
in particular, the static method `TrialTokenValidator::IsTrialPossibleOnOrigin()` must be disabled.
also the assumption that I had made about the source is not correct, so it is necessary to inhibit also `ProcessHttpEquivOriginTrial`