### PR TITLE
Viewport protection

### DIFF
--- a/build/patches/Add-Viewport-Protection.patch
+++ b/build/patches/Add-Viewport-Protection.patch
@@ -22,6 +22,7 @@ Subject: Viewport Protection
  .../renderer/content_settings_agent_impl.h    |  1 +
  .../platform/web_content_settings_client.h    |  2 +
  .../blink/renderer/core/css/media_values.cc   | 10 +++
+ .../core/frame/dom_visual_viewport.cc         |  4 +-
  .../renderer/core/frame/local_frame_view.cc   |  3 +
  .../blink/renderer/core/frame/screen.cc       | 17 +++-
  .../renderer/core/frame/visual_viewport.cc    |  4 +
@@ -31,7 +32,7 @@ Subject: Viewport Protection
  third_party/blink/renderer/core/page/page.cc  |  8 ++
  third_party/blink/renderer/core/page/page.h   |  3 +
  .../screen_enumeration/screen_detailed.cc     | 15 ++++
- 28 files changed, 247 insertions(+), 12 deletions(-)
+ 29 files changed, 250 insertions(+), 13 deletions(-)
  create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
  create mode 100644 components/browser_ui/strings/android/viewport.grdp
 
@@ -406,6 +407,21 @@ diff --git a/third_party/blink/renderer/core/css/media_values.cc b/third_party/b
    return device_height;
  }
  
+diff --git a/third_party/blink/renderer/core/frame/dom_visual_viewport.cc b/third_party/blink/renderer/core/frame/dom_visual_viewport.cc
+--- a/third_party/blink/renderer/core/frame/dom_visual_viewport.cc
++++ b/third_party/blink/renderer/core/frame/dom_visual_viewport.cc
+@@ -177,8 +177,10 @@ double DOMVisualViewport::scale() const {
+   if (!frame->IsOutermostMainFrame())
+     return 1;
+ 
+-  if (Page* page = window_->GetFrame()->GetPage())
++  if (Page* page = window_->GetFrame()->GetPage()) {
++    if (page->PageWidthOverride() != 0) return 1;
+     return page->GetVisualViewport().ScaleForVisualViewport();
++  }
+ 
+   return 0;
+ }
 diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
 --- a/third_party/blink/renderer/core/frame/local_frame_view.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame_view.cc

--- a/build/patches/Add-Viewport-Protection.patch
+++ b/build/patches/Add-Viewport-Protection.patch
@@ -618,7 +618,7 @@ diff --git a/third_party/blink/renderer/core/html/html_meta_element.cc b/third_p
 +
 +    if (settings->AllowViewportChange(false)) {
 +      if (page->PageWidthOverride() == 0) {
-+        page->SetPageWidthOverride(base::RandInt(-30, 150) / 100.0);
++        page->SetPageWidthOverride(base::RandInt(-30, 150) / 10.0);
 +      }
 +
 +      float device_width = 1.0 + (page->PageWidthOverride() / 100.0);

--- a/build/patches/Add-Viewport-Protection.patch
+++ b/build/patches/Add-Viewport-Protection.patch
@@ -30,14 +30,12 @@ The feature is controlled by a site setting (default disabled)
  .../renderer/core/frame/local_dom_window.cc   |  6 ++
  .../renderer/core/frame/local_frame_view.cc   |  3 +
  .../blink/renderer/core/frame/screen.cc       | 17 +++-
- .../renderer/core/frame/visual_viewport.cc    |  4 +
- .../renderer/core/frame/visual_viewport.h     |  5 ++
- .../renderer/core/html/html_meta_element.cc   | 28 +++++-
+ .../renderer/core/frame/visual_viewport.cc    |  5 ++
+ .../renderer/core/html/html_meta_element.cc   | 26 +++++-
  .../renderer/core/loader/frame_loader.cc      | 15 +++-
- third_party/blink/renderer/core/page/page.cc  |  8 ++
- third_party/blink/renderer/core/page/page.h   |  3 +
- .../screen_enumeration/screen_detailed.cc     | 15 ++++
- 30 files changed, 275 insertions(+), 14 deletions(-)
+ third_party/blink/renderer/core/page/page.cc  | 12 +++
+ third_party/blink/renderer/core/page/page.h   |  5 ++
+ 28 files changed, 260 insertions(+), 14 deletions(-)
  create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
  create mode 100644 components/browser_ui/strings/android/viewport.grdp
 
@@ -561,39 +559,18 @@ diff --git a/third_party/blink/renderer/core/frame/screen.cc b/third_party/blink
 diff --git a/third_party/blink/renderer/core/frame/visual_viewport.cc b/third_party/blink/renderer/core/frame/visual_viewport.cc
 --- a/third_party/blink/renderer/core/frame/visual_viewport.cc
 +++ b/third_party/blink/renderer/core/frame/visual_viewport.cc
-@@ -467,6 +467,10 @@ void VisualViewport::SetScale(float scale) {
-                       gfx::PointAtOffsetFromOrigin(offset_));
- }
+@@ -1093,6 +1093,11 @@ bool VisualViewport::ShouldDisableDesktopWorkarounds() const {
+   if (!LocalMainFrame().GetSettings()->GetViewportEnabled())
+     return false;
  
-+void VisualViewport::SetPageWidthOverride(int value) {
-+  page_width_override_ = value;
-+}
++  if (LocalMainFrame().GetPage() &&
++      LocalMainFrame().GetPage()->PageWidthOverride() != 0) {
++    return true;
++  }
 +
- double VisualViewport::OffsetLeft() const {
-   // Offset{Left|Top} and Width|Height are used by the DOMVisualViewport to
-   // expose values to JS. We'll only ever ask the visual viewport for these
-diff --git a/third_party/blink/renderer/core/frame/visual_viewport.h b/third_party/blink/renderer/core/frame/visual_viewport.h
---- a/third_party/blink/renderer/core/frame/visual_viewport.h
-+++ b/third_party/blink/renderer/core/frame/visual_viewport.h
-@@ -145,6 +145,9 @@ class CORE_EXPORT VisualViewport : public GarbageCollected<VisualViewport>,
-   float Scale() const { return scale_; }
-   bool IsPinchGestureActive() const { return is_pinch_gesture_active_; }
- 
-+  void SetPageWidthOverride(int);
-+  int PageWidthOverride() const { return page_width_override_; }
-+
-   // Convert the given rect in the main LocalFrameView's coordinates into a rect
-   // in the viewport. The given and returned rects are in CSS pixels, meaning
-   // scale isn't applied.
-@@ -382,6 +385,8 @@ class CORE_EXPORT VisualViewport : public GarbageCollected<VisualViewport>,
-   CompositorElementId elasticity_effect_node_id_;
- 
-   bool needs_paint_property_update_;
-+
-+  int page_width_override_;
- };
- 
- }  // namespace blink
+   // A document is considered adapted to small screen UAs if one of these holds:
+   // 1. The author specified viewport has a constrained width that is equal to
+   //    the initial viewport width.
 diff --git a/third_party/blink/renderer/core/html/html_meta_element.cc b/third_party/blink/renderer/core/html/html_meta_element.cc
 --- a/third_party/blink/renderer/core/html/html_meta_element.cc
 +++ b/third_party/blink/renderer/core/html/html_meta_element.cc
@@ -605,7 +582,7 @@ diff --git a/third_party/blink/renderer/core/html/html_meta_element.cc b/third_p
  #include "third_party/blink/public/mojom/frame/color_scheme.mojom-blink.h"
  #include "third_party/blink/renderer/core/css/style_engine.h"
  #include "third_party/blink/renderer/core/dom/document.h"
-@@ -565,6 +566,27 @@ void HTMLMetaElement::ProcessContent() {
+@@ -565,6 +566,25 @@ void HTMLMetaElement::ProcessContent() {
    if (!IsInDocumentTree())
      return;
  
@@ -625,15 +602,13 @@ diff --git a/third_party/blink/renderer/core/html/html_meta_element.cc b/third_p
 +      String newvalue("initial-scale=" + base::NumberToString(device_width));
 +      ProcessViewportContentAttribute(newvalue, ViewportDescription::kViewportMeta);
 +      process_default = false;
-+    } else {
-+      page->SetPageWidthOverride(0);
 +    }
 +  }
 +
    const AtomicString& name_value = FastGetAttribute(html_names::kNameAttr);
    if (name_value.IsEmpty())
      return;
