### PR TITLE
Patch for allowing to match only system dark mode

### DIFF
--- a/build/patches/Follow-only-system-dark-mode.patch
+++ b/build/patches/Follow-only-system-dark-mode.patch
@@ -1,0 +1,24 @@
+From: krlvm <51774833+krlvm@users.noreply.github.com>
+Date: Mon, 4 Jul 2022 16:14:37 +0300
+Subject: Follow only system dark mode preference when theme is set to system default
+
+---
+ GlobalNightModeStateController.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/chrome/browser/ui/android/night_mode/java/src/org/chromium/chrome/browser/night_mode/GlobalNightModeStateController.java b/chrome/browser/ui/android/night_mode/java/src/org/chromium/chrome/browser/night_mode/GlobalNightModeStateController.java
+index 726e7f1..aedb911 100644
+--- a/chrome/browser/ui/android/night_mode/java/src/org/chromium/chrome/browser/night_mode/GlobalNightModeStateController.java
++++ b/chrome/browser/ui/android/night_mode/java/src/org/chromium/chrome/browser/night_mode/GlobalNightModeStateController.java
+@@ -126,7 +126,7 @@ class GlobalNightModeStateController implements NightModeStateProvider,
+     }
+ 
+     private void updateNightMode() {
+-        boolean powerSaveModeOn = mPowerSaveModeMonitor.powerSavingIsOn();
++        boolean powerSaveModeOn = false;
+         final int theme = NightModeUtils.getThemeSetting();
+         final boolean newNightModeOn = theme == ThemeType.SYSTEM_DEFAULT
+                         && (powerSaveModeOn || mSystemNightModeMonitor.isSystemNightModeOn())
+-- 
+2.25.1
+


### PR DESCRIPTION
Unlike other apps, when Chromium-based Android browsers are configured to follow system dark mode preference, they ignore the actual system preference and respect battery saver mode first of all, while most users always have power saving mode enabled, making this setting useless.

This patch forces Chromium to ignore power saving mode when choosing a theme, making its behavior consistent with the rest of the apps, including the system and Google apps that follow actual system theme on Android 10 and above in the first place.