### PR TITLE
Remove window name on cross origin navigation

### DIFF
--- a/build/patches/Remove-window-name-on-cross-origin-navigation.patch
+++ b/build/patches/Remove-window-name-on-cross-origin-navigation.patch
@@ -1,0 +1,31 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Sat, 9 Jul 2022 06:59:18 +0000
+Subject: Remove window name on cross origin navigation
+
+see also https://trac.webkit.org/changeset/209076/webkit
+---
+ third_party/blink/renderer/core/loader/document_loader.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/third_party/blink/renderer/core/loader/document_loader.cc b/third_party/blink/renderer/core/loader/document_loader.cc
+--- a/third_party/blink/renderer/core/loader/document_loader.cc
++++ b/third_party/blink/renderer/core/loader/document_loader.cc
+@@ -2412,7 +2412,7 @@ void DocumentLoader::CommitNavigation() {
+     // that the name would be nulled and if the name is accessed after we will
+     // fire a UseCounter. If we decide to move forward with this change, we'd
+     // actually clean the name here.
+-    // frame_->tree().setName(g_null_atom);
++    frame_->Tree().SetName(g_null_atom);
+     frame_->Tree().ExperimentalSetNulledName();
+   }
+ 
+@@ -2423,6 +2423,7 @@ void DocumentLoader::CommitNavigation() {
+     // TODO(shuuran): CrossSiteCrossBrowsingContextGroupSetNulledName will just
+     // record the fact that the name would be nulled and if the name is accessed
+     // after we will fire a UseCounter.
++    frame_->Tree().SetName(g_null_atom);
+     frame_->Tree().CrossSiteCrossBrowsingContextGroupSetNulledName();
+   }
+ 
+--
+2.25.1


### PR DESCRIPTION
this is a simple revert of [Revert Implemented: remove browsing context name on cross origin navigation](https://source.chromium.org/chromium/chromium/src/+/a9d3e8b258ba21d310bf7456cd4c270e3d49e820)

```
When updating the history after a cross-origin navigation, the HTML
Standard says: "If the browsing context is a top-level browsing context,
but not an auxiliary browsing context, then set the browsing context's
name to the empty string."
 
Currently we are not doing this which means there's potential
information leak.
```
Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=706350
Spec: https://html.spec.whatwg.org/multipage/browsers.html#resetBCName
Web Test: https://wpt.fyi/results/html/browsers/windows/clear-window-name.https.html?label=master&label=experimental&aligned

> Reason for revert: There is a blocking bug for Chromebox for Meetings that this patch has introduced.

I am of the opinion that if some site does not work it does not matter, but if you deem it necessary, I can add a new site setting

furthermore, it seems to be missing anyway "Mozilla is proposing the spec change to match Safari and clear the name for noopener popups as well; currently the spec exempts popups in general from this clearing."
~~I will try to verify but first I have to understand how to launch the webtest, do you know something about it?~~ EDIT: there is the button ;)