### PR TITLE
Fix Move-navigation-bar-to-bottom.patch

### DIFF
--- a/build/patches/Move-navigation-bar-to-bottom.patch
+++ b/build/patches/Move-navigation-bar-to-bottom.patch
@@ -1328,7 +1328,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/BottomContai
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -6590,6 +6590,11 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -6587,6 +6587,11 @@ const FeatureEntry kFeatureEntries[] = {
       flag_descriptions::kImpulseScrollAnimationsDescription, kOsAll,
       FEATURE_VALUE_TYPE(features::kImpulseScrollAnimations)},
  
@@ -1550,7 +1550,7 @@ diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/f
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
-@@ -407,6 +407,8 @@ public abstract class ChromeFeatureList {
+@@ -408,6 +408,8 @@ public abstract class ChromeFeatureList {
      public static final String MOBILE_IDENTITY_CONSISTENCY_PROMOS =
              "MobileIdentityConsistencyPromos";
      public static final String MODAL_PERMISSION_DIALOG_VIEW = "ModalPermissionDialogView";
@@ -1802,7 +1802,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -1384,6 +1384,12 @@ Your Google account may have other forms of browsing history like searches and a
+@@ -1386,6 +1386,12 @@ Your Google account may have other forms of browsing history like searches and a
        <message name="IDS_FORCE_TABLET_UI_TITLE" desc="Title of the preference that allows the user to update force tablet UI settings.">
          Force Tablet Mode
        </message>

--- a/build/patches/Move-navigation-bar-to-bottom.patch
+++ b/build/patches/Move-navigation-bar-to-bottom.patch
@@ -18,6 +18,7 @@ Support for tablet mode is also included.
  .../tab_management/TabGroupUiProperties.java  |  6 ++-
  .../tab_management/TabGroupUiToolbarView.java | 18 +++++++
  .../tab_management/TabGroupUiViewBinder.java  |  3 ++
+ .../tab_management/TabListRecyclerView.java   | 18 ++++++-
  .../tab_management/TabSwitcherMediator.java   | 15 ++++++
  .../ChromeAccessibilitySettingsDelegate.java  | 52 +++++++++++++++++++
  .../chrome/browser/app/ChromeActivity.java    |  8 +++
@@ -52,7 +53,7 @@ Support for tablet mode is also included.
  .../flags/android/chrome_feature_list.cc      |  2 +
  .../browser/flags/CachedFeatureFlags.java     | 19 +++++++
  .../browser/flags/ChromeFeatureList.java      |  2 +
- .../chrome/browser/ui/appmenu/AppMenu.java    |  4 ++
+ .../chrome/browser/ui/appmenu/AppMenu.java    | 19 +++++++
  .../omnibox/LocationBarCoordinator.java       |  9 +++-
  .../browser/omnibox/UrlBarCoordinator.java    | 11 +++-
  .../suggestions/AutocompleteCoordinator.java  | 16 +++++-
@@ -75,7 +76,7 @@ Support for tablet mode is also included.
  .../accessibility/AccessibilitySettings.java  | 16 ++++++
  .../AccessibilitySettingsDelegate.java        |  6 +++
  .../render_widget_host_view_android.cc        |  3 ++
- 66 files changed, 674 insertions(+), 51 deletions(-)
+ 67 files changed, 706 insertions(+), 52 deletions(-)
 
 diff --git a/cc/base/features.cc b/cc/base/features.cc
 --- a/cc/base/features.cc
@@ -356,6 +357,69 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
          }
      }
  }
+diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java
+--- a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java
++++ b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java
+@@ -65,6 +65,8 @@ class TabListRecyclerView
+     public static final long BASE_ANIMATION_DURATION_MS = 218;
+     public static final long FINAL_FADE_IN_DURATION_MS = 50;
+ 
++    private boolean mIsVisible = false;
++
+     /**
+      * Field trial parameter for downsampling scaling factor.
+      */
+@@ -192,6 +194,7 @@ class TabListRecyclerView
+                 ? FINAL_FADE_IN_DURATION_MS
+                 : BASE_ANIMATION_DURATION_MS;
+ 
++        mIsVisible = true;
+         setAlpha(0);
+         setVisibility(View.VISIBLE);
+         mFadeInAnimator = ObjectAnimator.ofFloat(this, View.ALPHA, 1);
+@@ -220,6 +223,11 @@ class TabListRecyclerView
+     }
+ 
+     void setShadowVisibility(boolean shouldShowShadow) {
++        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)
++                && mIsVisible) {
++            // always show shadow
++            shouldShowShadow = true;
++        }
+         if (mShadowImageView == null) {
+             Context context = getContext();
+             mShadowImageView = new ImageView(context);
+@@ -238,7 +246,10 @@ class TabListRecyclerView
+             if (getParent() instanceof FrameLayout) {
+                 // Add shadow for grid tab switcher.
+                 FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+-                        LayoutParams.MATCH_PARENT, shadowHeight, Gravity.TOP);
++                        LayoutParams.MATCH_PARENT, shadowHeight,
++                        (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM) ?
++                            Gravity.BOTTOM :
++                            Gravity.TOP));
+                 mShadowImageView.setLayoutParams(params);
+                 mShadowImageView.setTranslationY(mShadowTopOffset);
+                 FrameLayout parent = (FrameLayout) getParent();
+@@ -265,6 +276,10 @@ class TabListRecyclerView
+ 
+     void setShadowTopOffset(int shadowTopOffset) {
+         mShadowTopOffset = shadowTopOffset;
++        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            // invert the offset since Gravity is set to BOTTOM
++            mShadowTopOffset = -mShadowTopOffset;
++        }
+ 
+         if (mShadowImageView != null && getParent() instanceof FrameLayout) {
+             // Since the shadow has no functionality, other than just existing visually, we can use
+@@ -445,6 +460,7 @@ class TabListRecyclerView
+                 mListener.finishedHiding();
+             }
+         });
++        mIsVisible = false;
+         setShadowVisibility(false);
+         mFadeOutAnimator.start();
+         if (!animate) mFadeOutAnimator.end();
 diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java
 --- a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java
 +++ b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java
