### PR TITLE
Partitioning Blink memory cache

### DIFF
--- a/build/patches/Partitioning-Blink-memory-cache.patch
+++ b/build/patches/Partitioning-Blink-memory-cache.patch
@@ -1,0 +1,194 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Wed, 6 Jul 2022 10:15:20 +0000
+Subject: Partitioning Blink memory cache
+
+---
+ .../core/html/parser/html_srcset_parser.cc    |  2 +-
+ .../core/inspector/inspector_network_agent.cc |  2 +-
+ .../core/inspector/inspector_page_agent.cc    |  5 +++--
+ .../renderer/core/loader/image_loader.cc      |  3 ++-
+ .../platform/loader/fetch/memory_cache.cc     |  7 ++-----
+ .../platform/loader/fetch/memory_cache.h      |  4 ++--
+ .../platform/loader/fetch/resource_fetcher.cc | 21 ++++++++++++-------
+ .../platform/loader/fetch/resource_fetcher.h  |  3 ++-
+ 8 files changed, 27 insertions(+), 20 deletions(-)
+
+diff --git a/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc b/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc
+--- a/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc
++++ b/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc
+@@ -413,7 +413,7 @@ static unsigned AvoidDownloadIfHigherDensityResourceIsInCache(
+     KURL url = document->CompleteURL(
+         StripLeadingAndTrailingHTMLSpaces(image_candidates[i]->Url()));
+     if (GetMemoryCache()->ResourceForURL(
+-            url, document->Fetcher()->GetCacheIdentifier(url)) ||
++            url, document->Fetcher()->GetCacheIdentifier(url, document->TopFrameOrigin())) ||
+         url.ProtocolIsData())
+       return i;
+   }
+diff --git a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+--- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
++++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
+@@ -2208,7 +2208,7 @@ bool InspectorNetworkAgent::FetchResourceContent(Document* document,
+   Resource* cached_resource = document->Fetcher()->CachedResource(url);
+   if (!cached_resource) {
+     cached_resource = GetMemoryCache()->ResourceForURL(
+-        url, document->Fetcher()->GetCacheIdentifier(url));
++        url, document->Fetcher()->GetCacheIdentifier(url, document->TopFrameOrigin()));
+   }
+   if (cached_resource && InspectorPageAgent::CachedResourceContent(
+                              cached_resource, content, base64_encoded))
+diff --git a/third_party/blink/renderer/core/inspector/inspector_page_agent.cc b/third_party/blink/renderer/core/inspector/inspector_page_agent.cc
+--- a/third_party/blink/renderer/core/inspector/inspector_page_agent.cc
++++ b/third_party/blink/renderer/core/inspector/inspector_page_agent.cc
+@@ -166,9 +166,10 @@ Resource* CachedResource(LocalFrame* frame,
+   if (!document)
+     return nullptr;
+   Resource* cached_resource = document->Fetcher()->CachedResource(url);
+-  if (!cached_resource) {
++  if (!cached_resource && document->TopFrameOrigin()) {
+     cached_resource = GetMemoryCache()->ResourceForURL(
+-        url, document->Fetcher()->GetCacheIdentifier(url));
++        url, document->Fetcher()->GetCacheIdentifier(url,
++          document->TopFrameOrigin()));
+   }
+   if (!cached_resource)
+     cached_resource = loader->ResourceForURL(url);
+diff --git a/third_party/blink/renderer/core/loader/image_loader.cc b/third_party/blink/renderer/core/loader/image_loader.cc
+--- a/third_party/blink/renderer/core/loader/image_loader.cc
++++ b/third_party/blink/renderer/core/loader/image_loader.cc
+@@ -714,7 +714,8 @@ bool ImageLoader::ShouldLoadImmediately(const KURL& url) const {
+   // content when style recalc is over and DOM mutation is allowed again.
+   if (!url.IsNull()) {
+     Resource* resource = GetMemoryCache()->ResourceForURL(
+-        url, element_->GetDocument().Fetcher()->GetCacheIdentifier(url));
++        url, element_->GetDocument().Fetcher()->GetCacheIdentifier(url,
++                element_->GetDocument().TopFrameOrigin()));
+ 
+     if (resource && !resource->ErrorOccurred() &&
+         CanReuseFromListOfAvailableImages(
+diff --git a/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc b/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc
+--- a/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc
++++ b/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc
+@@ -196,7 +196,7 @@ void MemoryCache::RemoveInternal(ResourceMap* resource_map,
+ }
+ 
+ bool MemoryCache::Contains(const Resource* resource) const {
+-  if (!resource || resource->Url().IsEmpty())
++  if (!resource || resource->Url().IsEmpty() || resource->CacheIdentifier().IsEmpty())
+     return false;
+ 
+   const auto resource_maps_it =
+@@ -212,12 +212,9 @@ bool MemoryCache::Contains(const Resource* resource) const {
+   return resource == resources_it->value->GetResource();
+ }
+ 
+-Resource* MemoryCache::ResourceForURL(const KURL& resource_url) const {
+-  return ResourceForURL(resource_url, DefaultCacheIdentifier());
+-}
+-
+ Resource* MemoryCache::ResourceForURL(const KURL& resource_url,
+                                       const String& cache_identifier) const {
++  if (cache_identifier.IsEmpty()) return nullptr;
+   DCHECK(WTF::IsMainThread());
+   if (!resource_url.IsValid() || resource_url.IsNull())
+     return nullptr;
+diff --git a/third_party/blink/renderer/platform/loader/fetch/memory_cache.h b/third_party/blink/renderer/platform/loader/fetch/memory_cache.h
+--- a/third_party/blink/renderer/platform/loader/fetch/memory_cache.h
++++ b/third_party/blink/renderer/platform/loader/fetch/memory_cache.h
+@@ -112,9 +112,7 @@ class PLATFORM_EXPORT MemoryCache final : public GarbageCollected<MemoryCache>,
+     TypeStatistic other;
+   };
+ 
+-  Resource* ResourceForURL(const KURL&) const;
+   Resource* ResourceForURL(const KURL&, const String& cache_identifier) const;
+-  HeapVector<Member<Resource>> ResourcesForURL(const KURL&) const;
+ 
+   void Add(Resource*);
+   void Remove(Resource*);
+@@ -159,6 +157,8 @@ class PLATFORM_EXPORT MemoryCache final : public GarbageCollected<MemoryCache>,
+       base::MemoryPressureListener::MemoryPressureLevel) override;
+ 
+  private:
++   HeapVector<Member<Resource>> ResourcesForURL(const KURL&) const;
++
+   enum PruneStrategy {
+     // Automatically decide how much to prune.
+     kAutomaticPrune,
+diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
+--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
++++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
+@@ -640,7 +640,8 @@ Resource* ResourceFetcher::CreateResourceForStaticData(
+   if (!archive_ && factory.GetType() == ResourceType::kRaw)
+     return nullptr;
+ 
+-  const String cache_identifier = GetCacheIdentifier(url);
++  const String cache_identifier = GetCacheIdentifier(url,
++                          params.GetResourceRequest().TopFrameOrigin());
+   // Most off-main-thread resource fetches use Resource::kRaw and don't reach
+   // this point, but off-main-thread module fetches might.
+   if (IsMainThread()) {
+@@ -1083,7 +1084,9 @@ Resource* ResourceFetcher::RequestResource(FetchParameters& params,
+         resource = nullptr;
+       } else {
+         resource = GetMemoryCache()->ResourceForURL(
+-            params.Url(), GetCacheIdentifier(params.Url()));
++            params.Url(),
++            GetCacheIdentifier(params.Url(),
++              params.GetResourceRequest().TopFrameOrigin()));
+       }
+       if (resource) {
+         policy = DetermineRevalidationPolicy(resource_type, params, *resource,
+@@ -1291,7 +1294,8 @@ Resource* ResourceFetcher::CreateResourceForLoading(
+     const FetchParameters& params,
+     const ResourceFactory& factory) {
+   const String cache_identifier =
+-      GetCacheIdentifier(params.GetResourceRequest().Url());
++      GetCacheIdentifier(params.GetResourceRequest().Url(),
++        params.GetResourceRequest().TopFrameOrigin());
+   if (!base::FeatureList::IsEnabled(
+           blink::features::kScopeMemoryCachePerContext)) {
+     DCHECK(!IsMainThread() || params.IsStaleRevalidation() ||
+@@ -2185,13 +2189,16 @@ void ResourceFetcher::UpdateAllImageResourcePriorities() {
+   to_be_removed.clear();
+ }
+ 
+-String ResourceFetcher::GetCacheIdentifier(const KURL& url) const {
++String ResourceFetcher::GetCacheIdentifier(const KURL& url,
++              scoped_refptr<const blink::SecurityOrigin> origin) const {
++  String origin_url = origin ? origin->ToRawString() : "";
++
+   if (properties_->GetControllerServiceWorkerMode() !=
+       mojom::ControllerServiceWorkerMode::kNoController) {
+-    return String::Number(properties_->ServiceWorkerId());
++    return origin_url + "_" + String::Number(properties_->ServiceWorkerId());
+   }
+   if (properties_->WebBundlePhysicalUrl().IsValid())
+-    return properties_->WebBundlePhysicalUrl().GetString();
++    return origin_url + "_" + properties_->WebBundlePhysicalUrl().GetString();
+ 
+   // Requests that can be satisfied via `archive_` (i.e. MHTML) or
+   // `subresource_web_bundles_` should not participate in the global caching,
+@@ -2206,7 +2213,7 @@ String ResourceFetcher::GetCacheIdentifier(const KURL& url) const {
+       return bundle->GetCacheIdentifier();
+   }
+ 
+-  return MemoryCache::DefaultCacheIdentifier();
++  return origin_url;
+ }
+ 
+ void ResourceFetcher::EmulateLoadStartedForInspector(
+diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
+--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
++++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
+@@ -248,7 +248,8 @@ class PLATFORM_EXPORT ResourceFetcher
+                          uint32_t inflight_keepalive_bytes);
+   blink::mojom::ControllerServiceWorkerMode IsControlledByServiceWorker() const;
+ 
+-  String GetCacheIdentifier(const KURL& url) const;
++  String GetCacheIdentifier(const KURL& url,
++    scoped_refptr<const blink::SecurityOrigin> cache_identifier) const;
+ 
+   enum IsImageSet { kImageNotImageSet, kImageIsImageSet };
+ 
+--
+2.25.1

--- a/build/patches/Partitioning-Blink-memory-cache.patch
+++ b/build/patches/Partitioning-Blink-memory-cache.patch
@@ -1,5 +1,5 @@
 From: uazo <uazo@users.noreply.github.com>
-Date: Wed, 6 Jul 2022 10:15:20 +0000
+Date: Wed, 13 Jul 2022 14:51:09 +0000
 Subject: Partitioning Blink memory cache
 
 ---
@@ -160,11 +160,11 @@ diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.c
    if (properties_->GetControllerServiceWorkerMode() !=
        mojom::ControllerServiceWorkerMode::kNoController) {
 -    return String::Number(properties_->ServiceWorkerId());
-+    return origin_url + "_" + String::Number(properties_->ServiceWorkerId());
++    return origin_url + " " + String::Number(properties_->ServiceWorkerId());
    }
    if (properties_->WebBundlePhysicalUrl().IsValid())
 -    return properties_->WebBundlePhysicalUrl().GetString();
-+    return origin_url + "_" + properties_->WebBundlePhysicalUrl().GetString();
++    return origin_url + " " + properties_->WebBundlePhysicalUrl().GetString();
  
    // Requests that can be satisfied via `archive_` (i.e. MHTML) or
    // `subresource_web_bundles_` should not participate in the global caching,


### PR DESCRIPTION
as documented in [1127971](https://bugs.chromium.org/p/chromium/issues/detail?id=1127971), blink's in-memory cache is not partitioned.
normally this is not a problem, but in the event that the rendering process is reused, the cache can be reused to transfer information between different contexts.
a similar thing is present in [brave](https://github.com/brave/brave-core/pull/11013), but the implementation I made is different.