### PR TITLE
Some changes on v103

### DIFF
--- a/build/patches/Add-option-to-force-tablet-UI.patch
+++ b/build/patches/Add-option-to-force-tablet-UI.patch
@@ -4,24 +4,24 @@ Subject: Add option to force tablet UI
 
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- .../ChromeAccessibilitySettingsDelegate.java  | 57 +++++++++++++++++++
+ .../ChromeAccessibilitySettingsDelegate.java  | 19 +++++++++++++++++++
  .../preferences/ChromePreferenceKeys.java     |  1 +
  .../LegacyChromePreferenceKeys.java           |  1 +
  .../omnibox/LocationBarCoordinator.java       |  2 +-
- .../strings/android_chrome_strings.grd        |  6 ++
- .../toolbar/top/ToolbarControlContainer.java  | 16 ------
- components/BUILD.gn                           |  6 +-
- .../res/xml/accessibility_preferences.xml     |  5 ++
- .../accessibility/AccessibilitySettings.java  | 10 ++++
- .../AccessibilitySettingsDelegate.java        |  2 +
- ui/android/BUILD.gn                           |  2 +
- .../chromium/ui/base/DeviceFormFactor.java    |  5 ++
- 12 files changed, 93 insertions(+), 20 deletions(-)
+ .../strings/android_chrome_strings.grd        |  6 ++++++
+ .../toolbar/top/ToolbarControlContainer.java  | 16 ----------------
+ components/BUILD.gn                           |  6 +++---
+ .../res/xml/accessibility_preferences.xml     |  5 +++++
+ .../accessibility/AccessibilitySettings.java  | 10 ++++++++++
+ .../AccessibilitySettingsDelegate.java        |  2 ++
+ ui/android/BUILD.gn                           |  2 ++
+ .../chromium/ui/base/DeviceFormFactor.java    |  5 +++++
+ 12 files changed, 55 insertions(+), 20 deletions(-)
 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/accessibility/settings/ChromeAccessibilitySettingsDelegate.java b/chrome/android/java/src/org/chromium/chrome/browser/accessibility/settings/ChromeAccessibilitySettingsDelegate.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/accessibility/settings/ChromeAccessibilitySettingsDelegate.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/accessibility/settings/ChromeAccessibilitySettingsDelegate.java
-@@ -67,6 +67,63 @@ public class ChromeAccessibilitySettingsDelegate implements AccessibilitySetting
+@@ -67,6 +67,25 @@ public class ChromeAccessibilitySettingsDelegate implements AccessibilitySetting
          return new ReaderForAccessibilityDelegate();
      }
  
@@ -42,44 +42,6 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/accessibility/s
 +    @Override
 +    public BooleanPreferenceDelegate getForceTabletUIDelegate() {
 +        return new ForceTabletUIDelegate();
-+    }
-+
-+    private static class MoveTopToolbarToBottomDelegate implements BooleanPreferenceDelegate {
-+        @Override
-+        public boolean isEnabled() {
-+            return CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM);
-+        }
-+
-+        @Override
-+        public void setEnabled(boolean value) {
-+            CachedFeatureFlags.setFlagEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM,
-+                    "move-top-toolbar-to-bottom", value);
-+        }
-+    }
-+
-+    @Override
-+    public BooleanPreferenceDelegate getMoveTopToolbarToBottomDelegate() {
-+        return new MoveTopToolbarToBottomDelegate();
-+    }
-+
-+    @Override
-+    public void requestRestart(Activity activity) {
-+        Snackbar mSnackbar = Snackbar.make(activity.getString(R.string.ui_relaunch_notice),
-+                new SnackbarManager.SnackbarController() {
-+                        @Override
-+                        public void onDismissNoAction(Object actionData) { }
-+
-+                        @Override
-+                        public void onAction(Object actionData) {
-+                                ApplicationLifetime.terminate(true);
-+                        }
-+                }, Snackbar.TYPE_NOTIFICATION, Snackbar.UMA_UNKNOWN)
-+                .setSingleLine(false)
-+                .setAction(activity.getString(R.string.relaunch),
-+                        /*actionData*/null)
-+                .setDuration(/*durationMs*/70000);
-+        if (!mSnackbarManager.isShowing())
-+            mSnackbarManager.showSnackbar(mSnackbar);
 +    }
 +
      @Override

