### PR TITLE
Add svg fingerprinting mitigation

### DIFF
--- a/build/patches/Multiple-fingerprinting-mitigations.patch
+++ b/build/patches/Multiple-fingerprinting-mitigations.patch
@@ -38,6 +38,8 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  third_party/blink/renderer/core/dom/range.cc  |  12 +-
  .../renderer/core/html/canvas/text_metrics.cc |  18 ++
  .../renderer/core/html/canvas/text_metrics.h  |   2 +
+ .../renderer/core/svg/svg_graphics_element.cc |   1 +
+ .../core/svg/svg_text_content_element.cc      |  23 ++-
  .../canvas2d/base_rendering_context_2d.cc     |   5 +
  .../canvas2d/canvas_rendering_context_2d.cc   |   8 +-
  third_party/blink/renderer/platform/BUILD.gn  |   5 +-
@@ -49,7 +51,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  third_party/ungoogled/BUILD.gn                |  10 ++
  third_party/ungoogled/ungoogled_switches.cc   |  18 ++
  third_party/ungoogled/ungoogled_switches.h    |  18 ++
- 24 files changed, 346 insertions(+), 3 deletions(-)
+ 26 files changed, 364 insertions(+), 9 deletions(-)
  create mode 100644 third_party/ungoogled/BUILD.gn
  create mode 100644 third_party/ungoogled/ungoogled_switches.cc
  create mode 100644 third_party/ungoogled/ungoogled_switches.h
@@ -340,6 +342,93 @@ diff --git a/third_party/blink/renderer/core/html/canvas/text_metrics.h b/third_
   private:
    void Update(const Font&,
                const TextDirection&,
+diff --git a/third_party/blink/renderer/core/svg/svg_graphics_element.cc b/third_party/blink/renderer/core/svg/svg_graphics_element.cc
+--- a/third_party/blink/renderer/core/svg/svg_graphics_element.cc
++++ b/third_party/blink/renderer/core/svg/svg_graphics_element.cc
+@@ -193,6 +193,7 @@ SVGRectTearOff* SVGGraphicsElement::getBBoxFromJavascript() {
+ 
+     if (layout_object->IsSVGText() || layout_object->IsSVGInline())
+       UseCounter::Count(GetDocument(), WebFeature::kGetBBoxForText);
++    bounding_box.Scale(GetDocument().GetNoiseFactorX(), GetDocument().GetNoiseFactorY());
+   }
+   return SVGRectTearOff::CreateDetached(bounding_box);
+ }
+diff --git a/third_party/blink/renderer/core/svg/svg_text_content_element.cc b/third_party/blink/renderer/core/svg/svg_text_content_element.cc
+--- a/third_party/blink/renderer/core/svg/svg_text_content_element.cc
++++ b/third_party/blink/renderer/core/svg/svg_text_content_element.cc
+@@ -117,11 +117,14 @@ float SVGTextContentElement::getComputedTextLength() {
+   GetDocument().UpdateStyleAndLayoutForNode(this,
+                                             DocumentUpdateReason::kJavaScript);
+   auto* layout_object = GetLayoutObject();
++  float value = 0;
+   if (IsNGTextOrInline(layout_object)) {
+     NGSvgTextQuery query(*layout_object);
+-    return query.SubStringLength(0, query.NumberOfCharacters());
++    value = query.SubStringLength(0, query.NumberOfCharacters());
++  } else {
++    value = SVGTextQuery(layout_object).TextLength();
+   }
+-  return SVGTextQuery(layout_object).TextLength();
++  return value * GetDocument().GetNoiseFactorX();
+ }
+ 
+ float SVGTextContentElement::getSubStringLength(
+@@ -144,9 +147,12 @@ float SVGTextContentElement::getSubStringLength(
+     nchars = number_of_chars - charnum;
+ 
+   auto* layout_object = GetLayoutObject();
++  float value = 0;
+   if (IsNGTextOrInline(layout_object))
+-    return NGSvgTextQuery(*layout_object).SubStringLength(charnum, nchars);
+-  return SVGTextQuery(layout_object).SubStringLength(charnum, nchars);
++    value = NGSvgTextQuery(*layout_object).SubStringLength(charnum, nchars);
++  else
++    value = SVGTextQuery(layout_object).SubStringLength(charnum, nchars);
++  return value * GetDocument().GetNoiseFactorX();
+ }
+ 
+ SVGPointTearOff* SVGTextContentElement::getStartPositionOfChar(
+@@ -170,6 +176,7 @@ SVGPointTearOff* SVGTextContentElement::getStartPositionOfChar(
+   } else {
+     point = SVGTextQuery(layout_object).StartPositionOfCharacter(charnum);
+   }
++  point.Scale(GetDocument().GetNoiseFactorX(), GetDocument().GetNoiseFactorY());
+   return SVGPointTearOff::CreateDetached(point);
+ }
+ 
+@@ -194,6 +201,7 @@ SVGPointTearOff* SVGTextContentElement::getEndPositionOfChar(
+   } else {
+     point = SVGTextQuery(layout_object).EndPositionOfCharacter(charnum);
+   }
++  point.Scale(GetDocument().GetNoiseFactorX(), GetDocument().GetNoiseFactorY());
+   return SVGPointTearOff::CreateDetached(point);
+ }
+ 
+@@ -218,6 +226,7 @@ SVGRectTearOff* SVGTextContentElement::getExtentOfChar(
+   } else {
+     rect = SVGTextQuery(layout_object).ExtentOfCharacter(charnum);
+   }
++  rect.Scale(GetDocument().GetNoiseFactorX(), GetDocument().GetNoiseFactorY());
+   return SVGRectTearOff::CreateDetached(rect);
+ }
+ 
+@@ -247,12 +256,14 @@ int SVGTextContentElement::getCharNumAtPosition(
+   GetDocument().UpdateStyleAndLayoutForNode(this,
+                                             DocumentUpdateReason::kJavaScript);
+   auto* layout_object = GetLayoutObject();
++  gfx::PointF target = gfx::PointF(point->Target()->Value());
++  target.Scale(GetDocument().GetNoiseFactorX(), GetDocument().GetNoiseFactorY());
+   if (IsNGTextOrInline(layout_object)) {
+     return NGSvgTextQuery(*layout_object)
+-        .CharacterNumberAtPosition(point->Target()->Value());
++        .CharacterNumberAtPosition(target);
+   }
+   return SVGTextQuery(layout_object)
+-      .CharacterNumberAtPosition(point->Target()->Value());
++      .CharacterNumberAtPosition(target);
+ }
+ 
+ void SVGTextContentElement::selectSubString(unsigned charnum,
 diff --git a/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc b/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
 --- a/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
 +++ b/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc


### PR DESCRIPTION
## Description

Adds a mitigation to scripts that use svg to generate hashes for the device fingerprint

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [ ] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
