### PR TITLE
Fix User agent customization Patch

### DIFF
--- a/build/patches/User-agent-customization.patch
+++ b/build/patches/User-agent-customization.patch
@@ -31,14 +31,14 @@ to use the flag in the hamburger menu to navigate with a custom useragent leavin
  chrome/common/pref_names.cc                   |  13 ++
  chrome/common/pref_names.h                    |   8 +
  .../widget/RadioButtonWithEditText.java       |  11 +
- .../embedder_support/user_agent_utils.cc      |   4 +
+ .../embedder_support/user_agent_utils.cc      |  11 +
  .../navigation_controller_android.cc          |   4 +
  .../navigation_controller_android.h           |   1 +
  .../renderer_host/render_process_host_impl.cc |   1 +
  .../browser/web_contents/web_contents_impl.cc |   4 +
  .../framehost/NavigationControllerImpl.java   |   3 +-
  content/renderer/render_thread_impl.cc        |   1 -
- 31 files changed, 739 insertions(+), 14 deletions(-)
+ 31 files changed, 746 insertions(+), 14 deletions(-)
  create mode 100644 chrome/android/java/res/layout/custom_useragent_preferences.xml
  create mode 100644 chrome/android/java/res/xml/useragent_preferences.xml
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/settings/UserAgentPreferences.java
@@ -1073,7 +1073,21 @@ diff --git a/components/browser_ui/widget/android/java/src/org/chromium/componen
 diff --git a/components/embedder_support/user_agent_utils.cc b/components/embedder_support/user_agent_utils.cc
 --- a/components/embedder_support/user_agent_utils.cc
 +++ b/components/embedder_support/user_agent_utils.cc
-@@ -513,6 +513,10 @@ blink::UserAgentMetadata GetUserAgentMetadata(PrefService* pref_service) {
+@@ -347,6 +347,13 @@ std::string GetUserAgent(
+ 
+ std::string GetReducedUserAgent(
+     ForceMajorVersionToMinorPosition force_major_to_minor) {
++  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
++  if (command_line->HasSwitch(kUserAgent)) {
++    std::string ua = command_line->GetSwitchValueASCII(kUserAgent);
++    if (net::HttpUtil::IsValidHeaderValue(ua))
++      return ua;
++    LOG(WARNING) << "Ignored invalid value for flag --" << kUserAgent;
++  }
+   return content::GetReducedUserAgent(
+       base::CommandLine::ForCurrentProcess()->HasSwitch(
+           switches::kUseMobileUserAgent),
+@@ -513,6 +520,10 @@ blink::UserAgentMetadata GetUserAgentMetadata(PrefService* pref_service) {
            policy::policy_prefs::kUserAgentClientHintsGREASEUpdateEnabled);
      ua_options.force_major_to_minor = GetMajorToMinorFromPrefs(pref_service);
    }


### PR DESCRIPTION
fix the lack of use of the useragent passed by the user with reduced user agent flag active, which did not exist at the time of early development.

Fix for #1936 