--- a/build/patches/Add-webGL-site-setting.patch
+++ b/build/patches/Add-webGL-site-setting.patch
@@ -18,7 +18,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  components/components_strings.grd             |  1 +
  .../core/browser/content_settings_registry.cc | 14 +++
  .../core/browser/content_settings_utils.cc    |  2 +
- .../core/common/content_settings.cc           |  3 +-
+ .../core/common/content_settings.cc           |  4 +-
  .../core/common/content_settings.h            |  1 +
  .../core/common/content_settings.mojom        |  1 +
  .../common/content_settings_mojom_traits.cc   |  3 +-
@@ -31,7 +31,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../execution_context/execution_context.h     |  5 ++
  .../webgl/webgl_rendering_context_base.cc     | 32 +++----
  .../webgl/webgl_rendering_context_base.h      |  2 +
- 22 files changed, 196 insertions(+), 23 deletions(-)
+ 22 files changed, 197 insertions(+), 23 deletions(-)
  create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteWebGLContentSetting.java
  create mode 100644 components/browser_ui/strings/android/webgl.grdp
 
@@ -268,6 +268,14 @@ diff --git a/components/content_settings/core/common/content_settings.cc b/compo
  }
  
  void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+@@ -216,6 +217,7 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+   FilterRulesForType(auto_dark_content_rules, outermost_main_frame_url);
+   FilterRulesForType(timezone_override_rules, outermost_main_frame_url);
+   FilterRulesForType(autoplay_rules, outermost_main_frame_url);
++  FilterRulesForType(webgl_rules, outermost_main_frame_url);
+ }
+ 
+ RendererContentSettingRules::RendererContentSettingRules() = default;
 diff --git a/components/content_settings/core/common/content_settings.h b/components/content_settings/core/common/content_settings.h
 --- a/components/content_settings/core/common/content_settings.h
 +++ b/components/content_settings/core/common/content_settings.h

--- a/build/patches/Add-webRTC-site-settings.patch
+++ b/build/patches/Add-webRTC-site-settings.patch
@@ -16,7 +16,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  components/components_strings.grd             |  1 +
  .../core/browser/content_settings_registry.cc | 14 +++
  .../core/browser/content_settings_utils.cc    |  2 +
- .../core/common/content_settings.cc           |  3 +-
+ .../core/common/content_settings.cc           |  4 +-
  .../core/common/content_settings.h            |  1 +
  .../core/common/content_settings.mojom        |  1 +
  .../common/content_settings_mojom_traits.cc   |  3 +-
@@ -26,7 +26,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../renderer/content_settings_agent_impl.h    |  1 +
  .../platform/web_content_settings_client.h    |  2 +
  .../peer_connection_dependency_factory.cc     |  5 ++
- 19 files changed, 159 insertions(+), 4 deletions(-)
+ 19 files changed, 160 insertions(+), 4 deletions(-)
  create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteWebRTCContentSetting.java
  create mode 100644 components/browser_ui/strings/android/webrtc.grdp
 
@@ -264,6 +264,14 @@ diff --git a/components/content_settings/core/common/content_settings.cc b/compo
  }
  
  void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+@@ -218,6 +219,7 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+   FilterRulesForType(timezone_override_rules, outermost_main_frame_url);
+   FilterRulesForType(autoplay_rules, outermost_main_frame_url);
+   FilterRulesForType(webgl_rules, outermost_main_frame_url);
++  FilterRulesForType(webrtc_rules, outermost_main_frame_url);
+ }
+ 
+ RendererContentSettingRules::RendererContentSettingRules() = default;
 diff --git a/components/content_settings/core/common/content_settings.h b/components/content_settings/core/common/content_settings.h
 --- a/components/content_settings/core/common/content_settings.h
 +++ b/components/content_settings/core/common/content_settings.h