@@ -1264,7 +1328,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/BottomContai
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -6587,6 +6587,11 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -6590,6 +6590,11 @@ const FeatureEntry kFeatureEntries[] = {
       flag_descriptions::kImpulseScrollAnimationsDescription, kOsAll,
       FEATURE_VALUE_TYPE(features::kImpulseScrollAnimations)},
  
@@ -1486,7 +1550,7 @@ diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/f
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
-@@ -408,6 +408,8 @@ public abstract class ChromeFeatureList {
+@@ -407,6 +407,8 @@ public abstract class ChromeFeatureList {
      public static final String MOBILE_IDENTITY_CONSISTENCY_PROMOS =
              "MobileIdentityConsistencyPromos";
      public static final String MODAL_PERMISSION_DIALOG_VIEW = "ModalPermissionDialogView";
@@ -1507,15 +1571,37 @@ diff --git a/chrome/browser/ui/android/appmenu/internal/java/src/org/chromium/ch
  import org.chromium.chrome.browser.ui.appmenu.internal.R;
  import org.chromium.components.browser_ui.styles.ChromeColors;
  import org.chromium.components.browser_ui.widget.chips.ChipView;
-@@ -522,6 +524,8 @@ class AppMenu implements OnItemClickListener, OnKeyListener, AppMenuClickHandler
-             View anchorView, @IdRes int groupDividerResourceId) {
-         anchorView.getLocationOnScreen(mTempLocation);
-         int anchorViewY = mTempLocation[1] - appDimensions.top;
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM))
-+            anchorViewY += mNegativeVerticalOffsetNotTopAnchored;
+@@ -341,6 +343,14 @@ class AppMenu implements OnItemClickListener, OnKeyListener, AppMenuClickHandler
+         int anchorViewX = tempLocation[0];
+         int anchorViewY = tempLocation[1];
  
-         int anchorViewImpactHeight = mIsByPermanentButton ? anchorView.getHeight() : 0;
++        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            // moves the view offset up by the height of the popup
++            anchorViewY -= popupHeight;
++            // fix it if it goes offscreen
++            if (anchorViewY <= negativeSoftwareVerticalOffset)
++                anchorViewY = negativeSoftwareVerticalOffset;
++        }
++
+         int[] offsets = new int[2];
+         // If we have a hardware menu button, locate the app menu closer to the estimated
+         // hardware menu button location.
+@@ -531,6 +541,15 @@ class AppMenu implements OnItemClickListener, OnKeyListener, AppMenuClickHandler
+         }
+         int availableScreenSpace = Math.max(
+                 anchorViewY, appDimensions.height() - anchorViewY - anchorViewImpactHeight);
++        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            // use all available space
++            availableScreenSpace = appDimensions.height() - anchorViewImpactHeight;
++            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N) {
++                // due to a bug in A7, the popup does not appear above the anchorview.
++                // the display is not pleasant, so we reduce the space
++                availableScreenSpace -= anchorView.getHeight();
++            }
++        }
  
+         availableScreenSpace -= (padding.bottom + footerHeight + headerHeight);
+         if (mIsByPermanentButton) availableScreenSpace -= padding.top;
 diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarCoordinator.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarCoordinator.java
 --- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarCoordinator.java
 +++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarCoordinator.java
@@ -1716,7 +1802,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -1386,6 +1386,12 @@ Your Google account may have other forms of browsing history like searches and a
+@@ -1384,6 +1384,12 @@ Your Google account may have other forms of browsing history like searches and a
        <message name="IDS_FORCE_TABLET_UI_TITLE" desc="Title of the preference that allows the user to update force tablet UI settings.">
          Force Tablet Mode
        </message>


### PR DESCRIPTION
the bug of #2011 is present in all versions because the offset of the menu is not correctly calculated and is off-screen, but only in A7 is it taken into account.
in the other android versions it automatically adjusts the offsets to make the menu be always visible.
in addition, and only in A7, the menu is not drawn correctly if the bar is docked at the bottom, for this reason I reduce the size so that it is pleasant but still functional.

Fixes #1995 #2011