### PR TITLE
Remove navigator.connection info

### DIFF
--- a/build/patches/Remove-navigator-connection-info.patch
+++ b/build/patches/Remove-navigator-connection-info.patch
@@ -1,21 +1,97 @@
 From: uazo <uazo@users.noreply.github.com>
-Date: Wed, 6 Jul 2022 10:18:16 +0000
+Date: Thu, 14 Jul 2022 09:48:45 +0000
 Subject: Remove navigator.connection info
 
+Change the result of navigator.connection to default values 
+and disable observers
 ---
- .../blink/renderer/modules/netinfo/network_information.cc        | 1 +
- 1 file changed, 1 insertion(+)
+ .../renderer/modules/netinfo/network_information.cc   |  7 ++++++-
+ .../renderer/modules/netinfo/network_information.h    |  1 +
+ .../platform/network/network_state_notifier.cc        | 11 +++++++++++
+ .../platform/network/network_state_notifier.h         |  2 +-
+ 4 files changed, 19 insertions(+), 2 deletions(-)
 
 diff --git a/third_party/blink/renderer/modules/netinfo/network_information.cc b/third_party/blink/renderer/modules/netinfo/network_information.cc
 --- a/third_party/blink/renderer/modules/netinfo/network_information.cc
 +++ b/third_party/blink/renderer/modules/netinfo/network_information.cc
-@@ -261,6 +261,7 @@ void NetworkInformation::StopObserving() {
- const char NetworkInformation::kSupplementName[] = "NetworkInformation";
+@@ -61,7 +61,7 @@ NetworkInformation::~NetworkInformation() {
+ }
  
- NetworkInformation* NetworkInformation::connection(NavigatorBase& navigator) {
-+  if ((true)) return nullptr;
-   if (!navigator.GetExecutionContext())
-     return nullptr;
-   NetworkInformation* supplement =
+ bool NetworkInformation::IsObserving() const {
+-  return !!connection_observer_handle_;
++  return !!connection_observer_handle_ || is_fake_observing_;
+ }
+ 
+ String NetworkInformation::type() const {
+@@ -147,6 +147,7 @@ void NetworkInformation::ConnectionChange(
+     const absl::optional<base::TimeDelta>& transport_rtt,
+     const absl::optional<double>& downlink_mbps,
+     bool save_data) {
++  if ((true)) return;
+   DCHECK(GetExecutionContext()->IsContextThread());
+ 
+   const String host = Host();
+@@ -242,6 +243,8 @@ void NetworkInformation::ContextDestroyed() {
+ }
+ 
+ void NetworkInformation::StartObserving() {
++  is_fake_observing_ = true;
++  if ((true)) return;
+   if (!IsObserving() && !context_stopped_) {
+     type_ = GetNetworkStateNotifier().ConnectionType();
+     DCHECK(!connection_observer_handle_);
+@@ -252,6 +255,8 @@ void NetworkInformation::StartObserving() {
+ }
+ 
+ void NetworkInformation::StopObserving() {
++  is_fake_observing_ = false;
++  if ((true)) return;
+   if (IsObserving()) {
+     DCHECK(connection_observer_handle_);
+     connection_observer_handle_ = nullptr;
+diff --git a/third_party/blink/renderer/modules/netinfo/network_information.h b/third_party/blink/renderer/modules/netinfo/network_information.h
+--- a/third_party/blink/renderer/modules/netinfo/network_information.h
++++ b/third_party/blink/renderer/modules/netinfo/network_information.h
+@@ -118,6 +118,7 @@ class NetworkInformation final
+ 
+   std::unique_ptr<NetworkStateNotifier::NetworkStateObserverHandle>
+       connection_observer_handle_;
++  bool is_fake_observing_ = false;
+ };
+ 
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/platform/network/network_state_notifier.cc b/third_party/blink/renderer/platform/network/network_state_notifier.cc
+--- a/third_party/blink/renderer/platform/network/network_state_notifier.cc
++++ b/third_party/blink/renderer/platform/network/network_state_notifier.cc
+@@ -522,6 +522,17 @@ NetworkStateNotifier::GetWebHoldbackDownlinkThroughputMbps() const {
+   return absl::nullopt;
+ }
+ 
++NetworkStateNotifier::NetworkStateNotifier() : has_override_(false) {
++  // set default data
++  // see third_party/blink/renderer/platform/network/network_state_notifier_test.cc
++  SetNetworkConnectionInfoOverride(
++    /*on_line*/true,
++    /*type*/WebConnectionType::kWebConnectionTypeUnknown,
++    /*effective_type*/absl::nullopt,
++    /*http_rtt_msec*/0,
++    /*max_bandwidth_mbps*/0);
++}
++
+ void NetworkStateNotifier::GetMetricsWithWebHoldback(
+     WebConnectionType* type,
+     double* downlink_max_mbps,
+diff --git a/third_party/blink/renderer/platform/network/network_state_notifier.h b/third_party/blink/renderer/platform/network/network_state_notifier.h
+--- a/third_party/blink/renderer/platform/network/network_state_notifier.h
++++ b/third_party/blink/renderer/platform/network/network_state_notifier.h
+@@ -122,7 +122,7 @@ class PLATFORM_EXPORT NetworkStateNotifier {
+     scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
+   };
+ 
+-  NetworkStateNotifier() : has_override_(false) {}
++  NetworkStateNotifier();
+   NetworkStateNotifier(const NetworkStateNotifier&) = delete;
+   NetworkStateNotifier& operator=(const NetworkStateNotifier&) = delete;
+ 
 --
 2.25.1

--- a/build/patches/Remove-navigator-connection-info.patch
+++ b/build/patches/Remove-navigator-connection-info.patch
@@ -1,0 +1,21 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Wed, 6 Jul 2022 10:18:16 +0000
+Subject: Remove navigator.connection info
+
+---
+ .../blink/renderer/modules/netinfo/network_information.cc        | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/third_party/blink/renderer/modules/netinfo/network_information.cc b/third_party/blink/renderer/modules/netinfo/network_information.cc
+--- a/third_party/blink/renderer/modules/netinfo/network_information.cc
++++ b/third_party/blink/renderer/modules/netinfo/network_information.cc
+@@ -261,6 +261,7 @@ void NetworkInformation::StopObserving() {
+ const char NetworkInformation::kSupplementName[] = "NetworkInformation";
+ 
+ NetworkInformation* NetworkInformation::connection(NavigatorBase& navigator) {
++  if ((true)) return nullptr;
+   if (!navigator.GetExecutionContext())
+     return nullptr;
+   NetworkInformation* supplement =
+--
+2.25.1


### PR DESCRIPTION
since it is a fingerprinting surface, it makes sense to remove the result of `navigator.connection`