--- a/build/patches/Allow-building-without-enable_reporting.patch
+++ b/build/patches/Allow-building-without-enable_reporting.patch
@@ -4,7 +4,6 @@ Subject: Allow building without enable_reporting
 
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- android_webview/browser/aw_contents.cc           |  2 +-
  .../browser/devtools/protocol/network_handler.cc |  2 ++
  .../net/cross_origin_embedder_policy_reporter.cc |  4 +++-
  .../net/cross_origin_opener_policy_reporter.cc   | 16 +++++++---------
@@ -20,20 +19,8 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../blink/renderer/core/frame/local_frame.h      |  6 +++---
  .../renderer/core/frame/reporting_context.cc     |  9 +++++++++
  .../renderer/core/frame/reporting_context.h      |  7 +++++--
- 16 files changed, 49 insertions(+), 25 deletions(-)
+ 15 files changed, 48 insertions(+), 24 deletions(-)
 
-diff --git a/android_webview/browser/aw_contents.cc b/android_webview/browser/aw_contents.cc
---- a/android_webview/browser/aw_contents.cc
-+++ b/android_webview/browser/aw_contents.cc
-@@ -339,7 +339,7 @@ void AwContents::InitAutofillIfNecessary(bool autocomplete_enabled) {
-       autofill_provider
-           ? base::BindRepeating(&autofill::AndroidDriverInitHook,
-                                 AwAutofillClient::FromWebContents(web_contents),
--                                enable_download_manager, /*enable_browser_autofill_manager*/ false)
-+                                enable_download_manager)
-           : base::BindRepeating(&autofill::BrowserDriverInitHook,
-                                 AwAutofillClient::FromWebContents(web_contents),
-                                 base::android::GetDefaultLocaleString(),
 diff --git a/content/browser/devtools/protocol/network_handler.cc b/content/browser/devtools/protocol/network_handler.cc
 --- a/content/browser/devtools/protocol/network_handler.cc
 +++ b/content/browser/devtools/protocol/network_handler.cc

--- a/build/patches/Disable-all-predictors-code.patch
+++ b/build/patches/Disable-all-predictors-code.patch
@@ -9,7 +9,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../optimization_guide_keyed_service.cc       |  1 -
  chrome/common/chrome_features.cc              |  4 ++--
  .../optimization_guide/core/hints_fetcher.cc  |  1 +
- .../optimization_guide/core/hints_manager.cc  |  3 +++
+ .../optimization_guide/core/hints_manager.cc  |  4 ++++
  .../core/optimization_guide_features.cc       | 24 +++++++++----------
  .../core/prediction_model_download_manager.cc |  6 +++--
  .../core/prediction_model_fetcher_impl.cc     |  1 +
@@ -17,7 +17,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  components/permissions/features.cc            |  2 +-
  .../segmentation_platform/public/features.cc  |  2 +-
  third_party/blink/common/features.cc          |  2 +-
- 12 files changed, 28 insertions(+), 23 deletions(-)
+ 12 files changed, 29 insertions(+), 23 deletions(-)
 
 diff --git a/chrome/browser/optimization_guide/chrome_hints_manager.cc b/chrome/browser/optimization_guide/chrome_hints_manager.cc
 --- a/chrome/browser/optimization_guide/chrome_hints_manager.cc
@@ -76,7 +76,15 @@ diff --git a/components/optimization_guide/core/hints_fetcher.cc b/components/op
 diff --git a/components/optimization_guide/core/hints_manager.cc b/components/optimization_guide/core/hints_manager.cc
 --- a/components/optimization_guide/core/hints_manager.cc
 +++ b/components/optimization_guide/core/hints_manager.cc
-@@ -1211,6 +1211,9 @@ OptimizationTypeDecision HintsManager::CanApplyOptimization(
+@@ -358,6 +358,7 @@ void HintsManager::Shutdown() {
+ OptimizationGuideDecision
+ HintsManager::GetOptimizationGuideDecisionFromOptimizationTypeDecision(
+     OptimizationTypeDecision optimization_type_decision) {
++  if ((true)) return OptimizationGuideDecision::kFalse;
+   switch (optimization_type_decision) {
+     case OptimizationTypeDecision::kAllowedByOptimizationFilter:
+     case OptimizationTypeDecision::kAllowedByHint:
+@@ -1211,6 +1212,9 @@ OptimizationTypeDecision HintsManager::CanApplyOptimization(
      proto::OptimizationType optimization_type,
      OptimizationMetadata* optimization_metadata) {
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);

--- a/build/patches/Disable-conversion-measurement-api.patch
+++ b/build/patches/Disable-conversion-measurement-api.patch
@@ -21,8 +21,8 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  content/browser/storage_partition_impl.cc         |  7 +------
  content/public/browser/navigation_controller.cc   |  1 -
  third_party/blink/common/features.cc              |  2 +-
- .../platform/runtime_enabled_features.json5       |  9 ++++++++-
- 11 files changed, 30 insertions(+), 30 deletions(-)
+ .../platform/runtime_enabled_features.json5       |  7 +++++++
+ 11 files changed, 29 insertions(+), 29 deletions(-)
 
 diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
 --- a/chrome/browser/flags/android/chrome_feature_list.cc
@@ -205,14 +205,5 @@ diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 
      {
        name: "AbortSignalThrowIfAborted",
        status: "stable",
-@@ -498,7 +505,7 @@
-     {
-       // https://drafts.csswg.org/css-counter-styles/#counter-style-speak-as
-       name: "CSSAtRuleCounterStyleSpeakAsDescriptor",
--      status: "test",
-+      depends_on: ["DisabledForBromite"],
-     },
-     {
-       // https://github.com/DevSDK/calc-infinity-and-NaN/blob/master/explainer.md
 --
 2.25.1

--- a/build/patches/Disable-various-metrics.patch
+++ b/build/patches/Disable-various-metrics.patch
@@ -14,11 +14,11 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../android/ntp/most_visited_sites_bridge.cc    | 17 -----------------
  chrome/browser/browser_process_impl.cc          |  2 +-
  chrome/browser/chrome_content_browser_client.cc | 15 ---------------
- .../chrome_metrics_services_manager_client.cc   |  2 +-
+ .../chrome_metrics_services_manager_client.cc   |  4 ++--
  components/ntp_tiles/BUILD.gn                   |  3 ---
  components/ntp_tiles/most_visited_sites.cc      |  2 --
  services/metrics/public/cpp/ukm_recorder.cc     |  2 +-
- 9 files changed, 4 insertions(+), 51 deletions(-)
+ 9 files changed, 5 insertions(+), 52 deletions(-)
 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivityBase.java b/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivityBase.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivityBase.java
@@ -170,6 +170,15 @@ diff --git a/chrome/browser/metrics/chrome_metrics_services_manager_client.cc b/
  
  #if BUILDFLAG(IS_ANDROID)
  // Same as |kMetricsReportingFeature|, but this feature is associated with a
+@@ -84,7 +84,7 @@ const base::Feature kMetricsReportingFeature{"MetricsReporting",
+ // the fix to not affect the overall sampling rate, this new feature was
+ // created. See crbug/1306481.
+ const base::Feature kPostFREFixMetricsReportingFeature{
+-    "PostFREFixMetricsReporting", base::FEATURE_ENABLED_BY_DEFAULT};
++    "PostFREFixMetricsReporting", base::FEATURE_DISABLED_BY_DEFAULT};
+ #endif  // BUILDFLAG(IS_ANDROID)
+ 
+ // Name of the variations param that defines the sampling rate.
 diff --git a/components/ntp_tiles/BUILD.gn b/components/ntp_tiles/BUILD.gn
 --- a/components/ntp_tiles/BUILD.gn
 +++ b/components/ntp_tiles/BUILD.gn

--- a/build/patches/Enable-native-Android-autofill.patch
+++ b/build/patches/Enable-native-Android-autofill.patch
@@ -15,7 +15,7 @@ See also: https://github.com/bromite/bromite/issues/547
 Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- android_webview/browser/aw_contents.cc        |  5 +-
+ android_webview/browser/aw_contents.cc        |  3 +-
  chrome/android/BUILD.gn                       |  1 +
  .../settings/PasswordSettings.java            | 81 ++++++++++++++++++-
  .../chromium/chrome/browser/tab/TabImpl.java  | 50 ++++++++++++
@@ -37,17 +37,13 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../autofill/core/common/autofill_prefs.h     |  2 +
  .../embedder_support/view/ContentView.java    | 46 +++++++++++
  .../chromium/ui/base/ViewAndroidDelegate.java |  8 ++
- 22 files changed, 312 insertions(+), 14 deletions(-)
+ 22 files changed, 311 insertions(+), 13 deletions(-)
 
 diff --git a/android_webview/browser/aw_contents.cc b/android_webview/browser/aw_contents.cc
 --- a/android_webview/browser/aw_contents.cc
 +++ b/android_webview/browser/aw_contents.cc
-@@ -339,10 +339,11 @@ void AwContents::InitAutofillIfNecessary(bool autocomplete_enabled) {
-       autofill_provider
-           ? base::BindRepeating(&autofill::AndroidDriverInitHook,
-                                 AwAutofillClient::FromWebContents(web_contents),
--                                enable_download_manager)
-+                                enable_download_manager, /*enable_browser_autofill_manager*/ false)
+@@ -342,7 +342,8 @@ void AwContents::InitAutofillIfNecessary(bool autocomplete_enabled) {
+                                 enable_download_manager)
            : base::BindRepeating(&autofill::BrowserDriverInitHook,
                                  AwAutofillClient::FromWebContents(web_contents),
 -                                base::android::GetDefaultLocaleString());

--- a/build/patches/Move-navigation-bar-to-bottom.patch
+++ b/build/patches/Move-navigation-bar-to-bottom.patch
@@ -17,13 +17,13 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  cc/input/browser_controls_offset_manager.cc   |  6 +++
  cc/trees/layer_tree_host_impl.cc              |  3 ++
  .../tab_management/TabGroupUiCoordinator.java |  7 ++-
- .../tab_management/TabGroupUiMediator.java    | 50 ++++++++++++++++++-
+ .../tab_management/TabGroupUiMediator.java    | 50 +++++++++++++++++-
  .../tab_management/TabGroupUiProperties.java  |  6 ++-
  .../tab_management/TabGroupUiToolbarView.java | 18 +++++++
  .../tab_management/TabGroupUiViewBinder.java  |  3 ++
  .../tab_management/TabListRecyclerView.java   | 19 ++++++-
  .../tab_management/TabSwitcherMediator.java   | 15 ++++++
- .../ChromeAccessibilitySettingsDelegate.java  | 14 ++++++
+ .../ChromeAccessibilitySettingsDelegate.java  | 52 +++++++++++++++++++
  .../chrome/browser/app/ChromeActivity.java    | 13 +++++
  .../browser/app/flags/ChromeCachedFlags.java  |  1 +
  .../compositor/CompositorViewHolder.java      |  6 +++
@@ -32,11 +32,11 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../overlays/strip/StripLayoutHelper.java     |  2 +-
  .../strip/StripLayoutHelperManager.java       | 36 +++++++++++--
  .../scene_layer/StaticTabSceneLayer.java      |  8 ++-
- .../scene_layer/TabListSceneLayer.java        | 14 ++++++
+ .../scene_layer/TabListSceneLayer.java        | 14 +++++
  .../scene_layer/TabStripSceneLayer.java       | 15 +++++-
  .../browser/findinpage/FindToolbarTablet.java | 11 ++--
  .../fullscreen/BrowserControlsManager.java    | 13 +++++
- .../messages/MessageContainerCoordinator.java | 17 ++++++-
+ .../messages/MessageContainerCoordinator.java | 17 +++++-
  .../modaldialog/ChromeTabModalPresenter.java  |  2 +-
  .../chrome/browser/ntp/NewTabPage.java        | 13 +++--
  .../chrome/browser/ntp/RecentTabsPage.java    | 22 ++++++--
@@ -44,7 +44,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../browser/settings/SettingsActivity.java    |  5 ++
  .../StatusIndicatorCoordinator.java           | 10 ++++
  .../StatusIndicatorSceneLayer.java            |  7 ++-
- .../browser/toolbar/ToolbarManager.java       | 37 ++++++++++++--
+ .../browser/toolbar/ToolbarManager.java       | 37 +++++++++++--
  .../chrome/browser/ui/BottomContainer.java    | 19 +++++++
  chrome/browser/about_flags.cc                 |  5 ++
  .../scene_layer/tab_strip_scene_layer.cc      | 16 ++++--
@@ -56,13 +56,13 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../flags/android/chrome_feature_list.cc      |  2 +
  .../browser/flags/CachedFeatureFlags.java     | 19 +++++++
  .../browser/flags/ChromeFeatureList.java      |  2 +
- .../chrome/browser/ui/appmenu/AppMenu.java    | 25 ++++++++++
+ .../chrome/browser/ui/appmenu/AppMenu.java    | 25 +++++++++
  .../ui/appmenu/AppMenuHandlerImpl.java        | 11 ++++
  .../omnibox/LocationBarCoordinator.java       |  9 +++-
  .../browser/omnibox/UrlBarCoordinator.java    | 11 +++-
  .../suggestions/AutocompleteCoordinator.java  | 16 +++++-
  .../suggestions/AutocompleteMediator.java     |  7 ++-
- .../OmniboxSuggestionsDropdown.java           | 23 ++++++++-
+ .../OmniboxSuggestionsDropdown.java           | 23 +++++++-
  .../OmniboxSuggestionsDropdownEmbedder.java   |  4 ++
  .../strings/android_chrome_strings.grd        |  6 +++
  chrome/browser/ui/android/toolbar/BUILD.gn    |  1 +
@@ -72,7 +72,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../bottom/BottomControlsMediator.java        |  9 ++++
  .../bottom/BottomControlsProperties.java      |  5 +-
  .../bottom/BottomControlsViewBinder.java      |  2 +
- .../bottom/ScrollingBottomViewSceneLayer.java | 20 +++++++-
+ .../bottom/ScrollingBottomViewSceneLayer.java | 20 ++++++-
  .../toolbar/top/ToolbarControlContainer.java  | 11 ++++
  .../top/TopToolbarOverlayCoordinator.java     |  7 +++
  .../top/TopToolbarOverlayProperties.java      |  8 ++-
@@ -81,7 +81,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../accessibility/AccessibilitySettings.java  | 16 ++++++
  .../AccessibilitySettingsDelegate.java        |  6 +++
  .../render_widget_host_view_android.cc        |  3 ++
- 69 files changed, 697 insertions(+), 53 deletions(-)
+ 69 files changed, 735 insertions(+), 53 deletions(-)
 
 diff --git a/cc/base/features.cc b/cc/base/features.cc
 --- a/cc/base/features.cc
@@ -501,6 +501,51 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/accessibility/s
      private static class ReaderForAccessibilityDelegate implements BooleanPreferenceDelegate {
          @Override
          public boolean isEnabled() {
+@@ -86,6 +100,44 @@ public class ChromeAccessibilitySettingsDelegate implements AccessibilitySetting
+         return new ForceTabletUIDelegate();
+     }
+ 
++    private static class MoveTopToolbarToBottomDelegate implements BooleanPreferenceDelegate {
++        @Override
++        public boolean isEnabled() {
++            return CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM);
++        }
++
++        @Override
++        public void setEnabled(boolean value) {
++            CachedFeatureFlags.setFlagEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM,
++                    "move-top-toolbar-to-bottom", value);
++        }
++    }
++
++    @Override
++    public BooleanPreferenceDelegate getMoveTopToolbarToBottomDelegate() {
++        return new MoveTopToolbarToBottomDelegate();
++    }
++
++    @Override
++    public void requestRestart(Activity activity) {
++        Snackbar mSnackbar = Snackbar.make(activity.getString(R.string.ui_relaunch_notice),
++                new SnackbarManager.SnackbarController() {
++                        @Override
++                        public void onDismissNoAction(Object actionData) { }
++
++                        @Override
++                        public void onAction(Object actionData) {
++                                ApplicationLifetime.terminate(true);
++                        }
++                }, Snackbar.TYPE_NOTIFICATION, Snackbar.UMA_UNKNOWN)
++                .setSingleLine(false)
++                .setAction(activity.getString(R.string.relaunch),
++                        /*actionData*/null)
++                .setDuration(/*durationMs*/70000);
++        if (!mSnackbarManager.isShowing())
++            mSnackbarManager.showSnackbar(mSnackbar);
++    }
++
+     @Override
+     public void addExtraPreferences(PreferenceFragmentCompat fragment) {
+         if (ImageDescriptionsController.getInstance().shouldShowImageDescriptionsMenuItem()) {
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java

--- a/build/patches/Revert-the-removal-of-an-option-to-block-autoplay.patch
+++ b/build/patches/Revert-the-removal-of-an-option-to-block-autoplay.patch
@@ -22,7 +22,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../strings/android/site_settings.grdp        |   9 +++++++
  .../core/browser/content_settings_registry.cc |   2 +-
  .../core/browser/content_settings_utils.cc    |   2 ++
- .../core/common/content_settings.cc           |   1 +
+ .../core/common/content_settings.cc           |   2 ++
  .../core/common/content_settings.h            |   1 +
  .../core/common/content_settings.mojom        |   1 +
  .../common/content_settings_mojom_traits.cc   |   1 +
@@ -34,9 +34,9 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  components/page_info/page_info_ui.cc          |   1 +
  components/site_settings_strings.grdp         |   3 +++
  .../platform/web_content_settings_client.h    |   3 +++
- .../core/html/media/autoplay_policy.cc        |  12 +++++++++-
+ .../core/html/media/autoplay_policy.cc        |  12 ++++++++++
  .../core/html/media/autoplay_policy.h         |   4 ++++
- 31 files changed, 118 insertions(+), 5 deletions(-)
+ 31 files changed, 120 insertions(+), 4 deletions(-)
  create mode 100644 components/browser_ui/site_settings/android/java/res/drawable-hdpi/settings_autoplay.png
  create mode 100644 components/browser_ui/site_settings/android/java/res/drawable-mdpi/settings_autoplay.png
  create mode 100644 components/browser_ui/site_settings/android/java/res/drawable-xhdpi/settings_autoplay.png
@@ -399,6 +399,14 @@ diff --git a/components/content_settings/core/common/content_settings.cc b/compo
           content_type == ContentSettingsType::MIXEDSCRIPT ||
           content_type == ContentSettingsType::AUTO_DARK_WEB_CONTENT ||
           content_type == ContentSettingsType::TIMEZONE_OVERRIDE;
+@@ -211,6 +212,7 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+   FilterRulesForType(mixed_content_rules, outermost_main_frame_url);
+   FilterRulesForType(auto_dark_content_rules, outermost_main_frame_url);
+   FilterRulesForType(timezone_override_rules, outermost_main_frame_url);
++  FilterRulesForType(autoplay_rules, outermost_main_frame_url);
+ }
+ 
+ RendererContentSettingRules::RendererContentSettingRules() = default;
 diff --git a/components/content_settings/core/common/content_settings.h b/components/content_settings/core/common/content_settings.h
 --- a/components/content_settings/core/common/content_settings.h
 +++ b/components/content_settings/core/common/content_settings.h
@@ -561,16 +569,16 @@ diff --git a/third_party/blink/renderer/core/html/media/autoplay_policy.cc b/thi
  #include "third_party/blink/public/platform/web_media_player.h"
  #include "third_party/blink/public/web/web_local_frame.h"
  #include "third_party/blink/public/web/web_local_frame_client.h"
-@@ -315,7 +316,7 @@ bool AutoplayPolicy::IsGestureNeededForPlayback() const {
- 
-   // We want to allow muted video to autoplay if the element is allowed to
-   // autoplay muted.
--  return !IsEligibleForAutoplayMuted();
-+  return !(IsEligibleForAutoplayMuted() && IsAutoplayAllowedPerSettings());
+@@ -310,6 +311,8 @@ void AutoplayPolicy::TryUnlockingUserGesture() {
  }
  
- String AutoplayPolicy::GetPlayErrorMessage() const {
-@@ -407,6 +408,15 @@ void AutoplayPolicy::MaybeSetAutoplayInitiated() {
+ bool AutoplayPolicy::IsGestureNeededForPlayback() const {
++  if (!IsAutoplayAllowedPerSettings())
++    return true;
+   if (!IsLockedPendingUserGesture())
+     return false;
+ 
+@@ -407,6 +410,15 @@ void AutoplayPolicy::MaybeSetAutoplayInitiated() {
    }
  }
  

--- a/build/patches/Timezone-customization.patch
+++ b/build/patches/Timezone-customization.patch
@@ -33,7 +33,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../core/browser/content_settings_utils.cc    |   7 +
  .../core/browser/host_content_settings_map.cc |   8 +
  .../core/browser/host_content_settings_map.h  |   3 +
- .../core/common/content_settings.cc           |   3 +-
+ .../core/common/content_settings.cc           |   4 +-
  .../core/common/content_settings.h            |   2 +
  .../core/common/content_settings.mojom        |   2 +
  .../common/content_settings_mojom_traits.cc   |   4 +-
@@ -44,7 +44,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../renderer/content_settings_agent_impl.cc   |  89 ++++++++
  .../renderer/content_settings_agent_impl.h    |   4 +
  .../WebLayerSiteSettingsDelegate.java         |   3 +
- 35 files changed, 698 insertions(+), 15 deletions(-)
+ 35 files changed, 699 insertions(+), 15 deletions(-)
  create mode 100755 components/browser_ui/site_settings/android/java/res/layout/time_zone_select_dialog.xml
  create mode 100755 components/browser_ui/site_settings/android/java/res/layout/timezoneoverride_site_settings_preference.xml
  create mode 100755 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/TimezoneOverrideSiteSettingsPreference.java
@@ -1111,6 +1111,14 @@ diff --git a/components/content_settings/core/common/content_settings.cc b/compo
  }
  
  void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+@@ -209,6 +210,7 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+   FilterRulesForType(popup_redirect_rules, outermost_main_frame_url);
+   FilterRulesForType(mixed_content_rules, outermost_main_frame_url);
+   FilterRulesForType(auto_dark_content_rules, outermost_main_frame_url);
++  FilterRulesForType(timezone_override_rules, outermost_main_frame_url);
+ }
+ 
+ RendererContentSettingRules::RendererContentSettingRules() = default;
 diff --git a/components/content_settings/core/common/content_settings.h b/components/content_settings/core/common/content_settings.h
 --- a/components/content_settings/core/common/content_settings.h
 +++ b/components/content_settings/core/common/content_settings.h


### PR DESCRIPTION
these are some changes to the v103 patches:

I assigned the changes to the right patches:
- Add option to force tablet UI
  Enable native Android autofill
  Move navigation bar to bottom
  Allow building without enable_reporting

Fix for https://github.com/bromite/bromite/issues/2133#issuecomment-1172277504:

- Add webGL site setting
 Add webRTC site settings
 Timezone customization

Fix for https://github.com/bromite/bromite/issues/2133#issuecomment-1172277504 and #2096 :
- Revert the removal of an option to block autoplay

I have disabled a new flag of v103:
- Disable all predictors code
- Disable various metrics

I removed the change a `CSSAtRuleCounterStyleSpeakAsDescriptor`:
- Disable conversion measurement api
