### PR TITLE
Fix for contextual search manager removal patch

### DIFF
--- a/build/patches/Remove-contextual-search-manager.patch
+++ b/build/patches/Remove-contextual-search-manager.patch
@@ -47,9 +47,10 @@ Subject: Remove contextual search manager
  ...nfiguration_policy_handler_list_factory.cc |   6 +-
  .../strings/android_chrome_strings.grd        |  49 ----------
  components/BUILD.gn                           |   1 -
+ content/browser/browser_interface_binders.cc  |   1 -
  third_party/blink/public/mojom/BUILD.gn       |   2 +-
  third_party/blink/public/public_features.gni  |   2 +-
- 46 files changed, 17 insertions(+), 855 deletions(-)
+ 47 files changed, 17 insertions(+), 856 deletions(-)
  delete mode 100644 chrome/android/java/res/drawable-hdpi/contextual_search_promo_ripple.9.png
  delete mode 100644 chrome/android/java/res/drawable-mdpi/contextual_search_promo_ripple.9.png
  delete mode 100644 chrome/android/java/res/drawable-xhdpi/contextual_search_promo_ripple.9.png
@@ -1750,6 +1751,17 @@ diff --git a/components/BUILD.gn b/components/BUILD.gn
        "//components/continuous_search/browser:unit_tests",
        "//components/continuous_search/common:unit_tests",
        "//components/data_use_measurement/core:unit_tests",
+diff --git a/content/browser/browser_interface_binders.cc b/content/browser/browser_interface_binders.cc
+--- a/content/browser/browser_interface_binders.cc
++++ b/content/browser/browser_interface_binders.cc
+@@ -160,7 +160,6 @@
+ #include "content/browser/renderer_host/render_widget_host_view_android.h"
+ #include "services/device/public/mojom/nfc.mojom.h"
+ #include "third_party/blink/public/mojom/hid/hid.mojom.h"
+-#include "third_party/blink/public/mojom/unhandled_tap_notifier/unhandled_tap_notifier.mojom.h"
+ #else  // BUILDFLAG(IS_ANDROID)
+ #include "content/browser/direct_sockets/direct_sockets_service_impl.h"
+ #include "media/mojo/mojom/speech_recognition_service.mojom.h"
 diff --git a/third_party/blink/public/mojom/BUILD.gn b/third_party/blink/public/mojom/BUILD.gn
 --- a/third_party/blink/public/mojom/BUILD.gn
 +++ b/third_party/blink/public/mojom/BUILD.gn


