### PR TITLE
Fix incorrect handling of blink::TimeZoneController::TimeZoneOverride

### DIFF
--- a/build/patches/Timezone-customization.patch
+++ b/build/patches/Timezone-customization.patch
@@ -41,10 +41,10 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../core/common/content_settings_types.h      |   3 +
  .../core/common/pref_names.cc                 |   3 +
  .../content_settings/core/common/pref_names.h |   2 +
- .../renderer/content_settings_agent_impl.cc   |  89 ++++++++
- .../renderer/content_settings_agent_impl.h    |   4 +
+ .../renderer/content_settings_agent_impl.cc   |  83 ++++++++
+ .../renderer/content_settings_agent_impl.h    |  11 +
  .../WebLayerSiteSettingsDelegate.java         |   3 +
- 35 files changed, 699 insertions(+), 15 deletions(-)
+ 35 files changed, 700 insertions(+), 15 deletions(-)
  create mode 100755 components/browser_ui/site_settings/android/java/res/layout/time_zone_select_dialog.xml
  create mode 100755 components/browser_ui/site_settings/android/java/res/layout/timezoneoverride_site_settings_preference.xml
  create mode 100755 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/TimezoneOverrideSiteSettingsPreference.java
@@ -1225,27 +1225,7 @@ diff --git a/components/content_settings/renderer/content_settings_agent_impl.cc
  #include "components/content_settings/core/common/content_settings.h"
  #include "components/content_settings/core/common/content_settings.mojom.h"
  #include "components/content_settings/core/common/content_settings_pattern.h"
-@@ -29,6 +31,10 @@
- #include "third_party/blink/public/web/web_local_frame.h"
- #include "third_party/blink/public/web/web_local_frame_client.h"
- #include "third_party/blink/public/web/web_view.h"
-+#include "third_party/blink/renderer/core/inspector/locale_controller.h"
-+#include "third_party/blink/renderer/core/timezone/timezone_controller.h"
-+#include "third_party/icu/source/common/unicode/strenum.h"
-+#include "third_party/icu/source/i18n/unicode/timezone.h"
- #include "url/gurl.h"
- #include "url/origin.h"
- #include "url/url_constants.h"
-@@ -41,6 +47,8 @@ using blink::WebString;
- using blink::WebURL;
- using blink::WebView;
- 
-+std::unique_ptr<blink::TimeZoneController::TimeZoneOverride> timezone_override_;
-+
- namespace content_settings {
- namespace {
- bool IsFrameWithOpaqueOrigin(WebFrame* frame) {
-@@ -329,6 +337,10 @@ bool ContentSettingsAgentImpl::AllowScript(bool enabled_per_settings) {
+@@ -329,6 +331,10 @@ bool ContentSettingsAgentImpl::AllowScript(bool enabled_per_settings) {
    allow = allow || IsAllowlistedForContentSettings();
  
    cached_script_permissions_[frame] = allow;
@@ -1256,7 +1236,7 @@ diff --git a/components/content_settings/renderer/content_settings_agent_impl.cc
    return allow;
  }
  
-@@ -465,4 +477,81 @@ bool ContentSettingsAgentImpl::IsAllowlistedForContentSettings() const {
+@@ -465,4 +471,81 @@ bool ContentSettingsAgentImpl::IsAllowlistedForContentSettings() const {
    return false;
  }
  
@@ -1341,10 +1321,24 @@ diff --git a/components/content_settings/renderer/content_settings_agent_impl.cc
 diff --git a/components/content_settings/renderer/content_settings_agent_impl.h b/components/content_settings/renderer/content_settings_agent_impl.h
 --- a/components/content_settings/renderer/content_settings_agent_impl.h
 +++ b/components/content_settings/renderer/content_settings_agent_impl.h
-@@ -167,6 +167,10 @@ class ContentSettingsAgentImpl
+@@ -25,6 +25,11 @@
+ #include "url/gurl.h"
+ #include "url/origin.h"
+ 
++#include "third_party/blink/renderer/core/inspector/locale_controller.h"
++#include "third_party/blink/renderer/core/timezone/timezone_controller.h"
++#include "third_party/icu/source/common/unicode/strenum.h"
++#include "third_party/icu/source/i18n/unicode/timezone.h"
++
+ namespace blink {
+ class WebFrame;
+ class WebURL;
+@@ -167,6 +172,12 @@ class ContentSettingsAgentImpl
    std::unique_ptr<Delegate> delegate_;
  
    mojo::AssociatedReceiverSet<mojom::ContentSettingsAgent> receivers_;
++
++  std::unique_ptr<blink::TimeZoneController::TimeZoneOverride> timezone_override_;
 +
 +  bool UpdateOverrides();
 +  bool UpdateTimeZoneOverride(ContentSetting setting, const std::string& timezone_override_value);


### PR DESCRIPTION
Due to the incorrect location (who knows why I put it there), the timezone override was immediately reset making the patch useless.