### PR TITLE
Add Disable-ua-full-version.patch

### DIFF
--- a/build/patches/Disable-ua-full-version.patch
+++ b/build/patches/Disable-ua-full-version.patch
@@ -1,0 +1,64 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Wed, 16 Feb 2022 14:28:58 +0000
+Subject: Disable ua full version in getHighEntropyValues()
+
+getHighEntropyValues returns only the major version
+---
+ .../renderer/core/frame/navigator_ua_data.cc  | 22 +++++++++++++++++--
+ 1 file changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/third_party/blink/renderer/core/frame/navigator_ua_data.cc b/third_party/blink/renderer/core/frame/navigator_ua_data.cc
+--- a/third_party/blink/renderer/core/frame/navigator_ua_data.cc
++++ b/third_party/blink/renderer/core/frame/navigator_ua_data.cc
+@@ -6,6 +6,7 @@
+ 
+ #include "base/compiler_specific.h"
+ #include "base/task/single_thread_task_runner.h"
++#include "base/version.h"
+ #include "third_party/blink/public/common/privacy_budget/identifiability_metric_builder.h"
+ #include "third_party/blink/public/common/privacy_budget/identifiability_study_settings.h"
+ #include "third_party/blink/public/common/privacy_budget/identifiable_surface.h"
+@@ -37,6 +38,23 @@ void MaybeRecordMetric(bool record_identifiability,
+       .Record(execution_context->UkmRecorder());
+ }
+ 
++const String GetReducedVersionNumber(const std::string& fullVersion) {
++  base::Version version(fullVersion);
++  std::string version_str;
++  const std::vector<uint32_t>& components = version.components();
++  for (size_t i = 0; i < components.size(); ++i) {
++    if (i > 0) {
++      version_str.append(".");
++    }
++    if (i == 0) {
++      version_str.append(base::NumberToString(components[0]));
++    } else {
++      version_str.append("0");
++    }
++  }
++  return String::FromUTF8(version_str);
++}
++
+ }  // namespace
+ 
+ NavigatorUAData::NavigatorUAData(ExecutionContext* context)
+@@ -75,7 +93,7 @@ void NavigatorUAData::SetFullVersionList(
+     const UserAgentBrandList& full_version_list) {
+   for (const auto& brand_version : full_version_list) {
+     AddBrandFullVersion(String::FromUTF8(brand_version.brand),
+-                        String::FromUTF8(brand_version.version));
++        GetReducedVersionNumber(brand_version.version));
+   }
+ }
+ 
+@@ -97,7 +115,7 @@ void NavigatorUAData::SetModel(const String& model) {
+ }
+ 
+ void NavigatorUAData::SetUAFullVersion(const String& ua_full_version) {
+-  ua_full_version_ = ua_full_version;
++  ua_full_version_ = GetReducedVersionNumber(ua_full_version.Ascii());
+ }
+ 
+ void NavigatorUAData::SetBitness(const String& bitness) {
+--
+2.25.1

--- a/build/patches/Disable-ua-full-version.patch
+++ b/build/patches/Disable-ua-full-version.patch
@@ -4,21 +4,22 @@ Subject: Disable ua full version in getHighEntropyValues()
 
 getHighEntropyValues returns only the major version
 ---
- .../renderer/core/frame/navigator_ua_data.cc  | 22 +++++++++++++++++--
- 1 file changed, 20 insertions(+), 2 deletions(-)
+ .../renderer/core/frame/navigator_ua_data.cc     | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
 
 diff --git a/third_party/blink/renderer/core/frame/navigator_ua_data.cc b/third_party/blink/renderer/core/frame/navigator_ua_data.cc
 --- a/third_party/blink/renderer/core/frame/navigator_ua_data.cc
 +++ b/third_party/blink/renderer/core/frame/navigator_ua_data.cc
-@@ -6,6 +6,7 @@
+@@ -6,6 +6,8 @@
  
  #include "base/compiler_specific.h"
  #include "base/task/single_thread_task_runner.h"
 +#include "base/version.h"
++#include "base/strings/strcat.h"
  #include "third_party/blink/public/common/privacy_budget/identifiability_metric_builder.h"
  #include "third_party/blink/public/common/privacy_budget/identifiability_study_settings.h"
  #include "third_party/blink/public/common/privacy_budget/identifiable_surface.h"
-@@ -37,6 +38,23 @@ void MaybeRecordMetric(bool record_identifiability,
+@@ -37,6 +39,16 @@ void MaybeRecordMetric(bool record_identifiability,
        .Record(execution_context->UkmRecorder());
  }
  
@@ -26,15 +27,8 @@ diff --git a/third_party/blink/renderer/core/frame/navigator_ua_data.cc b/third_
 +  base::Version version(fullVersion);
 +  std::string version_str;
 +  const std::vector<uint32_t>& components = version.components();
-+  for (size_t i = 0; i < components.size(); ++i) {
-+    if (i > 0) {
-+      version_str.append(".");
-+    }
-+    if (i == 0) {
-+      version_str.append(base::NumberToString(components[0]));
-+    } else {
-+      version_str.append("0");
-+    }
++  if (components.size() > 0) {
++    version_str = base::StrCat({base::NumberToString(components[0]), ".0.0.0"});
 +  }
 +  return String::FromUTF8(version_str);
 +}
@@ -42,7 +36,7 @@ diff --git a/third_party/blink/renderer/core/frame/navigator_ua_data.cc b/third_
  }  // namespace
  
  NavigatorUAData::NavigatorUAData(ExecutionContext* context)
-@@ -75,7 +93,7 @@ void NavigatorUAData::SetFullVersionList(
+@@ -75,7 +87,7 @@ void NavigatorUAData::SetFullVersionList(
      const UserAgentBrandList& full_version_list) {
    for (const auto& brand_version : full_version_list) {
      AddBrandFullVersion(String::FromUTF8(brand_version.brand),
@@ -51,7 +45,7 @@ diff --git a/third_party/blink/renderer/core/frame/navigator_ua_data.cc b/third_
    }
  }
  
-@@ -97,7 +115,7 @@ void NavigatorUAData::SetModel(const String& model) {
+@@ -97,7 +109,7 @@ void NavigatorUAData::SetModel(const String& model) {
  }
  
  void NavigatorUAData::SetUAFullVersion(const String& ua_full_version) {


### PR DESCRIPTION
As agreed, the patch that modifies `getHighEntropyValues()` returning only the major version.

fixes #1781 