### PR DESCRIPTION
As mentioned in https://github.com/bromite/bromite/commit/47d0d4f9f8e3443a2204f7bbebcd83b068d6debd#commitcomment-69463652, this is needed to avoid the following build error:
```
[41721/51515] CXX obj/content/browser/browser/browser_interface_binders.o
FAILED: obj/content/browser/browser/browser_interface_binders.o 
../../third_party/llvm-build/Release+Asserts/bin/clang++ -MMD -MF obj/content/browser/browser/browser_interface_binders.o.d -DOFFICIAL_BUILD -D_GNU_SOURCE -DANDROID -DHAVE_SYS_UIO_H -DANDROID_NDK_VERSION_ROLL=r22_1 -DCR_CLANG_REVISION=\"llvmorg-14-init-12719-gc4b45eeb-3\" -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D_LIBCPP_ABI_UNSTABLE -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCPP_ENABLE_NODISCARD -DCR_LIBCXX_REVISION=79a2e924d96e2fc1e4b937c42efd08898fa472d7 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DCONTENT_IMPLEMENTATION -DV8_USE_EXTERNAL_STARTUP_DATA -DWEBP_EXTERN=extern -DUSE_EGL -DVK_USE_PLATFORM_ANDROID_KHR -D_WTL_NO_AUTOMATIC_NAMESPACE -DGOOGLE_PROTOBUF_NO_RTTI -DGOOGLE_PROTOBUF_NO_STATIC_INITIALIZER -DHAVE_PTHREAD -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DUSE_CHROMIUM_ICU=1 -DU_ENABLE_TRACING=1 -DU_ENABLE_RESOURCE_TRACING=0 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_FILE -DSK_CODEC_DECODES_PNG -DSK_CODEC_DECODES_WEBP -DSK_ENCODE_PNG -DSK_ENCODE_WEBP -DSK_ENABLE_SKSL -DSK_UNTIL_CRBUG_1187654_IS_FIXED -DSK_USER_CONFIG_HEADER=\"../../skia/config/SkUserConfig.h\" -DSK_WIN_FONTMGR_NO_SIMULATIONS -DSK_GL -DSK_CODEC_DECODES_JPEG -DSK_ENCODE_JPEG -DSK_HAS_WUFFS_LIBRARY -DSK_VULKAN=1 -DSK_SUPPORT_GPU=1 -DSK_GPU_WORKAROUNDS_HEADER=\"gpu/config/gpu_driver_bug_workaround_autogen.h\" -DSK_BUILD_FOR_ANDROID -DUSE_CHROMIUM_SKIA -DWEBRTC_ENABLE_AVX2 -DWEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=0 -DWEBRTC_CHROMIUM_BUILD -DWEBRTC_POSIX -DWEBRTC_LINUX -DWEBRTC_ANDROID -DABSL_ALLOCATOR_NOTHROW=1 -DWEBRTC_USE_BUILTIN_ISAC_FIX=0 -DWEBRTC_USE_BUILTIN_ISAC_FLOAT=1 -DWEBRTC_HAVE_SCTP -DNO_MAIN_THREAD_WRAPPING -DLEVELDB_PLATFORM_CHROMIUM=1 -DV8_COMPRESS_POINTERS -DV8_COMPRESS_POINTERS_IN_SHARED_CAGE -DV8_31BIT_SMIS_ON_64BIT_ARCH -DV8_SANDBOX -DV8_DEPRECATION_WARNINGS -DCPPGC_CAGED_HEAP -DSQLITE_OMIT_ANALYZE -DSQLITE_OMIT_AUTOINIT -DSQLITE_OMIT_AUTOMATIC_INDEX -DSQLITE_OMIT_AUTORESET -DSQLITE_OMIT_COMPILEOPTION_DIAGS -DSQLITE_OMIT_COMPLETE -DSQLITE_OMIT_EXPLAIN -DSQLITE_OMIT_GET_TABLE -DSQLITE_OMIT_INTROSPECTION_PRAGMAS -DSQLITE_DEFAULT_LOOKASIDE=0,0 -DSQLITE_OMIT_LOOKASIDE -DSQLITE_OMIT_TCL_VARIABLE -DSQLITE_OMIT_REINDEX -DSQLITE_OMIT_TRACE -DSQLITE_OMIT_UPSERT -DSQLITE_OMIT_WINDOWFUNC -DSQLITE_ENABLE_FTS3 -DSQLITE_DISABLE_FTS3_UNICODE -DSQLITE_DISABLE_FTS4_DEFERRED -DSQLITE_ENABLE_ICU -DSQLITE_SECURE_DELETE -DSQLITE_THREADSAFE=1 -DSQLITE_MAX_WORKER_THREADS=0 -DSQLITE_MAX_MMAP_SIZE=268435456 -DSQLITE_DEFAULT_FILE_PERMISSIONS=0600 -DSQLITE_DEFAULT_LOCKING_MODE=1 -DSQLITE_DEFAULT_MEMSTATUS=1 -DSQLITE_DEFAULT_PAGE_SIZE=4096 -DSQLITE_DEFAULT_PCACHE_INITSZ=0 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS -DSQLITE_OMIT_DEPRECATED -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_SHARED_CACHE -DSQLITE_USE_ALLOCA -DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_HAVE_ISNAN -DSQLITE_ENABLE_BATCH_ATOMIC_WRITE -DSQLITE_TEMP_STORE=3 -DSQLITE_ENABLE_LOCKING_STYLE=0 -DFT_CONFIG_MODULES_H=\"freetype-custom/freetype/config/ftmodule.h\" -DFT_CONFIG_OPTIONS_H=\"freetype-custom/freetype/config/ftoption.h\" -DWITHOUT_HARFBUZZ -DCHROMIUM_RESTRICT_VISIBILITY -DWTF_USE_LOW_QUALITY_IMAGE_INTERPOLATION=1 -DWTF_USE_WEBAUDIO_PFFFT=1 -DVK_NO_PROTOTYPES -I../.. -Igen -I../../buildtools/third_party/libc++ -I../../third_party/perfetto/include -Igen/third_party/perfetto/build_config -Igen/third_party/perfetto -I../../third_party/libwebp/src -I../../third_party/vulkan-deps/vulkan-headers/src/include -I../../third_party/khronos -I../../gpu -I../../third_party/libyuv/include -I../../third_party/jsoncpp/source/include -Igen/third_party/dawn/src/include -I../../third_party/dawn/src/include -I../../third_party/wtl/include -I../../third_party/abseil-cpp -I../../third_party/boringssl/src/include -I../../third_party/protobuf/src -Igen/protoc_out -I../../third_party/ced/src -I../../third_party/icu/source/common -I../../third_party/icu/source/i18n -I../../third_party/skia -I../../third_party/wuffs/src/release/c -I../../third_party/vulkan/include -I../../third_party/mesa_headers -Igen/net/third_party/quiche/src -I../../net/third_party/quiche/overrides -I../../net/third_party/quiche/src/common/platform/default -I../../net/third_party/quiche/src -I../../third_party/webrtc_overrides -I../../third_party/webrtc -Igen/third_party/webrtc -I../../third_party/libwebm/source -I../../third_party/leveldatabase -I../../third_party/leveldatabase/src -I../../third_party/leveldatabase/src/include -Igen/third_party/metrics_proto -I../../third_party/zlib -I../../v8/include -Igen/v8/include -I../../third_party/brotli/include -I../../third_party/distributed_point_functions -I../../third_party/distributed_point_functions/code -Igen/third_party/distributed_point_functions -I../../third_party/re2/src -I../../third_party/freetype/include -I../../third_party/freetype/include/freetype-custom -I../../third_party/freetype/src/include -I../../third_party/harfbuzz-ng/src/src -fprofile-sample-use=../../chrome/android/profiles/afdo.prof -fprofile-sample-accurate -fno-delete-null-pointer-checks -fno-ident -fno-strict-aliasing -fstack-protector-strong -fwrapv -ftrivial-auto-var-init=zero -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang -Wno-unused-command-line-argument -funwind-tables -fPIC -fcolor-diagnostics -fmerge-all-constants -fcrash-diagnostics-dir=../../tools/clang/crashreports -mllvm -instcombine-lower-dbg-declare=0 -ffp-contract=off -flto=thin -fsplit-lto-unit -fwhole-program-vtables -fcomplete-member-pointers -ffunction-sections -fno-short-enums --target=aarch64-linux-android23 -mno-outline-atomics -mno-outline -ffile-compilation-dir=. -no-canonical-prefixes -Wall -Wextra -Wimplicit-fallthrough -Wunreachable-code-aggressive -Wthread-safety -Wextra-semi -Wno-missing-field-initializers -Wno-unused-parameter -Wloop-analysis -Wno-unneeded-internal-declaration -Wenum-compare-conditional -Wno-psabi -Wno-ignored-pragma-optimize -Wshadow -Oz -fdata-sections -ffunction-sections -fno-unique-section-names -fno-omit-frame-pointer -g0 -fsanitize=cfi-vcall -fsanitize-ignorelist=../../tools/cfi/ignores.txt -fsanitize=cfi-derived-cast -fsanitize=cfi-unrelated-cast -fvisibility=hidden -Xclang -add-plugin -Xclang find-bad-constructs -Xclang -plugin-arg-find-bad-constructs -Xclang raw-ptr-template-as-trivial-member -Xclang -plugin-arg-find-bad-constructs -Xclang use-classify-type -Xclang -plugin-arg-find-bad-constructs -Xclang check-ipc -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wexit-time-destructors -DPROTOBUF_ALLOW_DEPRECATED=1 -Wno-shadow -std=c++17 -Wno-trigraphs -fno-aligned-new -fno-exceptions -fno-rtti -nostdinc++ -isystem../../buildtools/third_party/libc++/trunk/include -isystem../../buildtools/third_party/libc++abi/trunk/include --sysroot=../../third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot -fvisibility-inlines-hidden -Wno-deprecated-declarations -c ../../content/browser/browser_interface_binders.cc -o obj/content/browser/browser/browser_interface_binders.o
../../content/browser/browser_interface_binders.cc:163:10: fatal error: 'third_party/blink/public/mojom/unhandled_tap_notifier/unhandled_tap_notifier.mojom.h' file not found
#include "third_party/blink/public/mojom/unhandled_tap_notifier/unhandled_tap_notifier.mojom.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[41738/51515] CXX obj/content/browser/browser/fenced_frame.o
ninja: build stopped: subcommand failed.
```