-@@ -594,8 +616,10 @@ void HTMLMetaElement::ProcessContent() {
+@@ -594,8 +614,10 @@ void HTMLMetaElement::ProcessContent() {
      return;
  
    if (EqualIgnoringASCIICase(name_value, "viewport")) {
@@ -686,16 +661,27 @@ diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/re
  }
  
 +void Page::SetPageWidthOverride(float value) {
-+  GetVisualViewport().SetPageWidthOverride(value);
++  page_width_override_ = value;
 +}
 +
-+int Page::PageWidthOverride() const {
-+  return GetVisualViewport().PageWidthOverride();
++float Page::PageWidthOverride() const {
++  return page_width_override_;
 +}
 +
  void Page::AllVisitedStateChanged(bool invalidate_visited_link_hashes) {
    for (const Page* page : OrdinaryPages()) {
      for (Frame* frame = page->main_frame_; frame;
+@@ -879,6 +887,10 @@ void Page::UpdateAcceleratedCompositingSettings() {
+ 
+ void Page::DidCommitLoad(LocalFrame* frame) {
+   if (main_frame_ == frame) {
++    blink::WebContentSettingsClient* settings = frame->GetContentSettingsClient();
++    if (!settings->AllowViewportChange(false))
++      SetPageWidthOverride(0);
++
+     GetConsoleMessageStorage().Clear();
+     GetInspectorIssueStorage().Clear();
+     // TODO(loonybear): Most of this doesn't appear to take into account that
 diff --git a/third_party/blink/renderer/core/page/page.h b/third_party/blink/renderer/core/page/page.h
 --- a/third_party/blink/renderer/core/page/page.h
 +++ b/third_party/blink/renderer/core/page/page.h
@@ -704,48 +690,19 @@ diff --git a/third_party/blink/renderer/core/page/page.h b/third_party/blink/ren
    float PageScaleFactor() const;
  
 +  void SetPageWidthOverride(float);
-+  int PageWidthOverride() const;
++  float PageWidthOverride() const;
 +
    float InspectorDeviceScaleFactorOverride() const {
      return inspector_device_scale_factor_override_;
    }
-diff --git a/third_party/blink/renderer/modules/screen_enumeration/screen_detailed.cc b/third_party/blink/renderer/modules/screen_enumeration/screen_detailed.cc
---- a/third_party/blink/renderer/modules/screen_enumeration/screen_detailed.cc
-+++ b/third_party/blink/renderer/modules/screen_enumeration/screen_detailed.cc
-@@ -9,12 +9,22 @@
- #include "third_party/blink/renderer/core/frame/local_frame.h"
- #include "third_party/blink/renderer/core/frame/settings.h"
- #include "third_party/blink/renderer/core/page/chrome_client.h"
-+#include "third_party/blink/renderer/core/page/page.h"
-+#include "third_party/blink/public/platform/web_content_settings_client.h"
- #include "third_party/blink/renderer/platform/wtf/text/string_statics.h"
- #include "ui/display/screen_info.h"
- #include "ui/display/screen_infos.h"
+@@ -538,6 +541,8 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
+   // browser side FrameTree has the FrameTree::Type of kFencedFrame.
+   bool is_fenced_frame_tree_ = false;
  
- namespace blink {
- 
-+namespace {
++  float page_width_override_ = 0;
 +
-+float GetScaleOverride(blink::Page* page) {
-+  return 1.0 - (page->PageWidthOverride() / 100.0);
-+}
-+
-+}
-+
- ScreenDetailed::ScreenDetailed(LocalDOMWindow* window,
-                                int64_t display_id,
-                                bool label_is_internal,
-@@ -87,6 +97,11 @@ bool ScreenDetailed::isInternal() const {
- float ScreenDetailed::devicePixelRatio() const {
-   if (!DomWindow())
-     return 0.f;
-+  LocalFrame* frame = DomWindow()->GetFrame();
-+  blink::WebContentSettingsClient* settings = frame->GetContentSettingsClient();
-+  blink::Page* page = frame->GetPage();
-+  if (settings->AllowViewportChange(false))
-+    return GetScreenInfo().device_scale_factor * GetScaleOverride(page);
-   return GetScreenInfo().device_scale_factor;
- }
- 
+   // If the page is hosted inside an MPArch fenced frame, this tracks the
+   // mode that the fenced frame is set to. This will always be set to kDefault
+   // for the ShadowDOM implementation of fenced frames.
 --
 2.25.1

--- a/build/patches/Add-Viewport-Protection.patch
+++ b/build/patches/Add-Viewport-Protection.patch
@@ -1,0 +1,667 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Thu, 30 Jun 2022 12:47:17 +0000
+Subject: Viewport Protection
+
+---
+ .../browser_ui/site_settings/android/BUILD.gn |  3 +
+ .../BromiteCustomContentSettingImpl.java      |  1 +
+ .../BromiteViewportContentSetting.java        | 86 +++++++++++++++++++
+ .../site_settings/SiteSettingsCategory.java   |  5 +-
+ .../strings/android/browser_ui_strings.grd    |  1 +
+ .../browser_ui/strings/android/viewport.grdp  | 18 ++++
+ components/components_strings.grd             |  1 +
+ .../core/browser/content_settings_registry.cc | 14 +++
+ .../core/browser/content_settings_utils.cc    |  2 +
+ .../core/common/content_settings.cc           |  4 +-
+ .../core/common/content_settings.h            |  1 +
+ .../core/common/content_settings.mojom        |  1 +
+ .../common/content_settings_mojom_traits.cc   |  3 +-
+ .../common/content_settings_mojom_traits.h    |  5 ++
+ .../core/common/content_settings_types.h      |  2 +
+ .../renderer/content_settings_agent_impl.cc   |  9 ++
+ .../renderer/content_settings_agent_impl.h    |  1 +
+ .../platform/web_content_settings_client.h    |  2 +
+ .../blink/renderer/core/css/media_values.cc   | 10 +++
+ .../renderer/core/frame/local_frame_view.cc   |  3 +
+ .../blink/renderer/core/frame/screen.cc       | 17 +++-
+ .../renderer/core/frame/visual_viewport.cc    |  4 +
+ .../renderer/core/frame/visual_viewport.h     |  5 ++
+ .../renderer/core/html/html_meta_element.cc   | 28 +++++-
+ .../renderer/core/loader/frame_loader.cc      |  7 +-
+ third_party/blink/renderer/core/page/page.cc  |  8 ++
+ third_party/blink/renderer/core/page/page.h   |  3 +
+ .../screen_enumeration/screen_detailed.cc     | 15 ++++
+ 28 files changed, 247 insertions(+), 12 deletions(-)
+ create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
+ create mode 100644 components/browser_ui/strings/android/viewport.grdp
+
+diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/browser_ui/site_settings/android/BUILD.gn
+--- a/components/browser_ui/site_settings/android/BUILD.gn
++++ b/components/browser_ui/site_settings/android/BUILD.gn
+@@ -78,6 +78,9 @@ android_library("java") {
+   sources += [
+     "java/src/org/chromium/components/browser_ui/site_settings/BromiteWebRTCContentSetting.java",
+   ]
++  sources += [
++    "java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java",
++  ]
+   annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
+   resources_package = "org.chromium.components.browser_ui.site_settings"
+   deps = [
+diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteCustomContentSettingImpl.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteCustomContentSettingImpl.java
+--- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteCustomContentSettingImpl.java
++++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteCustomContentSettingImpl.java
+@@ -45,6 +45,7 @@ public abstract class BromiteCustomContentSettingImpl {
+         mItemList = new ArrayList<BromiteCustomContentSetting>();
+         mItemList.add(new BromiteWebGLContentSetting());
+         mItemList.add(new BromiteWebRTCContentSetting());
++        mItemList.add(new BromiteViewportContentSetting());
+     }
+ 
+     public static SiteSettingsCategory createFromType(
+diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
+new file mode 100644
+--- /dev/null
++++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
+@@ -0,0 +1,86 @@
++/*
++    This file is part of Bromite.
++
++    Bromite is free software: you can redistribute it and/or modify
++    it under the terms of the GNU General Public License as published by
++    the Free Software Foundation, either version 3 of the License, or
++    (at your option) any later version.
++
++    Bromite is distributed in the hope that it will be useful,
++    but WITHOUT ANY WARRANTY; without even the implied warranty of
++    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++    GNU General Public License for more details.
++
++    You should have received a copy of the GNU General Public License
++    along with Bromite. If not, see <https://www.gnu.org/licenses/>.
++*/
++
++package org.chromium.components.browser_ui.site_settings;
++
++import org.chromium.components.browser_ui.site_settings.ContentSettingsResources;
++import org.chromium.components.browser_ui.site_settings.SiteSettingsCategory;
++import org.chromium.components.content_settings.ContentSettingValues;
++import org.chromium.components.content_settings.ContentSettingsType;
++import org.chromium.content_public.browser.BrowserContextHandle;
++
++import androidx.annotation.Nullable;
++import androidx.preference.Preference;
++import androidx.preference.PreferenceScreen;
++
++import java.util.ArrayList;
++
++public class BromiteViewportContentSetting extends BromiteCustomContentSetting {
++    public BromiteViewportContentSetting() {
++        super(/*contentSettingsType*/ ContentSettingsType.VIEWPORT,
++              /*siteSettingsCategory*/ SiteSettingsCategory.Type.VIEWPORT,
++              /*defaultEnabledValue*/ ContentSettingValues.ALLOW,
++              /*defaultDisabledValue*/ ContentSettingValues.BLOCK,
++              /*allowException*/ true,
++              /*preferenceKey*/ "viewport",
++              /*profilePrefKey*/ "viewport");
++    }
++
++    @Override
++    public ContentSettingsResources.ResourceItem getResourceItem() {
++        return new ContentSettingsResources.ResourceItem(
++            /*icon*/ R.drawable.web_asset,
++            /*title*/ R.string.viewport_permission_title,
++            /*defaultEnabledValue*/ getDefaultEnabledValue(),
++            /*defaultDisabledValue*/ getDefaultDisabledValue(),
++            /*enabledSummary*/ R.string.website_settings_category_viewport_enabled,
++            /*disabledSummary*/ R.string.website_settings_category_viewport_disabled);
++    }
++
++    @Override
++    public int getCategorySummary(@Nullable @ContentSettingValues int value) {
++        switch (value) {
++            case ContentSettingValues.ALLOW:
++                return R.string.website_settings_category_viewport_enabled;
++            case ContentSettingValues.BLOCK:
++                return R.string.website_settings_category_viewport_disabled;
++            default:
++                // this will cause a runtime exception
++                return 0;
++        }
++    }
++
++    @Override
++    public boolean requiresTriStateContentSetting() {
++        return false;
++    }
++
++    @Override
++    public boolean showOnlyDescriptions() {
++        return true;
++    }
++
++    @Override
++    public int getAddExceptionDialogMessage() {
++        return R.string.website_settings_category_viewport_enabled;
++    }
++
++    @Override
++    public @Nullable Boolean considerException(SiteSettingsCategory category, @ContentSettingValues int value) {
++        return value != ContentSettingValues.BLOCK;
++    }
++}
+diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java
+--- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java
++++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java
+@@ -44,7 +44,7 @@ public class SiteSettingsCategory {
+             Type.PROTECTED_MEDIA, Type.SENSORS, Type.SOUND, Type.USB, Type.VIRTUAL_REALITY,
+             Type.USE_STORAGE, Type.AUTO_DARK_WEB_CONTENT, Type.REQUEST_DESKTOP_SITE,
+             Type.FEDERATED_IDENTITY_API, Type.TIMEZONE_OVERRIDE, Type.AUTOPLAY, Type.JAVASCRIPT_JIT,
+-            Type.IMAGES, Type.WEBGL, Type.WEBRTC})
++            Type.IMAGES, Type.WEBGL, Type.WEBRTC, Type.VIEWPORT})
+     @Retention(RetentionPolicy.SOURCE)
+     public @interface Type {
+         // All updates here must also be reflected in {@link #preferenceKey(int)
+@@ -81,10 +81,11 @@ public class SiteSettingsCategory {
+         int IMAGES = 29;
+         int WEBGL = 30;
+         int WEBRTC = 31;
++        int VIEWPORT = 32;
+         /**
+          * Number of handled categories used for calculating array sizes.
+          */
+-        int NUM_ENTRIES = 32;
++        int NUM_ENTRIES = 33;
+     }
+ 
+     private final BrowserContextHandle mBrowserContextHandle;
+diff --git a/components/browser_ui/strings/android/browser_ui_strings.grd b/components/browser_ui/strings/android/browser_ui_strings.grd
+--- a/components/browser_ui/strings/android/browser_ui_strings.grd
++++ b/components/browser_ui/strings/android/browser_ui_strings.grd
+@@ -176,6 +176,7 @@
+       <part file="site_settings.grdp" />
+       <part file="webgl.grdp" />
+       <part file="webrtc.grdp" />
++      <part file="viewport.grdp" />
+ 
+       <message name="IDS_GOT_IT" desc="Button for the user to accept a disclosure/message">
+         Got it
+diff --git a/components/browser_ui/strings/android/viewport.grdp b/components/browser_ui/strings/android/viewport.grdp
+new file mode 100644
+--- /dev/null
++++ b/components/browser_ui/strings/android/viewport.grdp
+@@ -0,0 +1,18 @@
++<?xml version="1.0" encoding="utf-8"?>
++<grit-part>
++  <message name="IDS_SITE_SETTINGS_TYPE_VIEWPORT" desc="The label used for viewport size change site settings controls.">
++    Viewport Size Protection
++  </message>
++  <message name="IDS_SITE_SETTINGS_TYPE_VIEWPORT_MID_SENTENCE" desc="The label used for viewport size change site settings controls when used mid-sentence.">
++    Viewport Size Protection
++  </message>
++  <message name="IDS_VIEWPORT_PERMISSION_TITLE" desc="Title of the permission to use viewport size change [CHAR-LIMIT=32]">
++    Viewport Size Protection
++  </message>
++  <message name="IDS_WEBSITE_SETTINGS_CATEGORY_VIEWPORT_ENABLED" desc="Summary text explaining that viewport size change is full enabled.">
++    Enabled
++  </message>
++  <message name="IDS_WEBSITE_SETTINGS_CATEGORY_VIEWPORT_DISABLED" desc="Summary text explaining that viewport size change is full disabled.">
++    Disabled
++  </message>
++</grit-part>
+diff --git a/components/components_strings.grd b/components/components_strings.grd
+--- a/components/components_strings.grd
++++ b/components/components_strings.grd
+@@ -339,6 +339,7 @@
+       <part file="user_scripts/strings/userscripts_strings.grdp" />
+       <part file="browser_ui/strings/android/webgl.grdp" />
+       <part file="browser_ui/strings/android/webrtc.grdp" />
++      <part file="browser_ui/strings/android/viewport.grdp" />
+ 
+       <if expr="not is_ios">
+         <part file="management_strings.grdp" />
+diff --git a/components/content_settings/core/browser/content_settings_registry.cc b/components/content_settings/core/browser/content_settings_registry.cc
+--- a/components/content_settings/core/browser/content_settings_registry.cc
++++ b/components/content_settings/core/browser/content_settings_registry.cc
+@@ -707,6 +707,20 @@ void ContentSettingsRegistry::Init() {
+            /*show_into_info_page*/ true,
+            /*permission_type_ui*/ IDS_SITE_SETTINGS_TYPE_WEBRTC,
+            /*permission_type_ui_mid_sentence*/ IDS_SITE_SETTINGS_TYPE_WEBRTC_MID_SENTENCE);
++
++  Register(ContentSettingsType::VIEWPORT, "viewport", CONTENT_SETTING_BLOCK,
++           WebsiteSettingsInfo::SYNCABLE,
++           AllowlistedSchemes(),
++           ValidSettings(CONTENT_SETTING_ALLOW,
++                         CONTENT_SETTING_BLOCK),
++           WebsiteSettingsInfo::SINGLE_ORIGIN_WITH_EMBEDDED_EXCEPTIONS_SCOPE,
++           WebsiteSettingsRegistry::PLATFORM_ANDROID,
++           ContentSettingsInfo::INHERIT_IN_INCOGNITO,
++           ContentSettingsInfo::PERSISTENT,
++           ContentSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS,
++           /*show_into_info_page*/ true,
++           /*permission_type_ui*/ IDS_SITE_SETTINGS_TYPE_VIEWPORT,
++           /*permission_type_ui_mid_sentence*/ IDS_SITE_SETTINGS_TYPE_VIEWPORT_MID_SENTENCE);
+ }
+ 
+ void ContentSettingsRegistry::Register(
+diff --git a/components/content_settings/core/browser/content_settings_utils.cc b/components/content_settings/core/browser/content_settings_utils.cc
+--- a/components/content_settings/core/browser/content_settings_utils.cc
++++ b/components/content_settings/core/browser/content_settings_utils.cc
+@@ -159,6 +159,8 @@ void GetRendererContentSettingRules(const HostContentSettingsMap* map,
+                              &(rules->webgl_rules));
+   map->GetSettingsForOneType(ContentSettingsType::WEBRTC,
+                              &(rules->webrtc_rules));
++  map->GetSettingsForOneType(ContentSettingsType::VIEWPORT,
++                             &(rules->viewport_rules));
+ }
+ 
+ bool IsMorePermissive(ContentSetting a, ContentSetting b) {
+diff --git a/components/content_settings/core/common/content_settings.cc b/components/content_settings/core/common/content_settings.cc
+--- a/components/content_settings/core/common/content_settings.cc
++++ b/components/content_settings/core/common/content_settings.cc
+@@ -206,7 +206,8 @@ bool RendererContentSettingRules::IsRendererContentSetting(
+          content_type == ContentSettingsType::AUTO_DARK_WEB_CONTENT ||
+          content_type == ContentSettingsType::TIMEZONE_OVERRIDE ||
+          content_type == ContentSettingsType::WEBGL ||
+-         content_type == ContentSettingsType::WEBRTC;
++         content_type == ContentSettingsType::WEBRTC ||
++         content_type == ContentSettingsType::VIEWPORT;
+ }
+ 
+ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+@@ -220,6 +221,7 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+   FilterRulesForType(autoplay_rules, outermost_main_frame_url);
+   FilterRulesForType(webgl_rules, outermost_main_frame_url);
+   FilterRulesForType(webrtc_rules, outermost_main_frame_url);
++  FilterRulesForType(viewport_rules, outermost_main_frame_url);
+ }
+ 
+ RendererContentSettingRules::RendererContentSettingRules() = default;
+diff --git a/components/content_settings/core/common/content_settings.h b/components/content_settings/core/common/content_settings.h
+--- a/components/content_settings/core/common/content_settings.h
++++ b/components/content_settings/core/common/content_settings.h
+@@ -99,6 +99,7 @@ struct RendererContentSettingRules {
+   std::string timezone_override_value;
+   ContentSettingsForOneType webgl_rules;
+   ContentSettingsForOneType webrtc_rules;
++  ContentSettingsForOneType viewport_rules;
+ };
+ 
+ namespace content_settings {
+diff --git a/components/content_settings/core/common/content_settings.mojom b/components/content_settings/core/common/content_settings.mojom
+--- a/components/content_settings/core/common/content_settings.mojom
++++ b/components/content_settings/core/common/content_settings.mojom
+@@ -83,4 +83,5 @@ struct RendererContentSettingRules {
+   string timezone_override_value;
+   array<ContentSettingPatternSource> webgl_rules;
+   array<ContentSettingPatternSource> webrtc_rules;
++  array<ContentSettingPatternSource> viewport_rules;
+ };
+diff --git a/components/content_settings/core/common/content_settings_mojom_traits.cc b/components/content_settings/core/common/content_settings_mojom_traits.cc
+--- a/components/content_settings/core/common/content_settings_mojom_traits.cc
++++ b/components/content_settings/core/common/content_settings_mojom_traits.cc
+@@ -106,7 +106,8 @@ bool StructTraits<content_settings::mojom::RendererContentSettingRulesDataView,
+          data.ReadTimezoneOverrideRules(&out->timezone_override_rules) &&
+          data.ReadTimezoneOverrideValue(&out->timezone_override_value) &&
+          data.ReadWebglRules(&out->webgl_rules) &&
+-         data.ReadWebrtcRules(&out->webrtc_rules);
++         data.ReadWebrtcRules(&out->webrtc_rules) &&
++         data.ReadViewportRules(&out->viewport_rules);
+ }
+ 
+ }  // namespace mojo
+diff --git a/components/content_settings/core/common/content_settings_mojom_traits.h b/components/content_settings/core/common/content_settings_mojom_traits.h
+--- a/components/content_settings/core/common/content_settings_mojom_traits.h
++++ b/components/content_settings/core/common/content_settings_mojom_traits.h
+@@ -175,6 +175,11 @@ struct StructTraits<
+     return r.webrtc_rules;
+   }
+ 
++ static const std::vector<ContentSettingPatternSource>& viewport_rules(
++      const RendererContentSettingRules& r) {
++    return r.viewport_rules;
++  }
++
+   static bool Read(
+       content_settings::mojom::RendererContentSettingRulesDataView data,
+       RendererContentSettingRules* out);
+diff --git a/components/content_settings/core/common/content_settings_types.h b/components/content_settings/core/common/content_settings_types.h
+--- a/components/content_settings/core/common/content_settings_types.h
++++ b/components/content_settings/core/common/content_settings_types.h
+@@ -284,6 +284,8 @@ enum class ContentSettingsType : int32_t {
+ 
+   WEBRTC,
+ 
++  VIEWPORT,
++
+   // Setting to indicate whether browser should allow signing into a website via
+   // the browser FedCM API.
+   FEDERATED_IDENTITY_API,
+diff --git a/components/content_settings/renderer/content_settings_agent_impl.cc b/components/content_settings/renderer/content_settings_agent_impl.cc
+--- a/components/content_settings/renderer/content_settings_agent_impl.cc
++++ b/components/content_settings/renderer/content_settings_agent_impl.cc
+@@ -473,6 +473,15 @@ bool ContentSettingsAgentImpl::AllowWebRTC(bool enabled_per_settings) {
+              url::Origin(frame->GetDocument().GetSecurityOrigin()).GetURL());
+ }
+ 
++bool ContentSettingsAgentImpl::AllowViewportChange(bool enabled_per_settings) {
++  if (!content_setting_rules_)
++    return false;
++  blink::WebLocalFrame* frame = render_frame()->GetWebFrame();
++  return CONTENT_SETTING_ALLOW == GetContentSettingFromRules(
++             content_setting_rules_->viewport_rules,
++             url::Origin(frame->GetDocument().GetSecurityOrigin()).GetURL());
++}
++
+ bool ContentSettingsAgentImpl::IsAllowlistedForContentSettings() const {
+   if (should_allowlist_)
+     return true;
+diff --git a/components/content_settings/renderer/content_settings_agent_impl.h b/components/content_settings/renderer/content_settings_agent_impl.h
+--- a/components/content_settings/renderer/content_settings_agent_impl.h
++++ b/components/content_settings/renderer/content_settings_agent_impl.h
+@@ -96,6 +96,7 @@ class ContentSettingsAgentImpl
+   bool ShouldAutoupgradeMixedContent() override;
+   bool AllowWebgl(bool enabled_per_settings) override;
+   bool AllowWebRTC(bool enabled_per_settings) override;
++  bool AllowViewportChange(bool enabled_per_settings) override;
+ 
+   bool allow_running_insecure_content() const {
+     return allow_running_insecure_content_;
+diff --git a/third_party/blink/public/platform/web_content_settings_client.h b/third_party/blink/public/platform/web_content_settings_client.h
+--- a/third_party/blink/public/platform/web_content_settings_client.h
++++ b/third_party/blink/public/platform/web_content_settings_client.h
+@@ -103,6 +103,8 @@ class WebContentSettingsClient {
+ 
+   virtual bool AllowWebRTC(bool default_value) { return default_value; }
+ 
++  virtual bool AllowViewportChange(bool default_value) { return default_value; }
++
+   // Reports that passive mixed content was found at the provided URL.
+   virtual void PassiveInsecureContentFound(const WebURL&) {}
+ 
+diff --git a/third_party/blink/renderer/core/css/media_values.cc b/third_party/blink/renderer/core/css/media_values.cc
+--- a/third_party/blink/renderer/core/css/media_values.cc
++++ b/third_party/blink/renderer/core/css/media_values.cc
+@@ -193,6 +193,11 @@ int MediaValues::CalculateDeviceWidth(LocalFrame* frame) {
+     device_width = static_cast<int>(
+         lroundf(device_width * screen_info.device_scale_factor));
+   }
++  float width_override = frame->GetPage()->PageWidthOverride();
++  if (width_override) {
++    device_width = static_cast<int>(
++        lroundf(device_width * (1.0 - (width_override / 100.0))));
++  }
+   return device_width;
+ }
+ 
+@@ -205,6 +210,11 @@ int MediaValues::CalculateDeviceHeight(LocalFrame* frame) {
+     device_height = static_cast<int>(
+         lroundf(device_height * screen_info.device_scale_factor));
+   }
++  float width_override = frame->GetPage()->PageWidthOverride();
++  if (width_override) {
++    device_height = static_cast<int>(
++        lroundf(device_height * (1.0 - (width_override / 100.0))));
++  }
+   return device_height;
+ }
+ 
+diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
+--- a/third_party/blink/renderer/core/frame/local_frame_view.cc
++++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
+@@ -1034,6 +1034,9 @@ gfx::SizeF LocalFrameView::ViewportSizeForMediaQueries() const {
+   gfx::SizeF viewport_size(layout_size_);
+   if (!frame_->GetDocument() || !frame_->GetDocument()->Printing())
+     viewport_size.Scale(1 / GetFrame().PageZoomFactor());
++  float width_override = frame_->GetPage()->PageWidthOverride();
++  if (width_override)
++    viewport_size.Scale(1.0 + (width_override / 100.0));
+   return viewport_size;
+ }
+ 
+diff --git a/third_party/blink/renderer/core/frame/screen.cc b/third_party/blink/renderer/core/frame/screen.cc
+--- a/third_party/blink/renderer/core/frame/screen.cc
++++ b/third_party/blink/renderer/core/frame/screen.cc
+@@ -35,6 +35,7 @@
+ #include "third_party/blink/renderer/core/frame/local_frame.h"
+ #include "third_party/blink/renderer/core/frame/settings.h"
+ #include "third_party/blink/renderer/core/page/chrome_client.h"
++#include "third_party/blink/renderer/core/page/page.h"
+ #include "ui/display/screen_info.h"
+ #include "ui/display/screen_infos.h"
+ 
+@@ -42,6 +43,10 @@ namespace blink {
+ 
+ namespace {
+ 
++float GetScaleOverride(blink::Page* page) {
++  return 1.0 - (page->PageWidthOverride() / 100.0);
++}
++
+ }  // namespace
+ 
+ Screen::Screen(LocalDOMWindow* window, int64_t display_id)
+@@ -83,9 +88,10 @@ int Screen::height() const {
+   const display::ScreenInfo& screen_info = GetScreenInfo();
+   if (frame->GetSettings()->GetReportScreenSizeInPhysicalPixelsQuirk()) {
+     return base::ClampRound(screen_info.rect.height() *
++                            GetScaleOverride(frame->GetPage()) *
+                             screen_info.device_scale_factor);
+   }
+-  return screen_info.rect.height();
++  return screen_info.rect.height() * GetScaleOverride(frame->GetPage());
+ }
+ 
+ int Screen::width() const {
+@@ -95,9 +101,10 @@ int Screen::width() const {
+   const display::ScreenInfo& screen_info = GetScreenInfo();
+   if (frame->GetSettings()->GetReportScreenSizeInPhysicalPixelsQuirk()) {
+     return base::ClampRound(screen_info.rect.width() *
++                            GetScaleOverride(frame->GetPage()) *
+                             screen_info.device_scale_factor);
+   }
+-  return screen_info.rect.width();
++  return screen_info.rect.width() * GetScaleOverride(frame->GetPage());
+ }
+ 
+ unsigned Screen::colorDepth() const {
+@@ -141,9 +148,10 @@ int Screen::availHeight() const {
+   const display::ScreenInfo& screen_info = GetScreenInfo();
+   if (frame->GetSettings()->GetReportScreenSizeInPhysicalPixelsQuirk()) {
+     return base::ClampRound(screen_info.available_rect.height() *
++                            GetScaleOverride(frame->GetPage()) *
+                             screen_info.device_scale_factor);
+   }
+-  return screen_info.available_rect.height();
++  return screen_info.available_rect.height() * GetScaleOverride(frame->GetPage());
+ }
+ 
+ int Screen::availWidth() const {
+@@ -153,9 +161,10 @@ int Screen::availWidth() const {
+   const display::ScreenInfo& screen_info = GetScreenInfo();
+   if (frame->GetSettings()->GetReportScreenSizeInPhysicalPixelsQuirk()) {
+     return base::ClampRound(screen_info.available_rect.width() *
++                            GetScaleOverride(frame->GetPage()) *
+                             screen_info.device_scale_factor);
+   }
+-  return screen_info.available_rect.width();
++  return screen_info.available_rect.width() * GetScaleOverride(frame->GetPage());
+ }
+ 
+ void Screen::Trace(Visitor* visitor) const {
+diff --git a/third_party/blink/renderer/core/frame/visual_viewport.cc b/third_party/blink/renderer/core/frame/visual_viewport.cc
+--- a/third_party/blink/renderer/core/frame/visual_viewport.cc
++++ b/third_party/blink/renderer/core/frame/visual_viewport.cc
+@@ -467,6 +467,10 @@ void VisualViewport::SetScale(float scale) {
+                       gfx::PointAtOffsetFromOrigin(offset_));
+ }
+ 
++void VisualViewport::SetPageWidthOverride(int value) {
++  page_width_override_ = value;
++}
++
+ double VisualViewport::OffsetLeft() const {
+   // Offset{Left|Top} and Width|Height are used by the DOMVisualViewport to
+   // expose values to JS. We'll only ever ask the visual viewport for these
+diff --git a/third_party/blink/renderer/core/frame/visual_viewport.h b/third_party/blink/renderer/core/frame/visual_viewport.h
+--- a/third_party/blink/renderer/core/frame/visual_viewport.h
++++ b/third_party/blink/renderer/core/frame/visual_viewport.h
+@@ -145,6 +145,9 @@ class CORE_EXPORT VisualViewport : public GarbageCollected<VisualViewport>,
+   float Scale() const { return scale_; }
+   bool IsPinchGestureActive() const { return is_pinch_gesture_active_; }
+ 
++  void SetPageWidthOverride(int);
++  int PageWidthOverride() const { return page_width_override_; }
++
+   // Convert the given rect in the main LocalFrameView's coordinates into a rect
+   // in the viewport. The given and returned rects are in CSS pixels, meaning
+   // scale isn't applied.
+@@ -382,6 +385,8 @@ class CORE_EXPORT VisualViewport : public GarbageCollected<VisualViewport>,
+   CompositorElementId elasticity_effect_node_id_;
+ 
+   bool needs_paint_property_update_;
++
++  int page_width_override_;
+ };
+ 
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/core/html/html_meta_element.cc b/third_party/blink/renderer/core/html/html_meta_element.cc
+--- a/third_party/blink/renderer/core/html/html_meta_element.cc
++++ b/third_party/blink/renderer/core/html/html_meta_element.cc
+@@ -22,6 +22,7 @@
+ 
+ #include "third_party/blink/renderer/core/html/html_meta_element.h"
+ 
++#include "base/rand_util.h"
+ #include "third_party/blink/public/mojom/frame/color_scheme.mojom-blink.h"
+ #include "third_party/blink/renderer/core/css/style_engine.h"
+ #include "third_party/blink/renderer/core/dom/document.h"
+@@ -565,6 +566,27 @@ void HTMLMetaElement::ProcessContent() {
+   if (!IsInDocumentTree())
+     return;
+ 
++  bool process_default = true;
++
++  if (GetDocument().GetFrame()) {
++    blink::LocalFrame* frame = GetDocument().GetFrame();
++    blink::WebContentSettingsClient* settings = frame->GetContentSettingsClient();
++    blink::Page* page = frame->GetPage();
++
++    if (settings->AllowViewportChange(false)) {
++      if (page->PageWidthOverride() == 0) {
++        page->SetPageWidthOverride(base::RandInt(-5, 15));
++      }
++
++      float device_width = 1.0 + (page->PageWidthOverride() / 100.0);
++      String newvalue("initial-scale=" + base::NumberToString(device_width));
++      ProcessViewportContentAttribute(newvalue, ViewportDescription::kViewportMeta);
++      process_default = false;
++    } else {
++      page->SetPageWidthOverride(0);
++    }
++  }
++
+   const AtomicString& name_value = FastGetAttribute(html_names::kNameAttr);
+   if (name_value.IsEmpty())
+     return;
+@@ -594,8 +616,10 @@ void HTMLMetaElement::ProcessContent() {
+     return;
+ 
+   if (EqualIgnoringASCIICase(name_value, "viewport")) {
+-    ProcessViewportContentAttribute(content_value,
+-                                    ViewportDescription::kViewportMeta);
++    if (process_default) {
++      ProcessViewportContentAttribute(content_value,
++                                      ViewportDescription::kViewportMeta);
++    }
+   } else if (EqualIgnoringASCIICase(name_value, "referrer") &&
+              GetExecutionContext()) {
+     UseCounter::Count(&GetDocument(),
+diff --git a/third_party/blink/renderer/core/loader/frame_loader.cc b/third_party/blink/renderer/core/loader/frame_loader.cc
+--- a/third_party/blink/renderer/core/loader/frame_loader.cc
++++ b/third_party/blink/renderer/core/loader/frame_loader.cc
+@@ -371,8 +371,11 @@ void FrameLoader::SaveScrollState() {
+   history_item->SetVisualViewportScrollOffset(
+       frame_->GetPage()->GetVisualViewport().VisibleRect().OffsetFromOrigin());
+ 
+-  if (frame_->IsMainFrame())
+-    history_item->SetPageScaleFactor(frame_->GetPage()->PageScaleFactor());
++  if (frame_->IsMainFrame()) {
++    int page_width_override = frame_->GetPage()->PageWidthOverride();
++    if (page_width_override == 0)
++      history_item->SetPageScaleFactor(frame_->GetPage()->PageScaleFactor());
++  }
+ 
+   Client()->DidUpdateCurrentHistoryItem();
+ }
+diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/renderer/core/page/page.cc
+--- a/third_party/blink/renderer/core/page/page.cc
++++ b/third_party/blink/renderer/core/page/page.cc
+@@ -507,6 +507,14 @@ float Page::PageScaleFactor() const {
+   return GetVisualViewport().Scale();
+ }
+ 
++void Page::SetPageWidthOverride(float value) {
++  GetVisualViewport().SetPageWidthOverride(value);
++}
++
++int Page::PageWidthOverride() const {
++  return GetVisualViewport().PageWidthOverride();
++}
++
+ void Page::AllVisitedStateChanged(bool invalidate_visited_link_hashes) {
+   for (const Page* page : OrdinaryPages()) {
+     for (Frame* frame = page->main_frame_; frame;
+diff --git a/third_party/blink/renderer/core/page/page.h b/third_party/blink/renderer/core/page/page.h
+--- a/third_party/blink/renderer/core/page/page.h
++++ b/third_party/blink/renderer/core/page/page.h
+@@ -273,6 +273,9 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
+   void SetPageScaleFactor(float);
+   float PageScaleFactor() const;
+ 
++  void SetPageWidthOverride(float);
++  int PageWidthOverride() const;
++
+   float InspectorDeviceScaleFactorOverride() const {
+     return inspector_device_scale_factor_override_;
+   }
+diff --git a/third_party/blink/renderer/modules/screen_enumeration/screen_detailed.cc b/third_party/blink/renderer/modules/screen_enumeration/screen_detailed.cc
+--- a/third_party/blink/renderer/modules/screen_enumeration/screen_detailed.cc
++++ b/third_party/blink/renderer/modules/screen_enumeration/screen_detailed.cc
+@@ -9,12 +9,22 @@
+ #include "third_party/blink/renderer/core/frame/local_frame.h"
+ #include "third_party/blink/renderer/core/frame/settings.h"
+ #include "third_party/blink/renderer/core/page/chrome_client.h"
++#include "third_party/blink/renderer/core/page/page.h"
++#include "third_party/blink/public/platform/web_content_settings_client.h"
+ #include "third_party/blink/renderer/platform/wtf/text/string_statics.h"
+ #include "ui/display/screen_info.h"
+ #include "ui/display/screen_infos.h"
+ 
+ namespace blink {
+ 
++namespace {
++
++float GetScaleOverride(blink::Page* page) {
++  return 1.0 - (page->PageWidthOverride() / 100.0);
++}
++
++}
++
+ ScreenDetailed::ScreenDetailed(LocalDOMWindow* window,
+                                int64_t display_id,
+                                bool label_is_internal,
+@@ -87,6 +97,11 @@ bool ScreenDetailed::isInternal() const {
+ float ScreenDetailed::devicePixelRatio() const {
+   if (!DomWindow())
+     return 0.f;
++  LocalFrame* frame = DomWindow()->GetFrame();
++  blink::WebContentSettingsClient* settings = frame->GetContentSettingsClient();
++  blink::Page* page = frame->GetPage();
++  if (settings->AllowViewportChange(false))
++    return GetScreenInfo().device_scale_factor * GetScaleOverride(page);
+   return GetScreenInfo().device_scale_factor;
+ }
+ 
+--
+2.25.1

--- a/build/patches/Add-Viewport-Protection.patch
+++ b/build/patches/Add-Viewport-Protection.patch
@@ -2,6 +2,10 @@ From: uazo <uazo@users.noreply.github.com>
 Date: Thu, 30 Jun 2022 12:47:17 +0000
 Subject: Viewport Protection
 
+Scale the viewport by a random factor to prevent coordinate-based fingerprinting scripts.
+The factor is changed at each change of origin.
+It acts on the javascript api to prevent the possibility of value recovery.
+The feature is controlled by a site setting (default disabled)
 ---
  .../browser_ui/site_settings/android/BUILD.gn |  3 +
  .../BromiteCustomContentSettingImpl.java      |  1 +
@@ -21,18 +25,19 @@ Subject: Viewport Protection
  .../renderer/content_settings_agent_impl.cc   |  9 ++
  .../renderer/content_settings_agent_impl.h    |  1 +
  .../platform/web_content_settings_client.h    |  2 +
- .../blink/renderer/core/css/media_values.cc   | 10 +++
+ .../blink/renderer/core/css/media_values.cc   | 22 ++++-
  .../core/frame/dom_visual_viewport.cc         |  4 +-
+ .../renderer/core/frame/local_dom_window.cc   |  6 ++
  .../renderer/core/frame/local_frame_view.cc   |  3 +
  .../blink/renderer/core/frame/screen.cc       | 17 +++-
  .../renderer/core/frame/visual_viewport.cc    |  4 +
  .../renderer/core/frame/visual_viewport.h     |  5 ++
  .../renderer/core/html/html_meta_element.cc   | 28 +++++-
- .../renderer/core/loader/frame_loader.cc      |  7 +-
+ .../renderer/core/loader/frame_loader.cc      | 15 +++-
  third_party/blink/renderer/core/page/page.cc  |  8 ++
  third_party/blink/renderer/core/page/page.h   |  3 +
  .../screen_enumeration/screen_detailed.cc     | 15 ++++
- 29 files changed, 250 insertions(+), 13 deletions(-)
+ 30 files changed, 275 insertions(+), 14 deletions(-)
  create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
  create mode 100644 components/browser_ui/strings/android/viewport.grdp
 
@@ -341,7 +346,7 @@ diff --git a/components/content_settings/core/common/content_settings_types.h b/
 diff --git a/components/content_settings/renderer/content_settings_agent_impl.cc b/components/content_settings/renderer/content_settings_agent_impl.cc
 --- a/components/content_settings/renderer/content_settings_agent_impl.cc
 +++ b/components/content_settings/renderer/content_settings_agent_impl.cc
-@@ -473,6 +473,15 @@ bool ContentSettingsAgentImpl::AllowWebRTC(bool enabled_per_settings) {
+@@ -467,6 +467,15 @@ bool ContentSettingsAgentImpl::AllowWebRTC(bool enabled_per_settings) {
               url::Origin(frame->GetDocument().GetSecurityOrigin()).GetURL());
  }
  
@@ -360,7 +365,7 @@ diff --git a/components/content_settings/renderer/content_settings_agent_impl.cc
 diff --git a/components/content_settings/renderer/content_settings_agent_impl.h b/components/content_settings/renderer/content_settings_agent_impl.h
 --- a/components/content_settings/renderer/content_settings_agent_impl.h
 +++ b/components/content_settings/renderer/content_settings_agent_impl.h
-@@ -96,6 +96,7 @@ class ContentSettingsAgentImpl
+@@ -101,6 +101,7 @@ class ContentSettingsAgentImpl
    bool ShouldAutoupgradeMixedContent() override;
    bool AllowWebgl(bool enabled_per_settings) override;
    bool AllowWebRTC(bool enabled_per_settings) override;
@@ -383,7 +388,32 @@ diff --git a/third_party/blink/public/platform/web_content_settings_client.h b/t
 diff --git a/third_party/blink/renderer/core/css/media_values.cc b/third_party/blink/renderer/core/css/media_values.cc
 --- a/third_party/blink/renderer/core/css/media_values.cc
 +++ b/third_party/blink/renderer/core/css/media_values.cc
-@@ -193,6 +193,11 @@ int MediaValues::CalculateDeviceWidth(LocalFrame* frame) {
+@@ -132,13 +132,23 @@ double MediaValues::CalculateViewportWidth(LocalFrame* frame) {
+   DCHECK(frame);
+   DCHECK(frame->View());
+   DCHECK(frame->GetDocument());
+-  return frame->View()->ViewportSizeForMediaQueries().width();
++  float width_override = frame->GetPage()->PageWidthOverride();
++  double width = frame->View()->ViewportSizeForMediaQueries().width();
++  if (width_override) {
++    width = width * (1.0 - (width_override / 100.0));
++  }
++  return width;
+ }
+ 
+ double MediaValues::CalculateViewportHeight(LocalFrame* frame) {
+   DCHECK(frame);
+   DCHECK(frame->View());
+   DCHECK(frame->GetDocument());
++  float width_override = frame->GetPage()->PageWidthOverride();
++  double height = frame->View()->ViewportSizeForMediaQueries().height();
++  if (width_override) {
++    height = height * (1.0 - (width_override / 100.0));
++  }
+   return frame->View()->ViewportSizeForMediaQueries().height();
+ }
+ 
+@@ -193,6 +203,11 @@ int MediaValues::CalculateDeviceWidth(LocalFrame* frame) {
      device_width = static_cast<int>(
          lroundf(device_width * screen_info.device_scale_factor));
    }
@@ -395,7 +425,7 @@ diff --git a/third_party/blink/renderer/core/css/media_values.cc b/third_party/b
    return device_width;
  }
  
-@@ -205,6 +210,11 @@ int MediaValues::CalculateDeviceHeight(LocalFrame* frame) {
+@@ -205,6 +220,11 @@ int MediaValues::CalculateDeviceHeight(LocalFrame* frame) {
      device_height = static_cast<int>(
          lroundf(device_height * screen_info.device_scale_factor));
    }
@@ -422,6 +452,29 @@ diff --git a/third_party/blink/renderer/core/frame/dom_visual_viewport.cc b/thir
  
    return 0;
  }
+diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_party/blink/renderer/core/frame/local_dom_window.cc
+--- a/third_party/blink/renderer/core/frame/local_dom_window.cc
++++ b/third_party/blink/renderer/core/frame/local_dom_window.cc
+@@ -1400,6 +1400,9 @@ int LocalDOMWindow::outerHeight() const {
+   if (!page)
+     return 0;
+ 
++  float width_override = page->PageWidthOverride();
++  if (width_override) return innerHeight();
++
+   ChromeClient& chrome_client = page->GetChromeClient();
+   if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
+     return static_cast<int>(
+@@ -1425,6 +1428,9 @@ int LocalDOMWindow::outerWidth() const {
+   if (!page)
+     return 0;
+ 
++  float width_override = page->PageWidthOverride();
++  if (width_override) return innerWidth();
++
+   ChromeClient& chrome_client = page->GetChromeClient();
+   if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
+     return static_cast<int>(
 diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
 --- a/third_party/blink/renderer/core/frame/local_frame_view.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
@@ -565,7 +618,7 @@ diff --git a/third_party/blink/renderer/core/html/html_meta_element.cc b/third_p
 +
 +    if (settings->AllowViewportChange(false)) {
 +      if (page->PageWidthOverride() == 0) {
-+        page->SetPageWidthOverride(base::RandInt(-5, 15));
++        page->SetPageWidthOverride(base::RandInt(-30, 150) / 100.0);
 +      }
 +
 +      float device_width = 1.0 + (page->PageWidthOverride() / 100.0);
@@ -596,7 +649,7 @@ diff --git a/third_party/blink/renderer/core/html/html_meta_element.cc b/third_p
 diff --git a/third_party/blink/renderer/core/loader/frame_loader.cc b/third_party/blink/renderer/core/loader/frame_loader.cc
 --- a/third_party/blink/renderer/core/loader/frame_loader.cc
 +++ b/third_party/blink/renderer/core/loader/frame_loader.cc
-@@ -371,8 +371,11 @@ void FrameLoader::SaveScrollState() {
+@@ -371,8 +371,13 @@ void FrameLoader::SaveScrollState() {
    history_item->SetVisualViewportScrollOffset(
        frame_->GetPage()->GetVisualViewport().VisibleRect().OffsetFromOrigin());
  
@@ -604,12 +657,27 @@ diff --git a/third_party/blink/renderer/core/loader/frame_loader.cc b/third_part
 -    history_item->SetPageScaleFactor(frame_->GetPage()->PageScaleFactor());
 +  if (frame_->IsMainFrame()) {
 +    int page_width_override = frame_->GetPage()->PageWidthOverride();
-+    if (page_width_override == 0)
++    if (page_width_override == 0) {
++      // set the scale factor only if the feature is not active
 +      history_item->SetPageScaleFactor(frame_->GetPage()->PageScaleFactor());
++    }
 +  }
  
    Client()->DidUpdateCurrentHistoryItem();
  }
+@@ -1326,6 +1331,12 @@ void FrameLoader::RestoreScrollPositionAndViewState() {
+       !GetDocumentLoader()->NavigationScrollAllowed()) {
+     return;
+   }
++  int page_width_override = frame_->GetPage()->PageWidthOverride();
++  if (page_width_override != 0) {
++    // we need to reset the page scale because, if the user activates
++    // the feature, it could be non-zero from the previous navigation
++    GetDocumentLoader()->GetHistoryItem()->SetPageScaleFactor(0);
++  }
+   RestoreScrollPositionAndViewState(
+       GetDocumentLoader()->LoadType(),
+       *GetDocumentLoader()->GetHistoryItem()->GetViewState(),
 diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/renderer/core/page/page.cc
 --- a/third_party/blink/renderer/core/page/page.cc
 +++ b/third_party/blink/renderer/core/page/page.cc

--- a/build/patches/Viewport-Protection.patch
+++ b/build/patches/Viewport-Protection.patch
@@ -1,5 +1,5 @@
 From: uazo <uazo@users.noreply.github.com>
-Date: Fri, 26 Aug 2022 13:15:43 +0000
+Date: Thu, 17 Nov 2022 14:23:47 +0000
 Subject: Viewport Protection
 
 Scale the viewport and the screen by a random factor to prevent coordinate-based fingerprinting scripts.
@@ -45,7 +45,7 @@ The feature is controlled by a site setting (default disabled)
 diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/browser_ui/site_settings/android/BUILD.gn
 --- a/components/browser_ui/site_settings/android/BUILD.gn
 +++ b/components/browser_ui/site_settings/android/BUILD.gn
-@@ -85,6 +85,9 @@ android_library("java") {
+@@ -95,6 +95,9 @@ android_library("java") {
    sources += [
      "java/src/org/chromium/components/browser_ui/site_settings/BromiteWebRTCContentSetting.java",
    ]
@@ -191,7 +191,7 @@ diff --git a/components/browser_ui/strings/android/browser_ui_strings.grd b/comp
        <part file="webrtc.grdp" />
 +      <part file="viewport.grdp" />
  
-       <message name="IDS_GOT_IT" desc="Button for the user to accept a disclosure/message">
+       <message name="IDS_GOT_IT" desc="Button for the user to accept a disclosure/message" formatter_data="android_java">
          Got it
 diff --git a/components/browser_ui/strings/android/viewport.grdp b/components/browser_ui/strings/android/viewport.grdp
 new file mode 100644
@@ -219,18 +219,18 @@ new file mode 100644
 diff --git a/components/components_strings.grd b/components/components_strings.grd
 --- a/components/components_strings.grd
 +++ b/components/components_strings.grd
-@@ -340,6 +340,7 @@
-       <part file="user_scripts/strings/userscripts_strings.grdp" />
+@@ -341,6 +341,7 @@
+ 
        <part file="browser_ui/strings/android/webgl.grdp" />
        <part file="browser_ui/strings/android/webrtc.grdp" />
 +      <part file="browser_ui/strings/android/viewport.grdp" />
- 
        <if expr="not is_ios">
          <part file="history_clusters_strings.grdp" />
+       </if>
 diff --git a/components/content_settings/core/browser/content_settings_registry.cc b/components/content_settings/core/browser/content_settings_registry.cc
 --- a/components/content_settings/core/browser/content_settings_registry.cc
 +++ b/components/content_settings/core/browser/content_settings_registry.cc
-@@ -707,6 +707,20 @@ void ContentSettingsRegistry::Init() {
+@@ -715,6 +715,20 @@ void ContentSettingsRegistry::Init() {
             /*show_into_info_page*/ true,
             /*permission_type_ui*/ IDS_SITE_SETTINGS_TYPE_WEBRTC,
             /*permission_type_ui_mid_sentence*/ IDS_SITE_SETTINGS_TYPE_WEBRTC_MID_SENTENCE);
@@ -240,7 +240,7 @@ diff --git a/components/content_settings/core/browser/content_settings_registry.
 +           AllowlistedSchemes(),
 +           ValidSettings(CONTENT_SETTING_ALLOW,
 +                         CONTENT_SETTING_BLOCK),
-+           WebsiteSettingsInfo::SINGLE_ORIGIN_WITH_EMBEDDED_EXCEPTIONS_SCOPE,
++           WebsiteSettingsInfo::TOP_ORIGIN_ONLY_SCOPE,
 +           WebsiteSettingsRegistry::PLATFORM_ANDROID,
 +           ContentSettingsInfo::INHERIT_IN_INCOGNITO,
 +           ContentSettingsInfo::PERSISTENT,
@@ -254,7 +254,7 @@ diff --git a/components/content_settings/core/browser/content_settings_registry.
 diff --git a/components/content_settings/core/browser/content_settings_utils.cc b/components/content_settings/core/browser/content_settings_utils.cc
 --- a/components/content_settings/core/browser/content_settings_utils.cc
 +++ b/components/content_settings/core/browser/content_settings_utils.cc
-@@ -159,6 +159,8 @@ void GetRendererContentSettingRules(const HostContentSettingsMap* map,
+@@ -160,6 +160,8 @@ void GetRendererContentSettingRules(const HostContentSettingsMap* map,
                               &(rules->webgl_rules));
    map->GetSettingsForOneType(ContentSettingsType::WEBRTC,
                               &(rules->webrtc_rules));
@@ -266,7 +266,7 @@ diff --git a/components/content_settings/core/browser/content_settings_utils.cc 
 diff --git a/components/content_settings/core/common/content_settings.cc b/components/content_settings/core/common/content_settings.cc
 --- a/components/content_settings/core/common/content_settings.cc
 +++ b/components/content_settings/core/common/content_settings.cc
-@@ -207,7 +207,8 @@ bool RendererContentSettingRules::IsRendererContentSetting(
+@@ -208,7 +208,8 @@ bool RendererContentSettingRules::IsRendererContentSetting(
           content_type == ContentSettingsType::AUTO_DARK_WEB_CONTENT ||
           content_type == ContentSettingsType::TIMEZONE_OVERRIDE ||
           content_type == ContentSettingsType::WEBGL ||
@@ -276,7 +276,7 @@ diff --git a/components/content_settings/core/common/content_settings.cc b/compo
  }
  
  void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
-@@ -221,6 +222,7 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+@@ -222,6 +223,7 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
    FilterRulesForType(autoplay_rules, outermost_main_frame_url);
    FilterRulesForType(webgl_rules, outermost_main_frame_url);
    FilterRulesForType(webrtc_rules, outermost_main_frame_url);
@@ -287,7 +287,7 @@ diff --git a/components/content_settings/core/common/content_settings.cc b/compo
 diff --git a/components/content_settings/core/common/content_settings.h b/components/content_settings/core/common/content_settings.h
 --- a/components/content_settings/core/common/content_settings.h
 +++ b/components/content_settings/core/common/content_settings.h
-@@ -99,6 +99,7 @@ struct RendererContentSettingRules {
+@@ -98,6 +98,7 @@ struct RendererContentSettingRules {
    std::string timezone_override_value;
    ContentSettingsForOneType webgl_rules;
    ContentSettingsForOneType webrtc_rules;
@@ -307,7 +307,7 @@ diff --git a/components/content_settings/core/common/content_settings.mojom b/co
 diff --git a/components/content_settings/core/common/content_settings_mojom_traits.cc b/components/content_settings/core/common/content_settings_mojom_traits.cc
 --- a/components/content_settings/core/common/content_settings_mojom_traits.cc
 +++ b/components/content_settings/core/common/content_settings_mojom_traits.cc
-@@ -106,7 +106,8 @@ bool StructTraits<content_settings::mojom::RendererContentSettingRulesDataView,
+@@ -107,7 +107,8 @@ bool StructTraits<content_settings::mojom::RendererContentSettingRulesDataView,
           data.ReadTimezoneOverrideRules(&out->timezone_override_rules) &&
           data.ReadTimezoneOverrideValue(&out->timezone_override_value) &&
           data.ReadWebglRules(&out->webgl_rules) &&
@@ -335,7 +335,7 @@ diff --git a/components/content_settings/core/common/content_settings_mojom_trai
 diff --git a/components/content_settings/core/common/content_settings_types.h b/components/content_settings/core/common/content_settings_types.h
 --- a/components/content_settings/core/common/content_settings_types.h
 +++ b/components/content_settings/core/common/content_settings_types.h
-@@ -284,6 +284,8 @@ enum class ContentSettingsType : int32_t {
+@@ -280,6 +280,8 @@ enum class ContentSettingsType : int32_t {
  
    WEBRTC,
  
@@ -389,7 +389,7 @@ diff --git a/third_party/blink/public/platform/web_content_settings_client.h b/t
 diff --git a/third_party/blink/renderer/core/css/resolver/style_resolver.cc b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
 --- a/third_party/blink/renderer/core/css/resolver/style_resolver.cc
 +++ b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
-@@ -1487,8 +1487,14 @@ scoped_refptr<ComputedStyle> StyleResolver::InitialStyleForElement() const {
+@@ -1513,8 +1513,14 @@ scoped_refptr<ComputedStyle> StyleResolver::InitialStyleForElement() const {
  
    initial_style->SetRtlOrdering(
        GetDocument().VisuallyOrdered() ? EOrder::kVisual : EOrder::kLogical);
@@ -417,7 +417,7 @@ diff --git a/third_party/blink/renderer/core/events/mouse_event.h b/third_party/
  
  namespace blink {
  
-@@ -139,8 +140,22 @@ class CORE_EXPORT MouseEvent : public UIEventWithKeyState {
+@@ -141,8 +142,22 @@ class CORE_EXPORT MouseEvent : public UIEventWithKeyState {
  
    // Note that these values are adjusted to counter the effects of zoom, so that
    // values exposed via DOM APIs are invariant under zooming.
@@ -478,7 +478,7 @@ diff --git a/third_party/blink/renderer/core/events/pointer_event.h b/third_part
 diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_party/blink/renderer/core/exported/web_view_impl.cc
 --- a/third_party/blink/renderer/core/exported/web_view_impl.cc
 +++ b/third_party/blink/renderer/core/exported/web_view_impl.cc
-@@ -1014,7 +1014,7 @@ WebPagePopupImpl* WebViewImpl::OpenPagePopup(PagePopupClient* client) {
+@@ -1028,7 +1028,7 @@ WebPagePopupImpl* WebViewImpl::OpenPagePopup(PagePopupClient* client) {
    page_popup_ = WebPagePopupImpl::Create(
        std::move(popup_widget_host), std::move(widget_host),
        std::move(widget_receiver), this, agent_group_scheduler,
@@ -490,7 +490,7 @@ diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_p
 diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_party/blink/renderer/core/frame/local_dom_window.cc
 --- a/third_party/blink/renderer/core/frame/local_dom_window.cc
 +++ b/third_party/blink/renderer/core/frame/local_dom_window.cc
-@@ -1388,6 +1388,11 @@ int LocalDOMWindow::outerHeight() const {
+@@ -1407,6 +1407,11 @@ int LocalDOMWindow::outerHeight() const {
    if (!page)
      return 0;
  
@@ -502,7 +502,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
    ChromeClient& chrome_client = page->GetChromeClient();
    if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
      return static_cast<int>(
-@@ -1413,6 +1418,11 @@ int LocalDOMWindow::outerWidth() const {
+@@ -1432,6 +1437,11 @@ int LocalDOMWindow::outerWidth() const {
    if (!page)
      return 0;
  
@@ -514,7 +514,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
    ChromeClient& chrome_client = page->GetChromeClient();
    if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
      return static_cast<int>(
-@@ -1600,7 +1610,8 @@ double LocalDOMWindow::devicePixelRatio() const {
+@@ -1619,7 +1629,8 @@ double LocalDOMWindow::devicePixelRatio() const {
    if (!GetFrame())
      return 0.0;
  
@@ -524,7 +524,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
  }
  
  void LocalDOMWindow::scrollBy(double x, double y) const {
-@@ -2142,6 +2153,20 @@ DOMWindow* LocalDOMWindow::open(v8::Isolate* isolate,
+@@ -2177,6 +2188,20 @@ DOMWindow* LocalDOMWindow::open(v8::Isolate* isolate,
    if (!completed_url.IsEmpty() || result.new_window)
      result.frame->Navigate(frame_request, WebFrameLoadType::kStandard);
  
@@ -548,7 +548,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
 diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/blink/renderer/core/frame/local_frame.cc
 --- a/third_party/blink/renderer/core/frame/local_frame.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame.cc
-@@ -1267,6 +1267,10 @@ gfx::SizeF LocalFrame::ResizePageRectsKeepingRatio(
+@@ -1275,6 +1275,10 @@ gfx::SizeF LocalFrame::ResizePageRectsKeepingRatio(
    return gfx::SizeF(result_width, result_height);
  }
  
@@ -559,7 +559,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/
  void LocalFrame::SetPageZoomFactor(float factor) {
    SetPageAndTextZoomFactors(factor, text_zoom_factor_);
  }
-@@ -1406,12 +1410,16 @@ device::mojom::blink::DevicePostureType LocalFrame::GetDevicePosture() {
+@@ -1414,12 +1418,16 @@ device::mojom::blink::DevicePostureType LocalFrame::GetDevicePosture() {
    return mojo_handler_->GetDevicePosture();
  }
  
@@ -581,7 +581,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/
 diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/blink/renderer/core/frame/local_frame.h
 --- a/third_party/blink/renderer/core/frame/local_frame.h
 +++ b/third_party/blink/renderer/core/frame/local_frame.h
-@@ -364,13 +364,14 @@ class CORE_EXPORT LocalFrame final
+@@ -378,13 +378,14 @@ class CORE_EXPORT LocalFrame final
    void SetInViewSourceMode(bool = true);
  
    void SetPageZoomFactor(float);
@@ -598,7 +598,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/b
  
    // Informs the local root's document and its local descendant subtree that a
    // media query value changed.
-@@ -886,6 +887,7 @@ class CORE_EXPORT LocalFrame final
+@@ -920,6 +921,7 @@ class CORE_EXPORT LocalFrame final
    unsigned hidden_ : 1;
  
    float page_zoom_factor_;
@@ -659,7 +659,7 @@ diff --git a/third_party/blink/renderer/core/frame/screen_metrics_emulator.h b/t
 diff --git a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc b/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
 --- a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
 +++ b/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
-@@ -1579,6 +1579,14 @@ void WebFrameWidgetImpl::ApplyVisualPropertiesSizing(
+@@ -1578,6 +1578,14 @@ void WebFrameWidgetImpl::ApplyVisualPropertiesSizing(
  
      if (auto* device_emulator = DeviceEmulator()) {
        device_emulator->UpdateVisualProperties(visual_properties);
@@ -677,7 +677,7 @@ diff --git a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc b/th
 diff --git a/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc b/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
 --- a/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
 +++ b/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
-@@ -339,7 +339,8 @@ void WebRemoteFrameImpl::InitializeFrameVisualProperties(
+@@ -348,7 +348,8 @@ void WebRemoteFrameImpl::InitializeFrameVisualProperties(
    visual_properties.page_scale_factor = ancestor_widget->PageScaleInMainFrame();
    visual_properties.is_pinch_gesture_active =
        ancestor_widget->PinchGestureActiveInMainFrame();

--- a/build/patches/Viewport-Protection.patch
+++ b/build/patches/Viewport-Protection.patch
@@ -31,8 +31,8 @@ The feature is controlled by a feature flag (default enabled)
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -7627,6 +7627,11 @@ const FeatureEntry kFeatureEntries[] = {
-                                     "PaintPreviewShowOnStartup")},
+@@ -7768,6 +7768,11 @@ const FeatureEntry kFeatureEntries[] = {
+      FEATURE_VALUE_TYPE(paint_preview::kPaintPreviewDemo)},
  #endif  // BUILDFLAG(ENABLE_PAINT_PREVIEW) && BUILDFLAG(IS_ANDROID)
  
 +    {"viewport-protection",
@@ -46,8 +46,8 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
-@@ -6847,6 +6847,12 @@ const char kPaintPreviewStartupDescription[] =
-     "instead.";
+@@ -6654,6 +6654,12 @@ const char kPaintPreviewDemoDescription[] =
+     "previews.";
  #endif  // ENABLE_PAINT_PREVIEW && BUILDFLAG(IS_ANDROID)
  
 +const char kViewportProtectionName[] = "Viewport Protection";
@@ -62,8 +62,8 @@ diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descripti
 diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
 --- a/chrome/browser/flag_descriptions.h
 +++ b/chrome/browser/flag_descriptions.h
-@@ -3948,6 +3948,9 @@ extern const char kPaintPreviewStartupName[];
- extern const char kPaintPreviewStartupDescription[];
+@@ -3857,6 +3857,9 @@ extern const char kPaintPreviewDemoName[];
+ extern const char kPaintPreviewDemoDescription[];
  #endif  // ENABLE_PAINT_PREVIEW && BUILDFLAG(IS_ANDROID)
  
 +extern const char kViewportProtectionName[];
@@ -75,8 +75,8 @@ diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptio
 diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
 --- a/third_party/blink/common/features.cc
 +++ b/third_party/blink/common/features.cc
-@@ -1637,6 +1637,10 @@ BASE_FEATURE(kDocumentEventNodePathCaching,
-              "DocumentEventNodePathCaching",
+@@ -1668,6 +1668,10 @@ BASE_FEATURE(kNewBaseUrlInheritanceBehavior,
+              "NewBaseUrlInheritanceBehavior",
               base::FEATURE_DISABLED_BY_DEFAULT);
  
 +BASE_FEATURE(kViewportProtection,
@@ -89,9 +89,9 @@ diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/fea
 diff --git a/third_party/blink/public/common/features.h b/third_party/blink/public/common/features.h
 --- a/third_party/blink/public/common/features.h
 +++ b/third_party/blink/public/common/features.h
-@@ -867,6 +867,9 @@ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kThreadedBodyLoader);
- // If enabled, will cache for each node's EventPath::NodePath in document.
- BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kDocumentEventNodePathCaching);
+@@ -933,6 +933,9 @@ BLINK_COMMON_EXPORT extern const base::FeatureParam<
+ // base url inheritance behavior from https://crbug.com/1356658.
+ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kNewBaseUrlInheritanceBehavior);
  
 +// Enable blink viewport protection
 +BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kViewportProtection);
@@ -125,22 +125,22 @@ diff --git a/third_party/blink/public/common/widget/device_emulation_params.h b/
 diff --git a/third_party/blink/renderer/core/css/resolver/style_resolver.cc b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
 --- a/third_party/blink/renderer/core/css/resolver/style_resolver.cc
 +++ b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
-@@ -1557,8 +1557,14 @@ scoped_refptr<ComputedStyle> StyleResolver::InitialStyleForElement() const {
- 
-   initial_style->SetRtlOrdering(
-       GetDocument().VisuallyOrdered() ? EOrder::kVisual : EOrder::kLogical);
--  initial_style->SetZoom(InitialZoom());
--  initial_style->SetEffectiveZoom(initial_style->Zoom());
+@@ -1533,8 +1533,14 @@ ComputedStyleBuilder StyleResolver::InitialStyleBuilderForElement() const {
+   ComputedStyleBuilder builder = CreateComputedStyleBuilder();
+   builder.SetRtlOrdering(GetDocument().VisuallyOrdered() ? EOrder::kVisual
+                                                          : EOrder::kLogical);
+-  builder.SetZoom(InitialZoom());
+-  builder.SetEffectiveZoom(InitialZoom());
 +  if (GetDocument().GetPage() && GetDocument().GetPage()->IsScreenEmulated()) {
 +    // hides the zoom override to the dom on the html tag
-+    initial_style->SetZoom(1);
-+    initial_style->SetEffectiveZoom(InitialZoom());
++    builder.SetZoom(1);
++    builder.SetEffectiveZoom(InitialZoom());
 +  } else {
-+    initial_style->SetZoom(InitialZoom());
-+    initial_style->SetEffectiveZoom(initial_style->Zoom());
++    builder.SetZoom(InitialZoom());
++    builder.SetEffectiveZoom(initial_style_->Zoom());
 +  }
-   initial_style->SetInForcedColorsMode(GetDocument().InForcedColorsMode());
-   initial_style->SetTapHighlightColor(
+   builder.SetInForcedColorsMode(GetDocument().InForcedColorsMode());
+   builder.SetTapHighlightColor(
        ComputedStyleInitialValues::InitialTapHighlightColor());
 diff --git a/third_party/blink/renderer/core/events/mouse_event.h b/third_party/blink/renderer/core/events/mouse_event.h
 --- a/third_party/blink/renderer/core/events/mouse_event.h
@@ -214,7 +214,7 @@ diff --git a/third_party/blink/renderer/core/events/pointer_event.h b/third_part
 diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_party/blink/renderer/core/exported/web_view_impl.cc
 --- a/third_party/blink/renderer/core/exported/web_view_impl.cc
 +++ b/third_party/blink/renderer/core/exported/web_view_impl.cc
-@@ -1031,7 +1031,7 @@ WebPagePopupImpl* WebViewImpl::OpenPagePopup(PagePopupClient* client) {
+@@ -1032,7 +1032,7 @@ WebPagePopupImpl* WebViewImpl::OpenPagePopup(PagePopupClient* client) {
    page_popup_ = WebPagePopupImpl::Create(
        std::move(popup_widget_host), std::move(widget_host),
        std::move(widget_receiver), this, agent_group_scheduler,
@@ -226,7 +226,7 @@ diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_p
 diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_party/blink/renderer/core/frame/local_dom_window.cc
 --- a/third_party/blink/renderer/core/frame/local_dom_window.cc
 +++ b/third_party/blink/renderer/core/frame/local_dom_window.cc
-@@ -1437,6 +1437,11 @@ int LocalDOMWindow::outerHeight() const {
+@@ -1478,6 +1478,11 @@ int LocalDOMWindow::outerHeight() const {
    if (!page)
      return 0;
  
@@ -238,7 +238,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
    ChromeClient& chrome_client = page->GetChromeClient();
    if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
      return static_cast<int>(
-@@ -1462,6 +1467,11 @@ int LocalDOMWindow::outerWidth() const {
+@@ -1503,6 +1508,11 @@ int LocalDOMWindow::outerWidth() const {
    if (!page)
      return 0;
  
@@ -250,7 +250,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
    ChromeClient& chrome_client = page->GetChromeClient();
    if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
      return static_cast<int>(
-@@ -1650,7 +1660,8 @@ double LocalDOMWindow::devicePixelRatio() const {
+@@ -1691,7 +1701,8 @@ double LocalDOMWindow::devicePixelRatio() const {
    if (!GetFrame())
      return 0.0;
  
@@ -260,7 +260,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
  }
  
  void LocalDOMWindow::scrollBy(double x, double y) const {
-@@ -2203,6 +2214,21 @@ DOMWindow* LocalDOMWindow::open(v8::Isolate* isolate,
+@@ -2237,6 +2248,21 @@ DOMWindow* LocalDOMWindow::open(v8::Isolate* isolate,
    if (!completed_url.IsEmpty() || result.new_window)
      result.frame->Navigate(frame_request, WebFrameLoadType::kStandard);
  
@@ -285,7 +285,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
 diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/blink/renderer/core/frame/local_frame.cc
 --- a/third_party/blink/renderer/core/frame/local_frame.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame.cc
-@@ -1278,6 +1278,10 @@ gfx::SizeF LocalFrame::ResizePageRectsKeepingRatio(
+@@ -1287,6 +1287,10 @@ gfx::SizeF LocalFrame::ResizePageRectsKeepingRatio(
    return gfx::SizeF(result_width, result_height);
  }
  
@@ -296,7 +296,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/
  void LocalFrame::SetPageZoomFactor(float factor) {
    SetPageAndTextZoomFactors(factor, text_zoom_factor_);
  }
-@@ -1417,12 +1421,16 @@ device::mojom::blink::DevicePostureType LocalFrame::GetDevicePosture() {
+@@ -1426,12 +1430,16 @@ device::mojom::blink::DevicePostureType LocalFrame::GetDevicePosture() {
    return mojo_handler_->GetDevicePosture();
  }
  
@@ -318,7 +318,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/
 diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/blink/renderer/core/frame/local_frame.h
 --- a/third_party/blink/renderer/core/frame/local_frame.h
 +++ b/third_party/blink/renderer/core/frame/local_frame.h
-@@ -381,13 +381,14 @@ class CORE_EXPORT LocalFrame final
+@@ -382,13 +382,14 @@ class CORE_EXPORT LocalFrame final
    void SetInViewSourceMode(bool = true);
  
    void SetPageZoomFactor(float);
@@ -335,7 +335,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/b
  
    // Informs the local root's document and its local descendant subtree that a
    // media query value changed.
-@@ -934,6 +935,7 @@ class CORE_EXPORT LocalFrame final
+@@ -972,6 +973,7 @@ class CORE_EXPORT LocalFrame final
    unsigned hidden_ : 1;
  
    float page_zoom_factor_;
@@ -441,7 +441,7 @@ diff --git a/third_party/blink/renderer/core/frame/screen_metrics_emulator.h b/t
 diff --git a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc b/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
 --- a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
 +++ b/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
-@@ -1578,6 +1578,14 @@ void WebFrameWidgetImpl::ApplyVisualPropertiesSizing(
+@@ -1597,6 +1597,14 @@ void WebFrameWidgetImpl::ApplyVisualPropertiesSizing(
  
      if (auto* device_emulator = DeviceEmulator()) {
        device_emulator->UpdateVisualProperties(visual_properties);
@@ -459,7 +459,7 @@ diff --git a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc b/th
 diff --git a/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc b/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
 --- a/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
 +++ b/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
-@@ -349,7 +349,8 @@ void WebRemoteFrameImpl::InitializeFrameVisualProperties(
+@@ -348,7 +348,8 @@ void WebRemoteFrameImpl::InitializeFrameVisualProperties(
    visual_properties.page_scale_factor = ancestor_widget->PageScaleInMainFrame();
    visual_properties.is_pinch_gesture_active =
        ancestor_widget->PinchGestureActiveInMainFrame();
@@ -531,7 +531,7 @@ diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/re
  
  namespace blink {
  
-@@ -881,7 +885,79 @@ void Page::UpdateAcceleratedCompositingSettings() {
+@@ -878,7 +882,79 @@ void Page::UpdateAcceleratedCompositingSettings() {
    }
  }
  
@@ -614,7 +614,7 @@ diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/re
 diff --git a/third_party/blink/renderer/core/page/page.h b/third_party/blink/renderer/core/page/page.h
 --- a/third_party/blink/renderer/core/page/page.h
 +++ b/third_party/blink/renderer/core/page/page.h
-@@ -410,6 +410,9 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
+@@ -409,6 +409,9 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
    }
    mojom::blink::FencedFrameMode FencedFrameMode() { return fenced_frame_mode_; }
  
@@ -624,7 +624,7 @@ diff --git a/third_party/blink/renderer/core/page/page.h b/third_party/blink/ren
   private:
    friend class ScopedPagePauser;
  
-@@ -539,6 +542,10 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
+@@ -538,6 +541,10 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
    // browser side FrameTree has the FrameTree::Type of kFencedFrame.
    bool is_fenced_frame_tree_ = false;
  

--- a/build/patches/Viewport-Protection.patch
+++ b/build/patches/Viewport-Protection.patch
@@ -1,395 +1,131 @@
 From: uazo <uazo@users.noreply.github.com>
-Date: Thu, 17 Nov 2022 14:23:47 +0000
+Date: Tue, 20 Dec 2022 11:06:42 +0000
 Subject: Viewport Protection
 
 Scale the viewport and the screen by a random factor to prevent coordinate-based fingerprinting scripts.
 The factor is changed at each change of origin.
-The feature is controlled by a site setting (default disabled)
+The feature is controlled by a feature flag (default enabled)
 ---
- .../browser_ui/site_settings/android/BUILD.gn |  3 +
- .../BromiteCustomContentSettingImpl.java      |  1 +
- .../BromiteViewportContentSetting.java        | 86 +++++++++++++++++++
- .../site_settings/SiteSettingsCategory.java   |  5 +-
- .../strings/android/browser_ui_strings.grd    |  1 +
- .../browser_ui/strings/android/viewport.grdp  | 18 ++++
- components/components_strings.grd             |  1 +
- .../core/browser/content_settings_registry.cc | 14 +++
- .../core/browser/content_settings_utils.cc    |  2 +
- .../core/common/content_settings.cc           |  4 +-
- .../core/common/content_settings.h            |  1 +
- .../core/common/content_settings.mojom        |  1 +
- .../common/content_settings_mojom_traits.cc   |  3 +-
- .../common/content_settings_mojom_traits.h    |  5 ++
- .../core/common/content_settings_types.h      |  2 +
- .../renderer/content_settings_agent_impl.cc   |  9 ++
- .../renderer/content_settings_agent_impl.h    |  1 +
- .../platform/web_content_settings_client.h    |  2 +
+ chrome/browser/about_flags.cc                 |  5 ++
+ chrome/browser/flag_descriptions.cc           |  6 ++
+ chrome/browser/flag_descriptions.h            |  3 +
+ third_party/blink/common/features.cc          |  4 +
+ third_party/blink/public/common/features.h    |  3 +
+ .../common/widget/device_emulation_params.h   |  6 +-
  .../core/css/resolver/style_resolver.cc       | 10 ++-
- .../blink/renderer/core/events/mouse_event.h  | 19 +++-
+ .../blink/renderer/core/events/mouse_event.h  | 19 ++++-
  .../renderer/core/events/pointer_event.h      | 11 +++
  .../renderer/core/exported/web_view_impl.cc   |  2 +-
- .../renderer/core/frame/local_dom_window.cc   | 27 +++++-
+ .../renderer/core/frame/local_dom_window.cc   | 28 ++++++-
  .../blink/renderer/core/frame/local_frame.cc  | 12 ++-
  .../blink/renderer/core/frame/local_frame.h   |  6 +-
- .../core/frame/screen_metrics_emulator.cc     |  8 +-
- .../core/frame/screen_metrics_emulator.h      |  8 ++
+ .../core/frame/screen_metrics_emulator.cc     | 18 ++++-
+ .../core/frame/screen_metrics_emulator.h      | 14 ++++
  .../core/frame/web_frame_widget_impl.cc       |  8 ++
  .../core/frame/web_remote_frame_impl.cc       |  3 +-
  .../blink/renderer/core/input/touch.cc        | 17 +++-
- third_party/blink/renderer/core/page/page.cc  | 74 ++++++++++++++++
+ third_party/blink/renderer/core/page/page.cc  | 80 +++++++++++++++++++
  third_party/blink/renderer/core/page/page.h   |  7 ++
- 32 files changed, 351 insertions(+), 20 deletions(-)
- create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
- create mode 100644 components/browser_ui/strings/android/viewport.grdp
+ 20 files changed, 245 insertions(+), 17 deletions(-)
 
-diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/browser_ui/site_settings/android/BUILD.gn
---- a/components/browser_ui/site_settings/android/BUILD.gn
-+++ b/components/browser_ui/site_settings/android/BUILD.gn
-@@ -95,6 +95,9 @@ android_library("java") {
-   sources += [
-     "java/src/org/chromium/components/browser_ui/site_settings/BromiteWebRTCContentSetting.java",
-   ]
-+  sources += [
-+    "java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java",
-+  ]
-   annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
-   resources_package = "org.chromium.components.browser_ui.site_settings"
-   deps = [
-diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteCustomContentSettingImpl.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteCustomContentSettingImpl.java
---- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteCustomContentSettingImpl.java
-+++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteCustomContentSettingImpl.java
-@@ -45,6 +45,7 @@ public abstract class BromiteCustomContentSettingImpl {
-         mItemList = new ArrayList<BromiteCustomContentSetting>();
-         mItemList.add(new BromiteWebGLContentSetting());
-         mItemList.add(new BromiteWebRTCContentSetting());
-+        mItemList.add(new BromiteViewportContentSetting());
-     }
+diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -7631,6 +7631,11 @@ const FeatureEntry kFeatureEntries[] = {
+                                     "PaintPreviewShowOnStartup")},
+ #endif  // BUILDFLAG(ENABLE_PAINT_PREVIEW) && BUILDFLAG(IS_ANDROID)
  
-     public static SiteSettingsCategory createFromType(
-diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
-new file mode 100644
---- /dev/null
-+++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
-@@ -0,0 +1,86 @@
-+/*
-+    This file is part of Bromite.
++    {"viewport-protection",
++     flag_descriptions::kViewportProtectionName,
++     flag_descriptions::kViewportProtectionDescription, kOsAll,
++     FEATURE_VALUE_TYPE(blink::features::kViewportProtection)},
 +
-+    Bromite is free software: you can redistribute it and/or modify
-+    it under the terms of the GNU General Public License as published by
-+    the Free Software Foundation, either version 3 of the License, or
-+    (at your option) any later version.
-+
-+    Bromite is distributed in the hope that it will be useful,
-+    but WITHOUT ANY WARRANTY; without even the implied warranty of
-+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+    GNU General Public License for more details.
-+
-+    You should have received a copy of the GNU General Public License
-+    along with Bromite. If not, see <https://www.gnu.org/licenses/>.
-+*/
-+
-+package org.chromium.components.browser_ui.site_settings;
-+
-+import org.chromium.components.browser_ui.site_settings.ContentSettingsResources;
-+import org.chromium.components.browser_ui.site_settings.SiteSettingsCategory;
-+import org.chromium.components.content_settings.ContentSettingValues;
-+import org.chromium.components.content_settings.ContentSettingsType;
-+import org.chromium.content_public.browser.BrowserContextHandle;
-+
-+import androidx.annotation.Nullable;
-+import androidx.preference.Preference;
-+import androidx.preference.PreferenceScreen;
-+
-+import java.util.ArrayList;
-+
-+public class BromiteViewportContentSetting extends BromiteCustomContentSetting {
-+    public BromiteViewportContentSetting() {
-+        super(/*contentSettingsType*/ ContentSettingsType.VIEWPORT,
-+              /*siteSettingsCategory*/ SiteSettingsCategory.Type.VIEWPORT,
-+              /*defaultEnabledValue*/ ContentSettingValues.ALLOW,
-+              /*defaultDisabledValue*/ ContentSettingValues.BLOCK,
-+              /*allowException*/ true,
-+              /*preferenceKey*/ "viewport",
-+              /*profilePrefKey*/ "viewport");
-+    }
-+
-+    @Override
-+    public ContentSettingsResources.ResourceItem getResourceItem() {
-+        return new ContentSettingsResources.ResourceItem(
-+            /*icon*/ R.drawable.web_asset,
-+            /*title*/ R.string.viewport_permission_title,
-+            /*defaultEnabledValue*/ getDefaultEnabledValue(),
-+            /*defaultDisabledValue*/ getDefaultDisabledValue(),
-+            /*enabledSummary*/ R.string.website_settings_category_viewport_enabled,
-+            /*disabledSummary*/ R.string.website_settings_category_viewport_disabled);
-+    }
-+
-+    @Override
-+    public int getCategorySummary(@Nullable @ContentSettingValues int value) {
-+        switch (value) {
-+            case ContentSettingValues.ALLOW:
-+                return R.string.website_settings_category_viewport_enabled;
-+            case ContentSettingValues.BLOCK:
-+                return R.string.website_settings_category_viewport_disabled;
-+            default:
-+                // this will cause a runtime exception
-+                return 0;
-+        }
-+    }
-+
-+    @Override
-+    public boolean requiresTriStateContentSetting() {
-+        return false;
-+    }
-+
-+    @Override
-+    public boolean showOnlyDescriptions() {
-+        return true;
-+    }
-+
-+    @Override
-+    public int getAddExceptionDialogMessage() {
-+        return R.string.website_settings_category_viewport_enabled;
-+    }
-+
-+    @Override
-+    public @Nullable Boolean considerException(SiteSettingsCategory category, @ContentSettingValues int value) {
-+        return value != ContentSettingValues.BLOCK;
-+    }
-+}
-diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java
---- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java
-+++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java
-@@ -44,7 +44,7 @@ public class SiteSettingsCategory {
-             Type.PROTECTED_MEDIA, Type.SENSORS, Type.SOUND, Type.USB, Type.VIRTUAL_REALITY,
-             Type.USE_STORAGE, Type.AUTO_DARK_WEB_CONTENT, Type.REQUEST_DESKTOP_SITE,
-             Type.FEDERATED_IDENTITY_API, Type.TIMEZONE_OVERRIDE, Type.AUTOPLAY, Type.JAVASCRIPT_JIT,
--            Type.IMAGES, Type.WEBGL, Type.WEBRTC})
-+            Type.IMAGES, Type.WEBGL, Type.WEBRTC, Type.VIEWPORT})
-     @Retention(RetentionPolicy.SOURCE)
-     public @interface Type {
-         // All updates here must also be reflected in {@link #preferenceKey(int)
-@@ -81,10 +81,11 @@ public class SiteSettingsCategory {
-         int IMAGES = 29;
-         int WEBGL = 30;
-         int WEBRTC = 31;
-+        int VIEWPORT = 32;
-         /**
-          * Number of handled categories used for calculating array sizes.
-          */
--        int NUM_ENTRIES = 32;
-+        int NUM_ENTRIES = 33;
-     }
+ #if BUILDFLAG(IS_ANDROID)
+     {"block-external-form-redirects-no-gesture",
+      flag_descriptions::kIntentBlockExternalFormRedirectsNoGestureName,
+diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
+--- a/chrome/browser/flag_descriptions.cc
++++ b/chrome/browser/flag_descriptions.cc
+@@ -6851,6 +6851,12 @@ const char kPaintPreviewStartupDescription[] =
+     "instead.";
+ #endif  // ENABLE_PAINT_PREVIEW && BUILDFLAG(IS_ANDROID)
  
-     private final BrowserContextHandle mBrowserContextHandle;
-diff --git a/components/browser_ui/strings/android/browser_ui_strings.grd b/components/browser_ui/strings/android/browser_ui_strings.grd
---- a/components/browser_ui/strings/android/browser_ui_strings.grd
-+++ b/components/browser_ui/strings/android/browser_ui_strings.grd
-@@ -176,6 +176,7 @@
-       <part file="site_settings.grdp" />
-       <part file="webgl.grdp" />
-       <part file="webrtc.grdp" />
-+      <part file="viewport.grdp" />
- 
-       <message name="IDS_GOT_IT" desc="Button for the user to accept a disclosure/message" formatter_data="android_java">
-         Got it
-diff --git a/components/browser_ui/strings/android/viewport.grdp b/components/browser_ui/strings/android/viewport.grdp
-new file mode 100644
---- /dev/null
-+++ b/components/browser_ui/strings/android/viewport.grdp
-@@ -0,0 +1,18 @@
-+<?xml version="1.0" encoding="utf-8"?>
-+<grit-part>
-+  <message name="IDS_SITE_SETTINGS_TYPE_VIEWPORT" desc="The label used for viewport size change site settings controls.">
-+    Viewport Size Protection
-+  </message>
-+  <message name="IDS_SITE_SETTINGS_TYPE_VIEWPORT_MID_SENTENCE" desc="The label used for viewport size change site settings controls when used mid-sentence.">
-+    Viewport Size Protection
-+  </message>
-+  <message name="IDS_VIEWPORT_PERMISSION_TITLE" desc="Title of the permission to use viewport size change [CHAR-LIMIT=32]">
-+    Viewport Size Protection
-+  </message>
-+  <message name="IDS_WEBSITE_SETTINGS_CATEGORY_VIEWPORT_ENABLED" desc="Summary text explaining that viewport size change is full enabled.">
-+    Enabled
-+  </message>
-+  <message name="IDS_WEBSITE_SETTINGS_CATEGORY_VIEWPORT_DISABLED" desc="Summary text explaining that viewport size change is full disabled.">
-+    Disabled
-+  </message>
-+</grit-part>
-diff --git a/components/components_strings.grd b/components/components_strings.grd
---- a/components/components_strings.grd
-+++ b/components/components_strings.grd
-@@ -341,6 +341,7 @@
- 
-       <part file="browser_ui/strings/android/webgl.grdp" />
-       <part file="browser_ui/strings/android/webrtc.grdp" />
-+      <part file="browser_ui/strings/android/viewport.grdp" />
-       <if expr="not is_ios">
-         <part file="history_clusters_strings.grdp" />
-       </if>
-diff --git a/components/content_settings/core/browser/content_settings_registry.cc b/components/content_settings/core/browser/content_settings_registry.cc
---- a/components/content_settings/core/browser/content_settings_registry.cc
-+++ b/components/content_settings/core/browser/content_settings_registry.cc
-@@ -715,6 +715,20 @@ void ContentSettingsRegistry::Init() {
-            /*show_into_info_page*/ true,
-            /*permission_type_ui*/ IDS_SITE_SETTINGS_TYPE_WEBRTC,
-            /*permission_type_ui_mid_sentence*/ IDS_SITE_SETTINGS_TYPE_WEBRTC_MID_SENTENCE);
++const char kViewportProtectionName[] = "Viewport Protection";
++const char kViewportProtectionDescription[] =
++    "Scale the viewport and the screen by a random factor to prevent "
++    "coordinate-based fingerprinting scripts. The factor is changed at each "
++    "change of origin.";
 +
-+  Register(ContentSettingsType::VIEWPORT, "viewport", CONTENT_SETTING_BLOCK,
-+           WebsiteSettingsInfo::SYNCABLE,
-+           AllowlistedSchemes(),
-+           ValidSettings(CONTENT_SETTING_ALLOW,
-+                         CONTENT_SETTING_BLOCK),
-+           WebsiteSettingsInfo::TOP_ORIGIN_ONLY_SCOPE,
-+           WebsiteSettingsRegistry::PLATFORM_ANDROID,
-+           ContentSettingsInfo::INHERIT_IN_INCOGNITO,
-+           ContentSettingsInfo::PERSISTENT,
-+           ContentSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS,
-+           /*show_into_info_page*/ true,
-+           /*permission_type_ui*/ IDS_SITE_SETTINGS_TYPE_VIEWPORT,
-+           /*permission_type_ui_mid_sentence*/ IDS_SITE_SETTINGS_TYPE_VIEWPORT_MID_SENTENCE);
+ #if BUILDFLAG(ENABLE_WEBUI_TAB_STRIP)
+ const char kWebUITabStripFlagId[] = "webui-tab-strip";
+ const char kWebUITabStripName[] = "WebUI tab strip";
+diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
+--- a/chrome/browser/flag_descriptions.h
++++ b/chrome/browser/flag_descriptions.h
+@@ -3950,6 +3950,9 @@ extern const char kPaintPreviewStartupName[];
+ extern const char kPaintPreviewStartupDescription[];
+ #endif  // ENABLE_PAINT_PREVIEW && BUILDFLAG(IS_ANDROID)
+ 
++extern const char kViewportProtectionName[];
++extern const char kViewportProtectionDescription[];
++
+ #if BUILDFLAG(ENABLE_WEBUI_TAB_STRIP)
+ extern const char kWebUITabStripFlagId[];
+ extern const char kWebUITabStripName[];
+diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
+--- a/third_party/blink/common/features.cc
++++ b/third_party/blink/common/features.cc
+@@ -1638,6 +1638,10 @@ BASE_FEATURE(kDocumentEventNodePathCaching,
+              "DocumentEventNodePathCaching",
+              base::FEATURE_DISABLED_BY_DEFAULT);
+ 
++BASE_FEATURE(kViewportProtection,
++             "ViewportProtection",
++             base::FEATURE_ENABLED_BY_DEFAULT);
++
+ BASE_FEATURE(kNewGetDisplayMediaPickerOrder,
+              "NewGetDisplayMediaPickerOrder",
+              base::FEATURE_DISABLED_BY_DEFAULT);
+diff --git a/third_party/blink/public/common/features.h b/third_party/blink/public/common/features.h
+--- a/third_party/blink/public/common/features.h
++++ b/third_party/blink/public/common/features.h
+@@ -868,6 +868,9 @@ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kThreadedBodyLoader);
+ // If enabled, will cache for each node's EventPath::NodePath in document.
+ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kDocumentEventNodePathCaching);
+ 
++// Enable blink viewport protection
++BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kViewportProtection);
++
+ // When an application calls getDisplayMedia(), a media-picker is displayed
+ // to the user, allowing them to share a tab, a window or a screen.
+ // * If this flag is enabled, the order is - tabs, windows, screens.
+diff --git a/third_party/blink/public/common/widget/device_emulation_params.h b/third_party/blink/public/common/widget/device_emulation_params.h
+--- a/third_party/blink/public/common/widget/device_emulation_params.h
++++ b/third_party/blink/public/common/widget/device_emulation_params.h
+@@ -19,6 +19,9 @@ namespace blink {
+ struct DeviceEmulationParams {
+   mojom::EmulatedScreenType screen_type = mojom::EmulatedScreenType::kDesktop;
+ 
++  // Forces screen recalculation the same way as mobile
++  bool force_mobile_calc = false;
++
+   // Emulated screen size. Typically full / physical size of the device screen
+   // in DIP. Empty size means using default value: original one for kDesktop
+   // screen position, equal to |view_size| for kMobile.
+@@ -71,7 +74,8 @@ inline bool operator==(const DeviceEmulationParams& a,
+          a.screen_orientation_angle == b.screen_orientation_angle &&
+          a.viewport_offset == b.viewport_offset &&
+          a.viewport_scale == b.viewport_scale &&
+-         a.window_segments == b.window_segments;
++         a.window_segments == b.window_segments &&
++         a.force_mobile_calc == b.force_mobile_calc;
  }
  
- void ContentSettingsRegistry::Register(
-diff --git a/components/content_settings/core/browser/content_settings_utils.cc b/components/content_settings/core/browser/content_settings_utils.cc
---- a/components/content_settings/core/browser/content_settings_utils.cc
-+++ b/components/content_settings/core/browser/content_settings_utils.cc
-@@ -160,6 +160,8 @@ void GetRendererContentSettingRules(const HostContentSettingsMap* map,
-                              &(rules->webgl_rules));
-   map->GetSettingsForOneType(ContentSettingsType::WEBRTC,
-                              &(rules->webrtc_rules));
-+  map->GetSettingsForOneType(ContentSettingsType::VIEWPORT,
-+                             &(rules->viewport_rules));
- }
- 
- bool IsMorePermissive(ContentSetting a, ContentSetting b) {
-diff --git a/components/content_settings/core/common/content_settings.cc b/components/content_settings/core/common/content_settings.cc
---- a/components/content_settings/core/common/content_settings.cc
-+++ b/components/content_settings/core/common/content_settings.cc
-@@ -208,7 +208,8 @@ bool RendererContentSettingRules::IsRendererContentSetting(
-          content_type == ContentSettingsType::AUTO_DARK_WEB_CONTENT ||
-          content_type == ContentSettingsType::TIMEZONE_OVERRIDE ||
-          content_type == ContentSettingsType::WEBGL ||
--         content_type == ContentSettingsType::WEBRTC;
-+         content_type == ContentSettingsType::WEBRTC ||
-+         content_type == ContentSettingsType::VIEWPORT;
- }
- 
- void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
-@@ -222,6 +223,7 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
-   FilterRulesForType(autoplay_rules, outermost_main_frame_url);
-   FilterRulesForType(webgl_rules, outermost_main_frame_url);
-   FilterRulesForType(webrtc_rules, outermost_main_frame_url);
-+  FilterRulesForType(viewport_rules, outermost_main_frame_url);
- }
- 
- RendererContentSettingRules::RendererContentSettingRules() = default;
-diff --git a/components/content_settings/core/common/content_settings.h b/components/content_settings/core/common/content_settings.h
---- a/components/content_settings/core/common/content_settings.h
-+++ b/components/content_settings/core/common/content_settings.h
-@@ -98,6 +98,7 @@ struct RendererContentSettingRules {
-   std::string timezone_override_value;
-   ContentSettingsForOneType webgl_rules;
-   ContentSettingsForOneType webrtc_rules;
-+  ContentSettingsForOneType viewport_rules;
- };
- 
- namespace content_settings {
-diff --git a/components/content_settings/core/common/content_settings.mojom b/components/content_settings/core/common/content_settings.mojom
---- a/components/content_settings/core/common/content_settings.mojom
-+++ b/components/content_settings/core/common/content_settings.mojom
-@@ -83,4 +83,5 @@ struct RendererContentSettingRules {
-   string timezone_override_value;
-   array<ContentSettingPatternSource> webgl_rules;
-   array<ContentSettingPatternSource> webrtc_rules;
-+  array<ContentSettingPatternSource> viewport_rules;
- };
-diff --git a/components/content_settings/core/common/content_settings_mojom_traits.cc b/components/content_settings/core/common/content_settings_mojom_traits.cc
---- a/components/content_settings/core/common/content_settings_mojom_traits.cc
-+++ b/components/content_settings/core/common/content_settings_mojom_traits.cc
-@@ -107,7 +107,8 @@ bool StructTraits<content_settings::mojom::RendererContentSettingRulesDataView,
-          data.ReadTimezoneOverrideRules(&out->timezone_override_rules) &&
-          data.ReadTimezoneOverrideValue(&out->timezone_override_value) &&
-          data.ReadWebglRules(&out->webgl_rules) &&
--         data.ReadWebrtcRules(&out->webrtc_rules);
-+         data.ReadWebrtcRules(&out->webrtc_rules) &&
-+         data.ReadViewportRules(&out->viewport_rules);
- }
- 
- }  // namespace mojo
-diff --git a/components/content_settings/core/common/content_settings_mojom_traits.h b/components/content_settings/core/common/content_settings_mojom_traits.h
---- a/components/content_settings/core/common/content_settings_mojom_traits.h
-+++ b/components/content_settings/core/common/content_settings_mojom_traits.h
-@@ -175,6 +175,11 @@ struct StructTraits<
-     return r.webrtc_rules;
-   }
- 
-+ static const std::vector<ContentSettingPatternSource>& viewport_rules(
-+      const RendererContentSettingRules& r) {
-+    return r.viewport_rules;
-+  }
-+
-   static bool Read(
-       content_settings::mojom::RendererContentSettingRulesDataView data,
-       RendererContentSettingRules* out);
-diff --git a/components/content_settings/core/common/content_settings_types.h b/components/content_settings/core/common/content_settings_types.h
---- a/components/content_settings/core/common/content_settings_types.h
-+++ b/components/content_settings/core/common/content_settings_types.h
-@@ -280,6 +280,8 @@ enum class ContentSettingsType : int32_t {
- 
-   WEBRTC,
- 
-+  VIEWPORT,
-+
-   // Setting to indicate whether browser should allow signing into a website via
-   // the browser FedCM API.
-   FEDERATED_IDENTITY_API,
-diff --git a/components/content_settings/renderer/content_settings_agent_impl.cc b/components/content_settings/renderer/content_settings_agent_impl.cc
---- a/components/content_settings/renderer/content_settings_agent_impl.cc
-+++ b/components/content_settings/renderer/content_settings_agent_impl.cc
-@@ -467,6 +467,15 @@ bool ContentSettingsAgentImpl::AllowWebRTC(bool enabled_per_settings) {
-              url::Origin(frame->GetDocument().GetSecurityOrigin()).GetURL());
- }
- 
-+bool ContentSettingsAgentImpl::AllowViewportChange(bool enabled_per_settings) {
-+  if (!content_setting_rules_)
-+    return false;
-+  blink::WebLocalFrame* frame = render_frame()->GetWebFrame();
-+  return CONTENT_SETTING_ALLOW == GetContentSettingFromRules(
-+             content_setting_rules_->viewport_rules,
-+             url::Origin(frame->GetDocument().GetSecurityOrigin()).GetURL());
-+}
-+
- bool ContentSettingsAgentImpl::IsAllowlistedForContentSettings() const {
-   if (should_allowlist_)
-     return true;
-diff --git a/components/content_settings/renderer/content_settings_agent_impl.h b/components/content_settings/renderer/content_settings_agent_impl.h
---- a/components/content_settings/renderer/content_settings_agent_impl.h
-+++ b/components/content_settings/renderer/content_settings_agent_impl.h
-@@ -101,6 +101,7 @@ class ContentSettingsAgentImpl
-   bool ShouldAutoupgradeMixedContent() override;
-   bool AllowWebgl(bool enabled_per_settings) override;
-   bool AllowWebRTC(bool enabled_per_settings) override;
-+  bool AllowViewportChange(bool enabled_per_settings) override;
- 
-   bool allow_running_insecure_content() const {
-     return allow_running_insecure_content_;
-diff --git a/third_party/blink/public/platform/web_content_settings_client.h b/third_party/blink/public/platform/web_content_settings_client.h
---- a/third_party/blink/public/platform/web_content_settings_client.h
-+++ b/third_party/blink/public/platform/web_content_settings_client.h
-@@ -103,6 +103,8 @@ class WebContentSettingsClient {
- 
-   virtual bool AllowWebRTC(bool default_value) { return default_value; }
- 
-+  virtual bool AllowViewportChange(bool default_value) { return default_value; }
-+
-   // Reports that passive mixed content was found at the provided URL.
-   virtual void PassiveInsecureContentFound(const WebURL&) {}
- 
+ inline bool operator!=(const DeviceEmulationParams& a,
 diff --git a/third_party/blink/renderer/core/css/resolver/style_resolver.cc b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
 --- a/third_party/blink/renderer/core/css/resolver/style_resolver.cc
 +++ b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
-@@ -1513,8 +1513,14 @@ scoped_refptr<ComputedStyle> StyleResolver::InitialStyleForElement() const {
+@@ -1557,8 +1557,14 @@ scoped_refptr<ComputedStyle> StyleResolver::InitialStyleForElement() const {
  
    initial_style->SetRtlOrdering(
        GetDocument().VisuallyOrdered() ? EOrder::kVisual : EOrder::kLogical);
@@ -417,7 +153,7 @@ diff --git a/third_party/blink/renderer/core/events/mouse_event.h b/third_party/
  
  namespace blink {
  
-@@ -141,8 +142,22 @@ class CORE_EXPORT MouseEvent : public UIEventWithKeyState {
+@@ -143,8 +144,22 @@ class CORE_EXPORT MouseEvent : public UIEventWithKeyState {
  
    // Note that these values are adjusted to counter the effects of zoom, so that
    // values exposed via DOM APIs are invariant under zooming.
@@ -478,7 +214,7 @@ diff --git a/third_party/blink/renderer/core/events/pointer_event.h b/third_part
 diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_party/blink/renderer/core/exported/web_view_impl.cc
 --- a/third_party/blink/renderer/core/exported/web_view_impl.cc
 +++ b/third_party/blink/renderer/core/exported/web_view_impl.cc
-@@ -1028,7 +1028,7 @@ WebPagePopupImpl* WebViewImpl::OpenPagePopup(PagePopupClient* client) {
+@@ -1031,7 +1031,7 @@ WebPagePopupImpl* WebViewImpl::OpenPagePopup(PagePopupClient* client) {
    page_popup_ = WebPagePopupImpl::Create(
        std::move(popup_widget_host), std::move(widget_host),
        std::move(widget_receiver), this, agent_group_scheduler,
@@ -490,7 +226,7 @@ diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_p
 diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_party/blink/renderer/core/frame/local_dom_window.cc
 --- a/third_party/blink/renderer/core/frame/local_dom_window.cc
 +++ b/third_party/blink/renderer/core/frame/local_dom_window.cc
-@@ -1407,6 +1407,11 @@ int LocalDOMWindow::outerHeight() const {
+@@ -1437,6 +1437,11 @@ int LocalDOMWindow::outerHeight() const {
    if (!page)
      return 0;
  
@@ -502,7 +238,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
    ChromeClient& chrome_client = page->GetChromeClient();
    if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
      return static_cast<int>(
-@@ -1432,6 +1437,11 @@ int LocalDOMWindow::outerWidth() const {
+@@ -1462,6 +1467,11 @@ int LocalDOMWindow::outerWidth() const {
    if (!page)
      return 0;
  
@@ -514,7 +250,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
    ChromeClient& chrome_client = page->GetChromeClient();
    if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
      return static_cast<int>(
-@@ -1619,7 +1629,8 @@ double LocalDOMWindow::devicePixelRatio() const {
+@@ -1650,7 +1660,8 @@ double LocalDOMWindow::devicePixelRatio() const {
    if (!GetFrame())
      return 0.0;
  
@@ -524,7 +260,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
  }
  
  void LocalDOMWindow::scrollBy(double x, double y) const {
-@@ -2177,6 +2188,20 @@ DOMWindow* LocalDOMWindow::open(v8::Isolate* isolate,
+@@ -2203,6 +2214,21 @@ DOMWindow* LocalDOMWindow::open(v8::Isolate* isolate,
    if (!completed_url.IsEmpty() || result.new_window)
      result.frame->Navigate(frame_request, WebFrameLoadType::kStandard);
  
@@ -537,9 +273,10 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
 +    // prevent this js code:
 +    //     var w = window.open()
 +    //     var not_emulated_screen_info = w.screen
++    bool protection_enabled = base::FeatureList::IsEnabled(features::kViewportProtection);
 +    result.frame->GetPage()->CalculateEmulatedScreenSetting(
 +      To<LocalFrame>(result.frame),
-+      /*force*/ GetFrame()->GetContentSettingsClient()->AllowViewportChange(false));
++      /*force*/ protection_enabled);
 +  }
 +
    // TODO(japhet): window-open-noopener.html?_top and several tests in
@@ -548,7 +285,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
 diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/blink/renderer/core/frame/local_frame.cc
 --- a/third_party/blink/renderer/core/frame/local_frame.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame.cc
-@@ -1275,6 +1275,10 @@ gfx::SizeF LocalFrame::ResizePageRectsKeepingRatio(
+@@ -1278,6 +1278,10 @@ gfx::SizeF LocalFrame::ResizePageRectsKeepingRatio(
    return gfx::SizeF(result_width, result_height);
  }
  
@@ -559,7 +296,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/
  void LocalFrame::SetPageZoomFactor(float factor) {
    SetPageAndTextZoomFactors(factor, text_zoom_factor_);
  }
-@@ -1414,12 +1418,16 @@ device::mojom::blink::DevicePostureType LocalFrame::GetDevicePosture() {
+@@ -1417,12 +1421,16 @@ device::mojom::blink::DevicePostureType LocalFrame::GetDevicePosture() {
    return mojo_handler_->GetDevicePosture();
  }
  
@@ -581,7 +318,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/
 diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/blink/renderer/core/frame/local_frame.h
 --- a/third_party/blink/renderer/core/frame/local_frame.h
 +++ b/third_party/blink/renderer/core/frame/local_frame.h
-@@ -378,13 +378,14 @@ class CORE_EXPORT LocalFrame final
+@@ -381,13 +381,14 @@ class CORE_EXPORT LocalFrame final
    void SetInViewSourceMode(bool = true);
  
    void SetPageZoomFactor(float);
@@ -598,7 +335,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/b
  
    // Informs the local root's document and its local descendant subtree that a
    // media query value changed.
-@@ -920,6 +921,7 @@ class CORE_EXPORT LocalFrame final
+@@ -934,6 +935,7 @@ class CORE_EXPORT LocalFrame final
    unsigned hidden_ : 1;
  
    float page_zoom_factor_;
@@ -609,7 +346,32 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/b
 diff --git a/third_party/blink/renderer/core/frame/screen_metrics_emulator.cc b/third_party/blink/renderer/core/frame/screen_metrics_emulator.cc
 --- a/third_party/blink/renderer/core/frame/screen_metrics_emulator.cc
 +++ b/third_party/blink/renderer/core/frame/screen_metrics_emulator.cc
-@@ -163,6 +163,9 @@ void ScreenMetricsEmulator::Apply() {
+@@ -34,6 +34,7 @@ void ScreenMetricsEmulator::Trace(Visitor* vistor) const {
+ }
+ 
+ void ScreenMetricsEmulator::DisableAndApply() {
++  override_screen_type_ = false;
+   frame_widget_->SetScreenMetricsEmulationParameters(false, emulation_params_);
+   frame_widget_->SetScreenRects(original_view_screen_rect_,
+                                 original_window_screen_rect_);
+@@ -45,7 +46,16 @@ void ScreenMetricsEmulator::DisableAndApply() {
+ 
+ void ScreenMetricsEmulator::ChangeEmulationParams(
+     const DeviceEmulationParams& params) {
++  if (!params.force_mobile_calc) {
++    // user has activated device emulator via devtools
++    override_screen_type_ = true;
++    // we need to save requested value
++    last_screen_type_ = params.screen_type;
++  }
+   emulation_params_ = params;
++  if (override_screen_type_) {
++    emulation_params_.screen_type = last_screen_type_;
++  }
+   Apply();
+ }
+ 
+@@ -163,6 +173,9 @@ void ScreenMetricsEmulator::Apply() {
    frame_widget_->SetScreenInfoAndSize(emulated_screen_infos,
                                        /*widget_size=*/widget_size,
                                        /*visible_viewport_size=*/widget_size);
@@ -619,7 +381,7 @@ diff --git a/third_party/blink/renderer/core/frame/screen_metrics_emulator.cc b/
  }
  
  void ScreenMetricsEmulator::UpdateVisualProperties(
-@@ -191,9 +194,8 @@ void ScreenMetricsEmulator::OnUpdateScreenRects(
+@@ -191,9 +204,8 @@ void ScreenMetricsEmulator::OnUpdateScreenRects(
      const gfx::Rect& window_screen_rect) {
    original_view_screen_rect_ = view_screen_rect;
    original_window_screen_rect_ = window_screen_rect;
@@ -646,7 +408,27 @@ diff --git a/third_party/blink/renderer/core/frame/screen_metrics_emulator.h b/t
    // Disables emulation and applies non-emulated values to the
    // WebFrameWidgetImpl. Call this before destroying the ScreenMetricsEmulator.
    void DisableAndApply();
-@@ -96,6 +101,9 @@ class ScreenMetricsEmulator : public GarbageCollected<ScreenMetricsEmulator> {
+@@ -77,6 +82,8 @@ class ScreenMetricsEmulator : public GarbageCollected<ScreenMetricsEmulator> {
+ 
+  private:
+   bool emulating_desktop() const {
++    if (emulation_params_.force_mobile_calc == true)
++      return false;
+     return emulation_params_.screen_type ==
+            mojom::blink::EmulatedScreenType::kDesktop;
+   }
+@@ -89,6 +96,10 @@ class ScreenMetricsEmulator : public GarbageCollected<ScreenMetricsEmulator> {
+   // Parameters as passed by `WebFrameWidgetImpl::EnableDeviceEmulation()`
+   DeviceEmulationParams emulation_params_;
+ 
++  // Used to remember the user's choice if devtools are activated
++  bool override_screen_type_ = false;
++  mojom::EmulatedScreenType last_screen_type_;
++
+   // Original values to restore back after emulation ends.
+   display::ScreenInfos original_screen_infos_;
+   gfx::Size original_widget_size_;
+@@ -96,6 +107,9 @@ class ScreenMetricsEmulator : public GarbageCollected<ScreenMetricsEmulator> {
    gfx::Rect original_view_screen_rect_;
    gfx::Rect original_window_screen_rect_;
    std::vector<gfx::Rect> original_root_window_segments_;
@@ -677,7 +459,7 @@ diff --git a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc b/th
 diff --git a/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc b/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
 --- a/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
 +++ b/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
-@@ -348,7 +348,8 @@ void WebRemoteFrameImpl::InitializeFrameVisualProperties(
+@@ -349,7 +349,8 @@ void WebRemoteFrameImpl::InitializeFrameVisualProperties(
    visual_properties.page_scale_factor = ancestor_widget->PageScaleInMainFrame();
    visual_properties.is_pinch_gesture_active =
        ancestor_widget->PinchGestureActiveInMainFrame();
@@ -731,7 +513,15 @@ diff --git a/third_party/blink/renderer/core/input/touch.cc b/third_party/blink/
 diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/renderer/core/page/page.cc
 --- a/third_party/blink/renderer/core/page/page.cc
 +++ b/third_party/blink/renderer/core/page/page.cc
-@@ -92,6 +92,9 @@
+@@ -23,6 +23,7 @@
+ 
+ #include "base/compiler_specific.h"
+ #include "base/feature_list.h"
++#include "build/build_config.h"
+ #include "third_party/blink/public/common/features.h"
+ #include "third_party/blink/public/mojom/frame/lifecycle.mojom-blink-forward.h"
+ #include "third_party/blink/public/platform/platform.h"
+@@ -92,6 +93,9 @@
  #include "third_party/blink/renderer/platform/scheduler/public/agent_group_scheduler.h"
  #include "third_party/blink/renderer/platform/scheduler/public/frame_scheduler.h"
  #include "third_party/skia/include/core/SkColor.h"
@@ -741,13 +531,13 @@ diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/re
  
  namespace blink {
  
-@@ -881,7 +884,78 @@ void Page::UpdateAcceleratedCompositingSettings() {
+@@ -881,7 +885,83 @@ void Page::UpdateAcceleratedCompositingSettings() {
    }
  }
  
 +void Page::CalculateEmulatedScreenSetting(LocalFrame* frame, bool force) {
-+  blink::WebContentSettingsClient* settings = frame->GetContentSettingsClient();
-+  if ( (settings && settings->AllowViewportChange(false)) || force) {
++  bool isEnabled = base::FeatureList::IsEnabled(features::kViewportProtection);
++  if (isEnabled || force) {
 +    // this is the maximum (and minimum) value which in percentage
 +    // corresponds to +- 0.03%
 +    // more or less 3-6 pixels according to the resolution 300-600px
@@ -778,8 +568,13 @@ diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/re
 +
 +      // set emulation params
 +      DeviceEmulationParams params;
-+      // the screen size is changed to match the widget size for mobile emulation
++      // the screen size is changed to match the widget size with force_mobile_calc
++      params.force_mobile_calc = true;
++#if BUILDFLAG(IS_ANDROID)
 +      params.screen_type = mojom::EmulatedScreenType::kMobile;
++#else
++      params.screen_type = mojom::EmulatedScreenType::kDesktop;
++#endif
 +      // scale the widget size (and the screen size) by half_random scale factor
 +      params.scale = 1 / (1.0 + half_random);
 +

--- a/build/patches/Viewport-Protection.patch
+++ b/build/patches/Viewport-Protection.patch
@@ -25,7 +25,7 @@ The feature is controlled by a site setting (default disabled)
  .../renderer/content_settings_agent_impl.cc   |  9 ++
  .../renderer/content_settings_agent_impl.h    |  1 +
  .../platform/web_content_settings_client.h    |  2 +
- .../blink/renderer/core/css/media_values.cc   | 22 ++++-
+ .../blink/renderer/core/css/media_values.cc   | 24 +++++-
  .../core/frame/dom_visual_viewport.cc         |  4 +-
  .../renderer/core/frame/local_dom_window.cc   |  6 ++
  .../renderer/core/frame/local_frame_view.cc   |  3 +
@@ -35,7 +35,7 @@ The feature is controlled by a site setting (default disabled)
  .../renderer/core/loader/frame_loader.cc      | 15 +++-
  third_party/blink/renderer/core/page/page.cc  | 12 +++
  third_party/blink/renderer/core/page/page.h   |  5 ++
- 28 files changed, 260 insertions(+), 14 deletions(-)
+ 28 files changed, 261 insertions(+), 15 deletions(-)
  create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
  create mode 100644 components/browser_ui/strings/android/viewport.grdp
 
@@ -386,7 +386,7 @@ diff --git a/third_party/blink/public/platform/web_content_settings_client.h b/t
 diff --git a/third_party/blink/renderer/core/css/media_values.cc b/third_party/blink/renderer/core/css/media_values.cc
 --- a/third_party/blink/renderer/core/css/media_values.cc
 +++ b/third_party/blink/renderer/core/css/media_values.cc
-@@ -132,13 +132,23 @@ double MediaValues::CalculateViewportWidth(LocalFrame* frame) {
+@@ -132,14 +132,24 @@ double MediaValues::CalculateViewportWidth(LocalFrame* frame) {
    DCHECK(frame);
    DCHECK(frame->View());
    DCHECK(frame->GetDocument());
@@ -403,14 +403,16 @@ diff --git a/third_party/blink/renderer/core/css/media_values.cc b/third_party/b
    DCHECK(frame);
    DCHECK(frame->View());
    DCHECK(frame->GetDocument());
+-  return frame->View()->ViewportSizeForMediaQueries().height();
 +  float width_override = frame->GetPage()->PageWidthOverride();
 +  double height = frame->View()->ViewportSizeForMediaQueries().height();
 +  if (width_override) {
 +    height = height * (1.0 - (width_override / 100.0));
 +  }
-   return frame->View()->ViewportSizeForMediaQueries().height();
++  return height;
  }
  
+ double MediaValues::CalculateSmallViewportWidth(LocalFrame* frame) {
 @@ -193,6 +203,11 @@ int MediaValues::CalculateDeviceWidth(LocalFrame* frame) {
      device_width = static_cast<int>(
          lroundf(device_width * screen_info.device_scale_factor));

--- a/build/patches/Viewport-Protection.patch
+++ b/build/patches/Viewport-Protection.patch
@@ -1,10 +1,9 @@
 From: uazo <uazo@users.noreply.github.com>
-Date: Thu, 30 Jun 2022 12:47:17 +0000
+Date: Fri, 26 Aug 2022 13:15:43 +0000
 Subject: Viewport Protection
 
-Scale the viewport by a random factor to prevent coordinate-based fingerprinting scripts.
+Scale the viewport and the screen by a random factor to prevent coordinate-based fingerprinting scripts.
 The factor is changed at each change of origin.
-It acts on the javascript api to prevent the possibility of value recovery.
 The feature is controlled by a site setting (default disabled)
 ---
  .../browser_ui/site_settings/android/BUILD.gn |  3 +
@@ -25,17 +24,21 @@ The feature is controlled by a site setting (default disabled)
  .../renderer/content_settings_agent_impl.cc   |  9 ++
  .../renderer/content_settings_agent_impl.h    |  1 +
  .../platform/web_content_settings_client.h    |  2 +
- .../blink/renderer/core/css/media_values.cc   | 24 +++++-
- .../core/frame/dom_visual_viewport.cc         |  4 +-
- .../renderer/core/frame/local_dom_window.cc   |  6 ++
- .../renderer/core/frame/local_frame_view.cc   |  3 +
- .../blink/renderer/core/frame/screen.cc       | 17 +++-
- .../renderer/core/frame/visual_viewport.cc    |  5 ++
- .../renderer/core/html/html_meta_element.cc   | 26 +++++-
- .../renderer/core/loader/frame_loader.cc      | 15 +++-
- third_party/blink/renderer/core/page/page.cc  | 12 +++
- third_party/blink/renderer/core/page/page.h   |  5 ++
- 28 files changed, 261 insertions(+), 15 deletions(-)
+ .../core/css/resolver/style_resolver.cc       | 10 ++-
+ .../blink/renderer/core/events/mouse_event.h  | 19 +++-
+ .../renderer/core/events/pointer_event.h      | 11 +++
+ .../renderer/core/exported/web_view_impl.cc   |  2 +-
+ .../renderer/core/frame/local_dom_window.cc   | 33 ++++++-
+ .../blink/renderer/core/frame/local_frame.cc  | 12 ++-
+ .../blink/renderer/core/frame/local_frame.h   |  6 +-
+ .../core/frame/screen_metrics_emulator.cc     |  7 +-
+ .../core/frame/screen_metrics_emulator.h      |  8 ++
+ .../core/frame/web_frame_widget_impl.cc       |  8 ++
+ .../core/frame/web_remote_frame_impl.cc       |  3 +-
+ .../blink/renderer/core/input/touch.cc        | 17 +++-
+ third_party/blink/renderer/core/page/page.cc  | 74 ++++++++++++++++
+ third_party/blink/renderer/core/page/page.h   |  7 ++
+ 32 files changed, 356 insertions(+), 20 deletions(-)
  create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
  create mode 100644 components/browser_ui/strings/android/viewport.grdp
 
@@ -263,7 +266,7 @@ diff --git a/components/content_settings/core/browser/content_settings_utils.cc 
 diff --git a/components/content_settings/core/common/content_settings.cc b/components/content_settings/core/common/content_settings.cc
 --- a/components/content_settings/core/common/content_settings.cc
 +++ b/components/content_settings/core/common/content_settings.cc
-@@ -206,7 +206,8 @@ bool RendererContentSettingRules::IsRendererContentSetting(
+@@ -207,7 +207,8 @@ bool RendererContentSettingRules::IsRendererContentSetting(
           content_type == ContentSettingsType::AUTO_DARK_WEB_CONTENT ||
           content_type == ContentSettingsType::TIMEZONE_OVERRIDE ||
           content_type == ContentSettingsType::WEBGL ||
@@ -273,7 +276,7 @@ diff --git a/components/content_settings/core/common/content_settings.cc b/compo
  }
  
  void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
-@@ -220,6 +221,7 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
+@@ -221,6 +222,7 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
    FilterRulesForType(autoplay_rules, outermost_main_frame_url);
    FilterRulesForType(webgl_rules, outermost_main_frame_url);
    FilterRulesForType(webrtc_rules, outermost_main_frame_url);
@@ -383,325 +386,466 @@ diff --git a/third_party/blink/public/platform/web_content_settings_client.h b/t
    // Reports that passive mixed content was found at the provided URL.
    virtual void PassiveInsecureContentFound(const WebURL&) {}
  
-diff --git a/third_party/blink/renderer/core/css/media_values.cc b/third_party/blink/renderer/core/css/media_values.cc
---- a/third_party/blink/renderer/core/css/media_values.cc
-+++ b/third_party/blink/renderer/core/css/media_values.cc
-@@ -132,14 +132,24 @@ double MediaValues::CalculateViewportWidth(LocalFrame* frame) {
-   DCHECK(frame);
-   DCHECK(frame->View());
-   DCHECK(frame->GetDocument());
--  return frame->View()->ViewportSizeForMediaQueries().width();
-+  float width_override = frame->GetPage()->PageWidthOverride();
-+  double width = frame->View()->ViewportSizeForMediaQueries().width();
-+  if (width_override) {
-+    width = width * (1.0 - (width_override / 100.0));
-+  }
-+  return width;
- }
+diff --git a/third_party/blink/renderer/core/css/resolver/style_resolver.cc b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
+--- a/third_party/blink/renderer/core/css/resolver/style_resolver.cc
++++ b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
+@@ -1478,8 +1478,14 @@ scoped_refptr<ComputedStyle> StyleResolver::InitialStyleForElement() const {
  
- double MediaValues::CalculateViewportHeight(LocalFrame* frame) {
-   DCHECK(frame);
-   DCHECK(frame->View());
-   DCHECK(frame->GetDocument());
--  return frame->View()->ViewportSizeForMediaQueries().height();
-+  float width_override = frame->GetPage()->PageWidthOverride();
-+  double height = frame->View()->ViewportSizeForMediaQueries().height();
-+  if (width_override) {
-+    height = height * (1.0 - (width_override / 100.0));
+   initial_style->SetRtlOrdering(
+       GetDocument().VisuallyOrdered() ? EOrder::kVisual : EOrder::kLogical);
+-  initial_style->SetZoom(InitialZoom());
+-  initial_style->SetEffectiveZoom(initial_style->Zoom());
++  if (GetDocument().GetPage() && GetDocument().GetPage()->IsScreenEmulated()) {
++    // hides the zoom override to the dom on the html tag
++    initial_style->SetZoom(1);
++    initial_style->SetEffectiveZoom(InitialZoom());
++  } else {
++    initial_style->SetZoom(InitialZoom());
++    initial_style->SetEffectiveZoom(initial_style->Zoom());
 +  }
-+  return height;
- }
+   initial_style->SetInForcedColorsMode(GetDocument().InForcedColorsMode());
+   initial_style->SetTapHighlightColor(
+       ComputedStyleInitialValues::InitialTapHighlightColor());
+diff --git a/third_party/blink/renderer/core/events/mouse_event.h b/third_party/blink/renderer/core/events/mouse_event.h
+--- a/third_party/blink/renderer/core/events/mouse_event.h
++++ b/third_party/blink/renderer/core/events/mouse_event.h
+@@ -31,6 +31,7 @@
+ #include "third_party/blink/renderer/core/dom/events/simulated_click_options.h"
+ #include "third_party/blink/renderer/core/events/ui_event_with_key_state.h"
+ #include "third_party/blink/renderer/platform/wtf/casting.h"
++#include "third_party/blink/renderer/core/page/page.h"
  
- double MediaValues::CalculateSmallViewportWidth(LocalFrame* frame) {
-@@ -193,6 +203,11 @@ int MediaValues::CalculateDeviceWidth(LocalFrame* frame) {
-     device_width = static_cast<int>(
-         lroundf(device_width * screen_info.device_scale_factor));
+ namespace blink {
+ 
+@@ -139,8 +140,22 @@ class CORE_EXPORT MouseEvent : public UIEventWithKeyState {
+ 
+   // Note that these values are adjusted to counter the effects of zoom, so that
+   // values exposed via DOM APIs are invariant under zooming.
+-  virtual double screenX() const { return std::floor(screen_x_); }
+-  virtual double screenY() const { return std::floor(screen_y_); }
++  virtual double screenX() const {
++    if (view() && view()->GetFrame() &&
++        view()->GetFrame()->GetPage() &&
++        view()->GetFrame()->GetPage()->IsScreenEmulated()) {
++      return std::floor(page_x_);
++    }
++    return std::floor(screen_x_);
++  }
++  virtual double screenY() const {
++    if (view() && view()->GetFrame() &&
++        view()->GetFrame()->GetPage() &&
++        view()->GetFrame()->GetPage()->IsScreenEmulated()) {
++      return std::floor(page_y_);
++    }
++    return std::floor(screen_y_);
++  }
+ 
+   virtual double clientX() const { return std::floor(client_x_); }
+   virtual double clientY() const { return std::floor(client_y_); }
+diff --git a/third_party/blink/renderer/core/events/pointer_event.h b/third_party/blink/renderer/core/events/pointer_event.h
+--- a/third_party/blink/renderer/core/events/pointer_event.h
++++ b/third_party/blink/renderer/core/events/pointer_event.h
+@@ -9,6 +9,7 @@
+ #include "third_party/blink/renderer/core/core_export.h"
+ #include "third_party/blink/renderer/core/events/mouse_event.h"
+ #include "third_party/blink/renderer/platform/wtf/casting.h"
++#include "third_party/blink/renderer/core/page/page.h"
+ 
+ namespace blink {
+ 
+@@ -57,11 +58,21 @@ class CORE_EXPORT PointerEvent : public MouseEvent {
+   double screenX() const override {
+     if (ShouldHaveIntegerCoordinates())
+       return MouseEvent::screenX();
++    if (view() && view()->GetFrame() &&
++        view()->GetFrame()->GetPage() &&
++        view()->GetFrame()->GetPage()->IsScreenEmulated()) {
++      return page_x_;
++    }
+     return screen_x_;
    }
-+  float width_override = frame->GetPage()->PageWidthOverride();
-+  if (width_override) {
-+    device_width = static_cast<int>(
-+        lroundf(device_width * (1.0 - (width_override / 100.0))));
-+  }
-   return device_width;
- }
- 
-@@ -205,6 +220,11 @@ int MediaValues::CalculateDeviceHeight(LocalFrame* frame) {
-     device_height = static_cast<int>(
-         lroundf(device_height * screen_info.device_scale_factor));
+   double screenY() const override {
+     if (ShouldHaveIntegerCoordinates())
+       return MouseEvent::screenY();
++    if (view() && view()->GetFrame() &&
++        view()->GetFrame()->GetPage() &&
++        view()->GetFrame()->GetPage()->IsScreenEmulated()) {
++      return page_y_;
++    }
+     return screen_y_;
    }
-+  float width_override = frame->GetPage()->PageWidthOverride();
-+  if (width_override) {
-+    device_height = static_cast<int>(
-+        lroundf(device_height * (1.0 - (width_override / 100.0))));
-+  }
-   return device_height;
- }
+   double clientX() const override {
+diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_party/blink/renderer/core/exported/web_view_impl.cc
+--- a/third_party/blink/renderer/core/exported/web_view_impl.cc
++++ b/third_party/blink/renderer/core/exported/web_view_impl.cc
+@@ -1015,7 +1015,7 @@ WebPagePopupImpl* WebViewImpl::OpenPagePopup(PagePopupClient* client) {
+       std::move(popup_widget_host), std::move(widget_host),
+       std::move(widget_receiver), agent_group_scheduler.DefaultTaskRunner());
+   popup_widget->InitializeCompositing(agent_group_scheduler,
+-                                      opener_widget->GetOriginalScreenInfos(),
++                                      opener_widget->GetScreenInfos(),
+                                       /*settings=*/nullptr);
  
-diff --git a/third_party/blink/renderer/core/frame/dom_visual_viewport.cc b/third_party/blink/renderer/core/frame/dom_visual_viewport.cc
---- a/third_party/blink/renderer/core/frame/dom_visual_viewport.cc
-+++ b/third_party/blink/renderer/core/frame/dom_visual_viewport.cc
-@@ -177,8 +177,10 @@ double DOMVisualViewport::scale() const {
-   if (!frame->IsOutermostMainFrame())
-     return 1;
- 
--  if (Page* page = window_->GetFrame()->GetPage())
-+  if (Page* page = window_->GetFrame()->GetPage()) {
-+    if (page->PageWidthOverride() != 0) return 1;
-     return page->GetVisualViewport().ScaleForVisualViewport();
-+  }
- 
-   return 0;
- }
+   page_popup_ = To<WebPagePopupImpl>(popup_widget);
 diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_party/blink/renderer/core/frame/local_dom_window.cc
 --- a/third_party/blink/renderer/core/frame/local_dom_window.cc
 +++ b/third_party/blink/renderer/core/frame/local_dom_window.cc
-@@ -1400,6 +1400,9 @@ int LocalDOMWindow::outerHeight() const {
+@@ -1406,6 +1406,11 @@ int LocalDOMWindow::outerHeight() const {
    if (!page)
      return 0;
  
-+  float width_override = page->PageWidthOverride();
-+  if (width_override) return innerHeight();
++  // If screen is emulated and this frame is remote cross-origin
++  // return innerHeight
++  if (page->IsScreenEmulated() && frame->IsCrossOriginToOutermostMainFrame())
++    return innerHeight();
 +
    ChromeClient& chrome_client = page->GetChromeClient();
    if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
      return static_cast<int>(
-@@ -1425,6 +1428,9 @@ int LocalDOMWindow::outerWidth() const {
+@@ -1431,6 +1436,11 @@ int LocalDOMWindow::outerWidth() const {
    if (!page)
      return 0;
  
-+  float width_override = page->PageWidthOverride();
-+  if (width_override) return innerWidth();
++  // If screen is emulated and this frame is remote cross-origin
++  // return innerWidth
++  if (page->IsScreenEmulated() && frame->IsCrossOriginToOutermostMainFrame())
++    return innerWidth();
 +
    ChromeClient& chrome_client = page->GetChromeClient();
    if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
      return static_cast<int>(
-diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
---- a/third_party/blink/renderer/core/frame/local_frame_view.cc
-+++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
-@@ -1034,6 +1034,9 @@ gfx::SizeF LocalFrameView::ViewportSizeForMediaQueries() const {
-   gfx::SizeF viewport_size(layout_size_);
-   if (!frame_->GetDocument() || !frame_->GetDocument()->Printing())
-     viewport_size.Scale(1 / GetFrame().PageZoomFactor());
-+  float width_override = frame_->GetPage()->PageWidthOverride();
-+  if (width_override)
-+    viewport_size.Scale(1.0 + (width_override / 100.0));
-   return viewport_size;
+@@ -1618,7 +1628,14 @@ double LocalDOMWindow::devicePixelRatio() const {
+   if (!GetFrame())
+     return 0.0;
+ 
+-  return GetFrame()->DevicePixelRatio();
++  bool with_zoom_factor = true;
++
++  // do not send the zoom factor override value
++  Page* page = GetFrame()->GetPage();
++  if (page && page->IsScreenEmulated())
++    with_zoom_factor = false;
++
++  return GetFrame()->DevicePixelRatio(with_zoom_factor);
  }
  
-diff --git a/third_party/blink/renderer/core/frame/screen.cc b/third_party/blink/renderer/core/frame/screen.cc
---- a/third_party/blink/renderer/core/frame/screen.cc
-+++ b/third_party/blink/renderer/core/frame/screen.cc
-@@ -35,6 +35,7 @@
- #include "third_party/blink/renderer/core/frame/local_frame.h"
- #include "third_party/blink/renderer/core/frame/settings.h"
- #include "third_party/blink/renderer/core/page/chrome_client.h"
-+#include "third_party/blink/renderer/core/page/page.h"
- #include "ui/display/screen_info.h"
- #include "ui/display/screen_infos.h"
+ void LocalDOMWindow::scrollBy(double x, double y) const {
+@@ -2162,6 +2179,20 @@ DOMWindow* LocalDOMWindow::open(v8::Isolate* isolate,
+   if (!completed_url.IsEmpty() || result.new_window)
+     result.frame->Navigate(frame_request, WebFrameLoadType::kStandard);
  
-@@ -42,6 +43,10 @@ namespace blink {
++  if (result.frame->IsLocalFrame()) {
++    // we need to use opener setting when opening a iframe without url
++    // (as "about:blank") to force emulated screen
++    // since result.frame.GetContentSettingsClient()->AllowViewportChange()
++    // in the Page::DidCommitLoad() event returns false for these urls
++    //
++    // prevent this js code:
++    //     var w = window.open()
++    //     var not_emulated_screen_info = w.screen
++    result.frame->GetPage()->CalculateEmulatedScreenSetting(
++      To<LocalFrame>(result.frame),
++      /*force*/ GetFrame()->GetContentSettingsClient()->AllowViewportChange(false));
++  }
++
+   // TODO(japhet): window-open-noopener.html?_top and several tests in
+   // html/browsers/windows/browsing-context-names/ appear to require that
+   // the special case target names (_top, _parent, _self) ignore opener
+diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/blink/renderer/core/frame/local_frame.cc
+--- a/third_party/blink/renderer/core/frame/local_frame.cc
++++ b/third_party/blink/renderer/core/frame/local_frame.cc
+@@ -1233,6 +1233,10 @@ gfx::SizeF LocalFrame::ResizePageRectsKeepingRatio(
+   return gfx::SizeF(result_width, result_height);
+ }
  
- namespace {
- 
-+float GetScaleOverride(blink::Page* page) {
-+  return 1.0 - (page->PageWidthOverride() / 100.0);
++void LocalFrame::SetPageZoomFactorBaseValue(float factor) {
++  page_zoom_factor_base_value_ = factor;
 +}
 +
- }  // namespace
- 
- Screen::Screen(LocalDOMWindow* window, int64_t display_id)
-@@ -83,9 +88,10 @@ int Screen::height() const {
-   const display::ScreenInfo& screen_info = GetScreenInfo();
-   if (frame->GetSettings()->GetReportScreenSizeInPhysicalPixelsQuirk()) {
-     return base::ClampRound(screen_info.rect.height() *
-+                            GetScaleOverride(frame->GetPage()) *
-                             screen_info.device_scale_factor);
-   }
--  return screen_info.rect.height();
-+  return screen_info.rect.height() * GetScaleOverride(frame->GetPage());
+ void LocalFrame::SetPageZoomFactor(float factor) {
+   SetPageAndTextZoomFactors(factor, text_zoom_factor_);
+ }
+@@ -1381,12 +1385,16 @@ device::mojom::blink::DevicePostureType LocalFrame::GetDevicePosture() {
+   return mojo_handler_->GetDevicePosture();
  }
  
- int Screen::width() const {
-@@ -95,9 +101,10 @@ int Screen::width() const {
-   const display::ScreenInfo& screen_info = GetScreenInfo();
-   if (frame->GetSettings()->GetReportScreenSizeInPhysicalPixelsQuirk()) {
-     return base::ClampRound(screen_info.rect.width() *
-+                            GetScaleOverride(frame->GetPage()) *
-                             screen_info.device_scale_factor);
-   }
--  return screen_info.rect.width();
-+  return screen_info.rect.width() * GetScaleOverride(frame->GetPage());
+-double LocalFrame::DevicePixelRatio() const {
++double LocalFrame::DevicePixelRatio(bool with_zoom_factor) const {
+   if (!page_)
+     return 0;
+ 
+   double ratio = page_->InspectorDeviceScaleFactorOverride();
+-  ratio *= PageZoomFactor();
++  // with_zoom_factor is default true
++  if (with_zoom_factor)
++    ratio *= PageZoomFactor();
++  else
++    ratio *= (PageZoomFactor() - page_zoom_factor_base_value_);
+   return ratio;
  }
  
- unsigned Screen::colorDepth() const {
-@@ -141,9 +148,10 @@ int Screen::availHeight() const {
-   const display::ScreenInfo& screen_info = GetScreenInfo();
-   if (frame->GetSettings()->GetReportScreenSizeInPhysicalPixelsQuirk()) {
-     return base::ClampRound(screen_info.available_rect.height() *
-+                            GetScaleOverride(frame->GetPage()) *
-                             screen_info.device_scale_factor);
-   }
--  return screen_info.available_rect.height();
-+  return screen_info.available_rect.height() * GetScaleOverride(frame->GetPage());
+diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/blink/renderer/core/frame/local_frame.h
+--- a/third_party/blink/renderer/core/frame/local_frame.h
++++ b/third_party/blink/renderer/core/frame/local_frame.h
+@@ -351,14 +351,15 @@ class CORE_EXPORT LocalFrame final
+   void SetInViewSourceMode(bool = true);
+ 
+   void SetPageZoomFactor(float);
+-  float PageZoomFactor() const { return page_zoom_factor_; }
++  void SetPageZoomFactorBaseValue(float factor);
++  float PageZoomFactor() const { return page_zoom_factor_ + page_zoom_factor_base_value_; }
+   void SetTextZoomFactor(float);
+   float TextZoomFactor() const { return text_zoom_factor_; }
+   void SetPageAndTextZoomFactors(float page_zoom_factor,
+                                  float text_zoom_factor);
+ 
+   void DeviceScaleFactorChanged();
+-  double DevicePixelRatio() const;
++  double DevicePixelRatio(bool with_zoom_factor = true) const;
+ 
+   // Informs the local root's document and its local descendant subtree that a
+   // media query value changed.
+@@ -867,6 +868,7 @@ class CORE_EXPORT LocalFrame final
+   unsigned hidden_ : 1;
+ 
+   float page_zoom_factor_;
++  float page_zoom_factor_base_value_ = 0;
+   float text_zoom_factor_;
+ 
+   Member<CoreProbeSink> probe_sink_;
+diff --git a/third_party/blink/renderer/core/frame/screen_metrics_emulator.cc b/third_party/blink/renderer/core/frame/screen_metrics_emulator.cc
+--- a/third_party/blink/renderer/core/frame/screen_metrics_emulator.cc
++++ b/third_party/blink/renderer/core/frame/screen_metrics_emulator.cc
+@@ -163,6 +163,9 @@ void ScreenMetricsEmulator::Apply() {
+   frame_widget_->SetScreenInfoAndSize(emulated_screen_infos,
+                                       /*widget_size=*/widget_size,
+                                       /*visible_viewport_size=*/widget_size);
++
++  // save emulated window size
++  window_size_ = window_size;
  }
  
- int Screen::availWidth() const {
-@@ -153,9 +161,10 @@ int Screen::availWidth() const {
-   const display::ScreenInfo& screen_info = GetScreenInfo();
-   if (frame->GetSettings()->GetReportScreenSizeInPhysicalPixelsQuirk()) {
-     return base::ClampRound(screen_info.available_rect.width() *
-+                            GetScaleOverride(frame->GetPage()) *
-                             screen_info.device_scale_factor);
-   }
--  return screen_info.available_rect.width();
-+  return screen_info.available_rect.width() * GetScaleOverride(frame->GetPage());
+ void ScreenMetricsEmulator::UpdateVisualProperties(
+@@ -191,9 +194,7 @@ void ScreenMetricsEmulator::OnUpdateScreenRects(
+     const gfx::Rect& window_screen_rect) {
+   original_view_screen_rect_ = view_screen_rect;
+   original_window_screen_rect_ = window_screen_rect;
+-  if (emulating_desktop()) {
+-    Apply();
+-  }
++  Apply();
  }
  
- void Screen::Trace(Visitor* visitor) const {
-diff --git a/third_party/blink/renderer/core/frame/visual_viewport.cc b/third_party/blink/renderer/core/frame/visual_viewport.cc
---- a/third_party/blink/renderer/core/frame/visual_viewport.cc
-+++ b/third_party/blink/renderer/core/frame/visual_viewport.cc
-@@ -1093,6 +1093,11 @@ bool VisualViewport::ShouldDisableDesktopWorkarounds() const {
-   if (!LocalMainFrame().GetSettings()->GetViewportEnabled())
-     return false;
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/core/frame/screen_metrics_emulator.h b/third_party/blink/renderer/core/frame/screen_metrics_emulator.h
+--- a/third_party/blink/renderer/core/frame/screen_metrics_emulator.h
++++ b/third_party/blink/renderer/core/frame/screen_metrics_emulator.h
+@@ -61,6 +61,11 @@ class ScreenMetricsEmulator : public GarbageCollected<ScreenMetricsEmulator> {
+   // Emulated position of the main frame widget (aka view) rect.
+   gfx::Point ViewRectOrigin();
  
-+  if (LocalMainFrame().GetPage() &&
-+      LocalMainFrame().GetPage()->PageWidthOverride() != 0) {
-+    return true;
++  // Get emulated window size
++  const gfx::Size& ViewWindowSize() const {
++    return window_size_;
 +  }
 +
-   // A document is considered adapted to small screen UAs if one of these holds:
-   // 1. The author specified viewport has a constrained width that is equal to
-   //    the initial viewport width.
-diff --git a/third_party/blink/renderer/core/html/html_meta_element.cc b/third_party/blink/renderer/core/html/html_meta_element.cc
---- a/third_party/blink/renderer/core/html/html_meta_element.cc
-+++ b/third_party/blink/renderer/core/html/html_meta_element.cc
-@@ -22,6 +22,7 @@
- 
- #include "third_party/blink/renderer/core/html/html_meta_element.h"
- 
-+#include "base/rand_util.h"
- #include "third_party/blink/public/mojom/frame/color_scheme.mojom-blink.h"
- #include "third_party/blink/renderer/core/css/style_engine.h"
- #include "third_party/blink/renderer/core/dom/document.h"
-@@ -565,6 +566,25 @@ void HTMLMetaElement::ProcessContent() {
-   if (!IsInDocumentTree())
-     return;
- 
-+  bool process_default = true;
+   // Disables emulation and applies non-emulated values to the
+   // WebFrameWidgetImpl. Call this before destroying the ScreenMetricsEmulator.
+   void DisableAndApply();
+@@ -96,6 +101,9 @@ class ScreenMetricsEmulator : public GarbageCollected<ScreenMetricsEmulator> {
+   gfx::Rect original_view_screen_rect_;
+   gfx::Rect original_window_screen_rect_;
+   std::vector<gfx::Rect> original_root_window_segments_;
 +
-+  if (GetDocument().GetFrame()) {
-+    blink::LocalFrame* frame = GetDocument().GetFrame();
-+    blink::WebContentSettingsClient* settings = frame->GetContentSettingsClient();
-+    blink::Page* page = frame->GetPage();
-+
-+    if (settings->AllowViewportChange(false)) {
-+      if (page->PageWidthOverride() == 0) {
-+        page->SetPageWidthOverride(base::RandInt(-30, 150) / 10.0);
-+      }
-+
-+      float device_width = 1.0 + (page->PageWidthOverride() / 100.0);
-+      String newvalue("initial-scale=" + base::NumberToString(device_width));
-+      ProcessViewportContentAttribute(newvalue, ViewportDescription::kViewportMeta);
-+      process_default = false;
++  // Actual size after apply
++  gfx::Size window_size_;
+ };
+ 
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc b/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
+--- a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
++++ b/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
+@@ -1499,6 +1499,14 @@ void WebFrameWidgetImpl::ApplyVisualPropertiesSizing(
+ 
+     if (auto* device_emulator = DeviceEmulator()) {
+       device_emulator->UpdateVisualProperties(visual_properties);
++      // Shink the view according to browsercontrols
++      size_ = widget_base_->DIPsToCeiledBlinkSpace(
++          device_emulator->ViewWindowSize());
++      View()->ResizeWithBrowserControls(
++          size_.value(),
++          widget_base_->DIPsToCeiledBlinkSpace(
++              widget_base_->VisibleViewportSizeInDIPs()),
++          visual_properties.browser_controls_params);
+       return;
+     }
+ 
+diff --git a/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc b/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
+--- a/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
++++ b/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
+@@ -315,7 +315,8 @@ void WebRemoteFrameImpl::InitializeFrameVisualProperties(
+   visual_properties.page_scale_factor = ancestor_widget->PageScaleInMainFrame();
+   visual_properties.is_pinch_gesture_active =
+       ancestor_widget->PinchGestureActiveInMainFrame();
+-  visual_properties.screen_infos = ancestor_widget->GetOriginalScreenInfos();
++  // for a cross-site iframe, set the actual (original or emulated) screen infos
++  visual_properties.screen_infos = ancestor_widget->GetScreenInfos();
+   visual_properties.visible_viewport_size =
+       ancestor_widget->VisibleViewportSizeInDIPs();
+   const WebVector<gfx::Rect>& window_segments =
+diff --git a/third_party/blink/renderer/core/input/touch.cc b/third_party/blink/renderer/core/input/touch.cc
+--- a/third_party/blink/renderer/core/input/touch.cc
++++ b/third_party/blink/renderer/core/input/touch.cc
+@@ -30,6 +30,7 @@
+ #include "third_party/blink/renderer/core/frame/local_frame_view.h"
+ #include "third_party/blink/renderer/core/paint/paint_layer_scrollable_area.h"
+ #include "ui/gfx/geometry/point_f.h"
++#include "third_party/blink/renderer/core/page/page.h"
+ 
+ namespace blink {
+ 
+@@ -75,7 +76,13 @@ Touch::Touch(LocalFrame* frame,
+       radius_(radius),
+       rotation_angle_(rotation_angle),
+       force_(force),
+-      absolute_location_(PageToAbsolute(frame, page_pos)) {}
++      absolute_location_(PageToAbsolute(frame, page_pos)) {
++    if (frame->GetPage() && frame->GetPage()->IsScreenEmulated()) {
++      // use page_pos instead of screen_pos
++      screen_pos_.set_x(page_pos_.x());
++      screen_pos_.set_y(page_pos_.y());
 +    }
 +  }
-+
-   const AtomicString& name_value = FastGetAttribute(html_names::kNameAttr);
-   if (name_value.IsEmpty())
-     return;
-@@ -594,8 +614,10 @@ void HTMLMetaElement::ProcessContent() {
-     return;
  
-   if (EqualIgnoringASCIICase(name_value, "viewport")) {
--    ProcessViewportContentAttribute(content_value,
--                                    ViewportDescription::kViewportMeta);
-+    if (process_default) {
-+      ProcessViewportContentAttribute(content_value,
-+                                      ViewportDescription::kViewportMeta);
-+    }
-   } else if (EqualIgnoringASCIICase(name_value, "referrer") &&
-              GetExecutionContext()) {
-     UseCounter::Count(&GetDocument(),
-diff --git a/third_party/blink/renderer/core/loader/frame_loader.cc b/third_party/blink/renderer/core/loader/frame_loader.cc
---- a/third_party/blink/renderer/core/loader/frame_loader.cc
-+++ b/third_party/blink/renderer/core/loader/frame_loader.cc
-@@ -371,8 +371,13 @@ void FrameLoader::SaveScrollState() {
-   history_item->SetVisualViewportScrollOffset(
-       frame_->GetPage()->GetVisualViewport().VisibleRect().OffsetFromOrigin());
- 
--  if (frame_->IsMainFrame())
--    history_item->SetPageScaleFactor(frame_->GetPage()->PageScaleFactor());
-+  if (frame_->IsMainFrame()) {
-+    int page_width_override = frame_->GetPage()->PageWidthOverride();
-+    if (page_width_override == 0) {
-+      // set the scale factor only if the feature is not active
-+      history_item->SetPageScaleFactor(frame_->GetPage()->PageScaleFactor());
+ Touch::Touch(EventTarget* target,
+              int identifier,
+@@ -105,7 +112,13 @@ Touch::Touch(LocalFrame* frame, const TouchInit* initializer)
+       radius_(initializer->radiusX(), initializer->radiusY()),
+       rotation_angle_(initializer->rotationAngle()),
+       force_(initializer->force()),
+-      absolute_location_(PageToAbsolute(frame, page_pos_)) {}
++      absolute_location_(PageToAbsolute(frame, page_pos_))  {
++    if (frame->GetPage() && frame->GetPage()->IsScreenEmulated()) {
++      // use page_pos instead of screen_pos
++      screen_pos_.set_x(page_pos_.x());
++      screen_pos_.set_y(page_pos_.y());
 +    }
 +  }
  
-   Client()->DidUpdateCurrentHistoryItem();
- }
-@@ -1326,6 +1331,12 @@ void FrameLoader::RestoreScrollPositionAndViewState() {
-       !GetDocumentLoader()->NavigationScrollAllowed()) {
-     return;
-   }
-+  int page_width_override = frame_->GetPage()->PageWidthOverride();
-+  if (page_width_override != 0) {
-+    // we need to reset the page scale because, if the user activates
-+    // the feature, it could be non-zero from the previous navigation
-+    GetDocumentLoader()->GetHistoryItem()->SetPageScaleFactor(0);
-+  }
-   RestoreScrollPositionAndViewState(
-       GetDocumentLoader()->LoadType(),
-       *GetDocumentLoader()->GetHistoryItem()->GetViewState(),
+ Touch* Touch::CloneWithNewTarget(EventTarget* event_target) const {
+   return MakeGarbageCollected<Touch>(
 diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/renderer/core/page/page.cc
 --- a/third_party/blink/renderer/core/page/page.cc
 +++ b/third_party/blink/renderer/core/page/page.cc
-@@ -507,6 +507,14 @@ float Page::PageScaleFactor() const {
-   return GetVisualViewport().Scale();
+@@ -92,6 +92,9 @@
+ #include "third_party/blink/renderer/platform/scheduler/public/agent_group_scheduler.h"
+ #include "third_party/blink/renderer/platform/scheduler/public/frame_scheduler.h"
+ #include "third_party/skia/include/core/SkColor.h"
++#include "base/rand_util.h"
++#include "third_party/blink/public/common/widget/device_emulation_params.h"
++#include "third_party/blink/renderer/core/exported/web_view_impl.h"
+ 
+ namespace blink {
+ 
+@@ -881,7 +884,78 @@ void Page::UpdateAcceleratedCompositingSettings() {
+   }
  }
  
-+void Page::SetPageWidthOverride(float value) {
-+  page_width_override_ = value;
++void Page::CalculateEmulatedScreenSetting(LocalFrame* frame, bool force) {
++  blink::WebContentSettingsClient* settings = frame->GetContentSettingsClient();
++  if (settings->AllowViewportChange(false) || force) {
++    // this is the maximum (and minimum) value which in percentage
++    // corresponds to +- 0.03%
++    // more or less 3-6 pixels according to the resolution 300-600px
++    // little enough not to change the page view the user is used to,
++    // but enough to change all bounds, especially those in floating point
++    const int max_range = 300;
++
++    // only for the local main frame
++    // the other local frames use the values from main
++    // while the remote ones do not communicate the values to the parent
++    // (and they will be local main frame in their page context)
++    if (main_frame_ == frame) {
++      // set the scale factor
++      double scale_factor = 0;
++      if (override_window_scale_factor_ != 0) {
++        scale_factor = override_window_scale_factor_;
++      } else {
++        // we allow the increase or decrease of the screen size (and view)
++        scale_factor = 1.0 + base::RandInt(-max_range, max_range) / 10000.0;
++      }
++
++      // save the value, so a same domain navigation will reuse same value
++      override_window_scale_factor_ = scale_factor;
++
++      // we divide the value in half: half for the screen and the view,
++      // which then the latter will be scaled again by the zoom
++      double half_random = (scale_factor - 1.0) / 2.0;
++
++      // set emulation params
++      DeviceEmulationParams params;
++      // the screen size is changed to match the widget size for mobile emulation
++      params.screen_type = mojom::EmulatedScreenType::kMobile;
++      // scale the widget size (and the screen size) by half_random scale factor
++      params.scale = 1 / (1.0 + half_random);
++
++      GetChromeClient().GetWebView()->EnableDeviceEmulation(params);
++
++      // set zoom factor
++      // the zoom factor is used by all the functions that manage the bounds,
++      // which is multiplied by the values in pixels when computed
++      // we do not modify the actual value but only the one used internally
++      // it becomes the base value used as the zoom property of the css, but
++      // it does not appear on the dom (which always remains 1.0)
++      double zoom_factor = 0;
++      if (override_zoom_factor_ != 0) {
++        zoom_factor = override_zoom_factor_;
++      } else {
++        // we only allow the page size to decrease, otherwise the scroll
++        // bars would not be visible
++        zoom_factor = base::RandInt(0, max_range/2) / 10000.0;
++      }
++
++      // save the value, so a same domain navigation will reuse same value
++      override_zoom_factor_ = zoom_factor;
++
++      frame->SetPageZoomFactorBaseValue(zoom_factor);
++    }
++    is_screen_emulated = true;
++  } else {
++    if (is_screen_emulated && main_frame_ == frame) {
++      GetChromeClient().GetWebView()->DisableDeviceEmulation();
++      frame->SetPageZoomFactorBaseValue(0);
++    }
++    is_screen_emulated = false;
++  }
 +}
 +
-+float Page::PageWidthOverride() const {
-+  return page_width_override_;
-+}
-+
- void Page::AllVisitedStateChanged(bool invalidate_visited_link_hashes) {
-   for (const Page* page : OrdinaryPages()) {
-     for (Frame* frame = page->main_frame_; frame;
-@@ -879,6 +887,10 @@ void Page::UpdateAcceleratedCompositingSettings() {
- 
  void Page::DidCommitLoad(LocalFrame* frame) {
++  CalculateEmulatedScreenSetting(frame);
    if (main_frame_ == frame) {
-+    blink::WebContentSettingsClient* settings = frame->GetContentSettingsClient();
-+    if (!settings->AllowViewportChange(false))
-+      SetPageWidthOverride(0);
-+
      GetConsoleMessageStorage().Clear();
      GetInspectorIssueStorage().Clear();
-     // TODO(loonybear): Most of this doesn't appear to take into account that
 diff --git a/third_party/blink/renderer/core/page/page.h b/third_party/blink/renderer/core/page/page.h
 --- a/third_party/blink/renderer/core/page/page.h
 +++ b/third_party/blink/renderer/core/page/page.h
-@@ -273,6 +273,9 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
-   void SetPageScaleFactor(float);
-   float PageScaleFactor() const;
- 
-+  void SetPageWidthOverride(float);
-+  float PageWidthOverride() const;
-+
-   float InspectorDeviceScaleFactorOverride() const {
-     return inspector_device_scale_factor_override_;
+@@ -410,6 +410,9 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
    }
-@@ -538,6 +541,8 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
+   mojom::blink::FencedFrameMode FencedFrameMode() { return fenced_frame_mode_; }
+ 
++  void CalculateEmulatedScreenSetting(LocalFrame* frame, bool force = false);
++  bool IsScreenEmulated() { return is_screen_emulated; }
++
+  private:
+   friend class ScopedPagePauser;
+ 
+@@ -539,6 +542,10 @@ class CORE_EXPORT Page final : public GarbageCollected<Page>,
    // browser side FrameTree has the FrameTree::Type of kFencedFrame.
    bool is_fenced_frame_tree_ = false;
  
-+  float page_width_override_ = 0;
++  bool is_screen_emulated = false;
++  double override_window_scale_factor_ = 0;
++  double override_zoom_factor_ = 0;
 +
    // If the page is hosted inside an MPArch fenced frame, this tracks the
    // mode that the fenced frame is set to. This will always be set to kDefault

--- a/build/patches/Viewport-Protection.patch
+++ b/build/patches/Viewport-Protection.patch
@@ -28,24 +28,24 @@ The feature is controlled by a site setting (default disabled)
  .../blink/renderer/core/events/mouse_event.h  | 19 +++-
  .../renderer/core/events/pointer_event.h      | 11 +++
  .../renderer/core/exported/web_view_impl.cc   |  2 +-
- .../renderer/core/frame/local_dom_window.cc   | 33 ++++++-
+ .../renderer/core/frame/local_dom_window.cc   | 27 +++++-
  .../blink/renderer/core/frame/local_frame.cc  | 12 ++-
  .../blink/renderer/core/frame/local_frame.h   |  6 +-
- .../core/frame/screen_metrics_emulator.cc     |  7 +-
+ .../core/frame/screen_metrics_emulator.cc     |  8 +-
  .../core/frame/screen_metrics_emulator.h      |  8 ++
  .../core/frame/web_frame_widget_impl.cc       |  8 ++
  .../core/frame/web_remote_frame_impl.cc       |  3 +-
  .../blink/renderer/core/input/touch.cc        | 17 +++-
  third_party/blink/renderer/core/page/page.cc  | 74 ++++++++++++++++
  third_party/blink/renderer/core/page/page.h   |  7 ++
- 32 files changed, 356 insertions(+), 20 deletions(-)
+ 32 files changed, 351 insertions(+), 20 deletions(-)
  create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BromiteViewportContentSetting.java
  create mode 100644 components/browser_ui/strings/android/viewport.grdp
 
 diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/browser_ui/site_settings/android/BUILD.gn
 --- a/components/browser_ui/site_settings/android/BUILD.gn
 +++ b/components/browser_ui/site_settings/android/BUILD.gn
-@@ -78,6 +78,9 @@ android_library("java") {
+@@ -85,6 +85,9 @@ android_library("java") {
    sources += [
      "java/src/org/chromium/components/browser_ui/site_settings/BromiteWebRTCContentSetting.java",
    ]
@@ -219,14 +219,14 @@ new file mode 100644
 diff --git a/components/components_strings.grd b/components/components_strings.grd
 --- a/components/components_strings.grd
 +++ b/components/components_strings.grd
-@@ -339,6 +339,7 @@
+@@ -340,6 +340,7 @@
        <part file="user_scripts/strings/userscripts_strings.grdp" />
        <part file="browser_ui/strings/android/webgl.grdp" />
        <part file="browser_ui/strings/android/webrtc.grdp" />
 +      <part file="browser_ui/strings/android/viewport.grdp" />
  
        <if expr="not is_ios">
-         <part file="management_strings.grdp" />
+         <part file="history_clusters_strings.grdp" />
 diff --git a/components/content_settings/core/browser/content_settings_registry.cc b/components/content_settings/core/browser/content_settings_registry.cc
 --- a/components/content_settings/core/browser/content_settings_registry.cc
 +++ b/components/content_settings/core/browser/content_settings_registry.cc
@@ -389,7 +389,7 @@ diff --git a/third_party/blink/public/platform/web_content_settings_client.h b/t
 diff --git a/third_party/blink/renderer/core/css/resolver/style_resolver.cc b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
 --- a/third_party/blink/renderer/core/css/resolver/style_resolver.cc
 +++ b/third_party/blink/renderer/core/css/resolver/style_resolver.cc
-@@ -1478,8 +1478,14 @@ scoped_refptr<ComputedStyle> StyleResolver::InitialStyleForElement() const {
+@@ -1487,8 +1487,14 @@ scoped_refptr<ComputedStyle> StyleResolver::InitialStyleForElement() const {
  
    initial_style->SetRtlOrdering(
        GetDocument().VisuallyOrdered() ? EOrder::kVisual : EOrder::kLogical);
@@ -478,19 +478,19 @@ diff --git a/third_party/blink/renderer/core/events/pointer_event.h b/third_part
 diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_party/blink/renderer/core/exported/web_view_impl.cc
 --- a/third_party/blink/renderer/core/exported/web_view_impl.cc
 +++ b/third_party/blink/renderer/core/exported/web_view_impl.cc
-@@ -1015,7 +1015,7 @@ WebPagePopupImpl* WebViewImpl::OpenPagePopup(PagePopupClient* client) {
+@@ -1014,7 +1014,7 @@ WebPagePopupImpl* WebViewImpl::OpenPagePopup(PagePopupClient* client) {
+   page_popup_ = WebPagePopupImpl::Create(
        std::move(popup_widget_host), std::move(widget_host),
-       std::move(widget_receiver), agent_group_scheduler.DefaultTaskRunner());
-   popup_widget->InitializeCompositing(agent_group_scheduler,
--                                      opener_widget->GetOriginalScreenInfos(),
-+                                      opener_widget->GetScreenInfos(),
-                                       /*settings=*/nullptr);
- 
-   page_popup_ = To<WebPagePopupImpl>(popup_widget);
+       std::move(widget_receiver), this, agent_group_scheduler,
+-      opener_widget->GetOriginalScreenInfos(), client);
++      opener_widget->GetScreenInfos(), client);
+   EnablePopupMouseWheelEventListener(web_opener_frame->LocalRoot());
+   return page_popup_.get();
+ }
 diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_party/blink/renderer/core/frame/local_dom_window.cc
 --- a/third_party/blink/renderer/core/frame/local_dom_window.cc
 +++ b/third_party/blink/renderer/core/frame/local_dom_window.cc
-@@ -1406,6 +1406,11 @@ int LocalDOMWindow::outerHeight() const {
+@@ -1388,6 +1388,11 @@ int LocalDOMWindow::outerHeight() const {
    if (!page)
      return 0;
  
@@ -502,7 +502,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
    ChromeClient& chrome_client = page->GetChromeClient();
    if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
      return static_cast<int>(
-@@ -1431,6 +1436,11 @@ int LocalDOMWindow::outerWidth() const {
+@@ -1413,6 +1418,11 @@ int LocalDOMWindow::outerWidth() const {
    if (!page)
      return 0;
  
@@ -514,23 +514,17 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
    ChromeClient& chrome_client = page->GetChromeClient();
    if (page->GetSettings().GetReportScreenSizeInPhysicalPixelsQuirk()) {
      return static_cast<int>(
-@@ -1618,7 +1628,14 @@ double LocalDOMWindow::devicePixelRatio() const {
+@@ -1600,7 +1610,8 @@ double LocalDOMWindow::devicePixelRatio() const {
    if (!GetFrame())
      return 0.0;
  
 -  return GetFrame()->DevicePixelRatio();
-+  bool with_zoom_factor = true;
-+
-+  // do not send the zoom factor override value
-+  Page* page = GetFrame()->GetPage();
-+  if (page && page->IsScreenEmulated())
-+    with_zoom_factor = false;
-+
-+  return GetFrame()->DevicePixelRatio(with_zoom_factor);
++  // never send the zoom factor override value
++  return GetFrame()->DevicePixelRatio(/*with_zoom_factor*/false);
  }
  
  void LocalDOMWindow::scrollBy(double x, double y) const {
-@@ -2162,6 +2179,20 @@ DOMWindow* LocalDOMWindow::open(v8::Isolate* isolate,
+@@ -2142,6 +2153,20 @@ DOMWindow* LocalDOMWindow::open(v8::Isolate* isolate,
    if (!completed_url.IsEmpty() || result.new_window)
      result.frame->Navigate(frame_request, WebFrameLoadType::kStandard);
  
@@ -554,7 +548,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_dom_window.cc b/third_p
 diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/blink/renderer/core/frame/local_frame.cc
 --- a/third_party/blink/renderer/core/frame/local_frame.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame.cc
-@@ -1233,6 +1233,10 @@ gfx::SizeF LocalFrame::ResizePageRectsKeepingRatio(
+@@ -1267,6 +1267,10 @@ gfx::SizeF LocalFrame::ResizePageRectsKeepingRatio(
    return gfx::SizeF(result_width, result_height);
  }
  
@@ -565,7 +559,7 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/
  void LocalFrame::SetPageZoomFactor(float factor) {
    SetPageAndTextZoomFactors(factor, text_zoom_factor_);
  }
-@@ -1381,12 +1385,16 @@ device::mojom::blink::DevicePostureType LocalFrame::GetDevicePosture() {
+@@ -1406,12 +1410,16 @@ device::mojom::blink::DevicePostureType LocalFrame::GetDevicePosture() {
    return mojo_handler_->GetDevicePosture();
  }
  
@@ -580,14 +574,14 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.cc b/third_party/
 +  if (with_zoom_factor)
 +    ratio *= PageZoomFactor();
 +  else
-+    ratio *= (PageZoomFactor() - page_zoom_factor_base_value_);
++    ratio = page_zoom_factor_;
    return ratio;
  }
  
 diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/blink/renderer/core/frame/local_frame.h
 --- a/third_party/blink/renderer/core/frame/local_frame.h
 +++ b/third_party/blink/renderer/core/frame/local_frame.h
-@@ -351,14 +351,15 @@ class CORE_EXPORT LocalFrame final
+@@ -364,13 +364,14 @@ class CORE_EXPORT LocalFrame final
    void SetInViewSourceMode(bool = true);
  
    void SetPageZoomFactor(float);
@@ -599,13 +593,12 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/b
    void SetPageAndTextZoomFactors(float page_zoom_factor,
                                   float text_zoom_factor);
  
-   void DeviceScaleFactorChanged();
 -  double DevicePixelRatio() const;
 +  double DevicePixelRatio(bool with_zoom_factor = true) const;
  
    // Informs the local root's document and its local descendant subtree that a
    // media query value changed.
-@@ -867,6 +868,7 @@ class CORE_EXPORT LocalFrame final
+@@ -886,6 +887,7 @@ class CORE_EXPORT LocalFrame final
    unsigned hidden_ : 1;
  
    float page_zoom_factor_;
@@ -626,13 +619,14 @@ diff --git a/third_party/blink/renderer/core/frame/screen_metrics_emulator.cc b/
  }
  
  void ScreenMetricsEmulator::UpdateVisualProperties(
-@@ -191,9 +194,7 @@ void ScreenMetricsEmulator::OnUpdateScreenRects(
+@@ -191,9 +194,8 @@ void ScreenMetricsEmulator::OnUpdateScreenRects(
      const gfx::Rect& window_screen_rect) {
    original_view_screen_rect_ = view_screen_rect;
    original_window_screen_rect_ = window_screen_rect;
 -  if (emulating_desktop()) {
 -    Apply();
 -  }
++  // needed as we need browser ui size
 +  Apply();
  }
  
@@ -665,7 +659,7 @@ diff --git a/third_party/blink/renderer/core/frame/screen_metrics_emulator.h b/t
 diff --git a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc b/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
 --- a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
 +++ b/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc
-@@ -1499,6 +1499,14 @@ void WebFrameWidgetImpl::ApplyVisualPropertiesSizing(
+@@ -1579,6 +1579,14 @@ void WebFrameWidgetImpl::ApplyVisualPropertiesSizing(
  
      if (auto* device_emulator = DeviceEmulator()) {
        device_emulator->UpdateVisualProperties(visual_properties);
@@ -683,7 +677,7 @@ diff --git a/third_party/blink/renderer/core/frame/web_frame_widget_impl.cc b/th
 diff --git a/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc b/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
 --- a/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
 +++ b/third_party/blink/renderer/core/frame/web_remote_frame_impl.cc
-@@ -315,7 +315,8 @@ void WebRemoteFrameImpl::InitializeFrameVisualProperties(
+@@ -339,7 +339,8 @@ void WebRemoteFrameImpl::InitializeFrameVisualProperties(
    visual_properties.page_scale_factor = ancestor_widget->PageScaleInMainFrame();
    visual_properties.is_pinch_gesture_active =
        ancestor_widget->PinchGestureActiveInMainFrame();
@@ -753,7 +747,7 @@ diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/re
  
 +void Page::CalculateEmulatedScreenSetting(LocalFrame* frame, bool force) {
 +  blink::WebContentSettingsClient* settings = frame->GetContentSettingsClient();
-+  if (settings->AllowViewportChange(false) || force) {
++  if ( (settings && settings->AllowViewportChange(false)) || force) {
 +    // this is the maximum (and minimum) value which in percentage
 +    // corresponds to +- 0.03%
 +    // more or less 3-6 pixels according to the resolution 300-600px

--- a/build/patches/Viewport-Protection.patch
+++ b/build/patches/Viewport-Protection.patch
@@ -23,15 +23,15 @@ The feature is controlled by a feature flag (default enabled)
  .../core/frame/screen_metrics_emulator.h      | 14 ++++
  .../core/frame/web_frame_widget_impl.cc       |  8 ++
  .../core/frame/web_remote_frame_impl.cc       |  3 +-
- .../blink/renderer/core/input/touch.cc        | 17 +++-
- third_party/blink/renderer/core/page/page.cc  | 80 +++++++++++++++++++
+ .../blink/renderer/core/input/touch.cc        | 17 ++++-
+ third_party/blink/renderer/core/page/page.cc  | 76 +++++++++++++++++++
  third_party/blink/renderer/core/page/page.h   |  7 ++
- 20 files changed, 245 insertions(+), 17 deletions(-)
+ 20 files changed, 241 insertions(+), 17 deletions(-)
 
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -7631,6 +7631,11 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -7627,6 +7627,11 @@ const FeatureEntry kFeatureEntries[] = {
                                      "PaintPreviewShowOnStartup")},
  #endif  // BUILDFLAG(ENABLE_PAINT_PREVIEW) && BUILDFLAG(IS_ANDROID)
  
@@ -46,7 +46,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
-@@ -6851,6 +6851,12 @@ const char kPaintPreviewStartupDescription[] =
+@@ -6847,6 +6847,12 @@ const char kPaintPreviewStartupDescription[] =
      "instead.";
  #endif  // ENABLE_PAINT_PREVIEW && BUILDFLAG(IS_ANDROID)
  
@@ -62,7 +62,7 @@ diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descripti
 diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
 --- a/chrome/browser/flag_descriptions.h
 +++ b/chrome/browser/flag_descriptions.h
-@@ -3950,6 +3950,9 @@ extern const char kPaintPreviewStartupName[];
+@@ -3948,6 +3948,9 @@ extern const char kPaintPreviewStartupName[];
  extern const char kPaintPreviewStartupDescription[];
  #endif  // ENABLE_PAINT_PREVIEW && BUILDFLAG(IS_ANDROID)
  
@@ -75,7 +75,7 @@ diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptio
 diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
 --- a/third_party/blink/common/features.cc
 +++ b/third_party/blink/common/features.cc
-@@ -1638,6 +1638,10 @@ BASE_FEATURE(kDocumentEventNodePathCaching,
+@@ -1637,6 +1637,10 @@ BASE_FEATURE(kDocumentEventNodePathCaching,
               "DocumentEventNodePathCaching",
               base::FEATURE_DISABLED_BY_DEFAULT);
  
@@ -89,7 +89,7 @@ diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/fea
 diff --git a/third_party/blink/public/common/features.h b/third_party/blink/public/common/features.h
 --- a/third_party/blink/public/common/features.h
 +++ b/third_party/blink/public/common/features.h
-@@ -868,6 +868,9 @@ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kThreadedBodyLoader);
+@@ -867,6 +867,9 @@ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kThreadedBodyLoader);
  // If enabled, will cache for each node's EventPath::NodePath in document.
  BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kDocumentEventNodePathCaching);
  
@@ -531,7 +531,7 @@ diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/re
  
  namespace blink {
  
-@@ -881,7 +885,83 @@ void Page::UpdateAcceleratedCompositingSettings() {
+@@ -881,7 +885,79 @@ void Page::UpdateAcceleratedCompositingSettings() {
    }
  }
  
@@ -570,11 +570,7 @@ diff --git a/third_party/blink/renderer/core/page/page.cc b/third_party/blink/re
 +      DeviceEmulationParams params;
 +      // the screen size is changed to match the widget size with force_mobile_calc
 +      params.force_mobile_calc = true;
-+#if BUILDFLAG(IS_ANDROID)
-+      params.screen_type = mojom::EmulatedScreenType::kMobile;
-+#else
 +      params.screen_type = mojom::EmulatedScreenType::kDesktop;
-+#endif
 +      // scale the widget size (and the screen size) by half_random scale factor
 +      params.scale = 1 / (1.0 + half_random);
 +


### PR DESCRIPTION
## Description

continue from https://github.com/bromite/bromite/pull/2175

I went ahead with the implementation, and this is the one I like the most of the versions I have developed.
basically it acts on the size of the screen and the view through the use of the emulator mode (which is normally active only in the desktop versions of chromium).
the use of those api allowed me to minimize the changes (because I let chromium behave as normal) and above all to have a greater guarantee about future changes (being an api internal to chromium).
I also added the function that modifies the rect of the dom regardless of how they are defined via css: substantially I have changed the zoom of the page since all the coordinates calculated from that, so:

> Does this mitigation supersede any pre-existing one?

now yes. By disabling the flags of ungoogled, the values do not remain constant, indeed the fingerprinting tools do not detect the anomaly.

the patch in fact reduces (or increases) the space available to the blink view with two factors:
- a value that is multiplied to the current standard size (in css pixels, which is calculated by dividing the effective space of the device by the device pixel ratio, which can be set from the android interface).
- a value that rescales the view (and therefore only keeps the screen at the value calculated above) by acting on the zoom of the page, so that all the rect of the dom are different.

in the code you will also find the management of remote frames (which I finally understood :) that they are the local same-domain IFRAMEs and remote cross-domain ones) because to they I pass the screen value of the top page and inhibit access to the browser controls size (innerWidth/Height == outerWidth/Height).

if you can try to give an eye...
to test it I used

https://canvasblocker.kkapsner.de/test/domRectTest.php
https://abrahamjuliot.github.io/creepjs/tests/domrect.html
https://abrahamjuliot.github.io/creepjs/tests/screen.html
https://dev-pages.brave.software/fingerprinting/farbling.html
https://browserleaks.com/rects
https://privacycheck.sec.lrz.de/active/fp_gcr/fp_getclientrects.html
https://arkenfox.github.io/TZP/tests/domrectspoof.html

but i'm thinking the next step will be to finally start building some bromite test

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
