### PR TITLE
Import patches to make WebView work on Tiramisu

### DIFF
--- a/build/bromite_patches_list.txt
+++ b/build/bromite_patches_list.txt
@@ -200,4 +200,9 @@ Re-introduce-kWebAuthCable.patch
 Add-new-cache-check-function.patch
 Stop-cross-origin-cache-hits.patch
 Revert-clipboard-user-gesture-requirement-removal.patch
+Clean-up-logic-in-BuildInfo.targetsAtLeastT.patch
+Suppress-lint-in-DarkModeHelper-for-T-SDK.patch
+Suppress-lints-for-Android-T-SDK-update.patch
+Suppress-T-SDK-lints-in-Cronet.patch
+Update-to-Android-T-SDK.patch
 Automated-domain-substitution.patch

--- a/build/patches/Clean-up-logic-in-BuildInfo.targetsAtLeastT.patch
+++ b/build/patches/Clean-up-logic-in-BuildInfo.targetsAtLeastT.patch
@@ -1,0 +1,55 @@
+From: "Torne (Richard Coles)" <torne@google.com>
+Date: Fri, 22 Jul 2022 18:22:34 +0000
+Subject: Clean up logic in BuildInfo.targetsAtLeastT.
+
+The logic previously implemented worked correctly, but was misleading as
+it implied that there were actually two separate cases for pre and post
+API finalization, when actually only the first case matters because
+CUR_DEVELOPMENT is greater than the actual API level.
+
+Clean this up and tweak the comments to make it clearer that the
+transition from API finalization to public SDK will be fine and the only
+reason for needing three "versions" of the function here is because the
+named constant won't be available at build time upstream yet.
+
+Bug: 1339376
+Change-Id: I9090300cf098753f02b9f13770fba51b8d76d388
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3782717
+Reviewed-by: Jinsuk Kim <jinsukkim@chromium.org>
+Commit-Queue: Jinsuk Kim <jinsukkim@chromium.org>
+Auto-Submit: Richard Coles <torne@chromium.org>
+Commit-Queue: Richard Coles <torne@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1027336}
+---
+ .../java/src/org/chromium/base/BuildInfo.java    | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/base/android/java/src/org/chromium/base/BuildInfo.java b/base/android/java/src/org/chromium/base/BuildInfo.java
+--- a/base/android/java/src/org/chromium/base/BuildInfo.java
++++ b/base/android/java/src/org/chromium/base/BuildInfo.java
+@@ -248,13 +248,15 @@ public class BuildInfo {
+         // Logic for pre-API-finalization:
+         // return BuildCompat.isAtLeastT() && target == Build.VERSION_CODES.CUR_DEVELOPMENT;
+ 
+-        // Logic for smooth transition period so that both pre-finalization and final SDKs
+-        // will return true, assuming T will be API 33.
+-        // Keeping this until we upstream the public SDK is a reasonable transition period.
+-        return target >= 33 ||
+-                (BuildCompat.isAtLeastT() && target == Build.VERSION_CODES.CUR_DEVELOPMENT);
+-
+-        // Logic for public SDK release:
++        // Logic for after API finalization but before public SDK release has to
++        // just hardcode the appropriate SDK integer. This will include Android
++        // builds with the finalized SDK, and also pre-API-finalization builds
++        // (because CUR_DEVELOPMENT == 10000).
++        return target >= 33;
++
++        // Once the public SDK is upstreamed we can use the defined constant,
++        // deprecate this, then eventually inline this at all callsites and
++        // remove it.
+         // return target >= Build.VERSION_CODES.TIRAMISU;
+     }
+ 
+-- 
+2.37.3
+

--- a/build/patches/Suppress-T-SDK-lints-in-Cronet.patch
+++ b/build/patches/Suppress-T-SDK-lints-in-Cronet.patch
@@ -1,0 +1,45 @@
+From: "Torne (Richard Coles)" <torne@google.com>
+Date: Mon, 25 Jul 2022 18:59:55 +0000
+Subject: Suppress T SDK lints in Cronet.
+
+Suppress lints for some uses of getIdentifier() in Cronet where there's
+no alternative.
+
+Bug: 1339376
+Change-Id: I47be8650048300431e1da9e5b7f56e8722d237a2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3779845
+Auto-Submit: Richard Coles <torne@chromium.org>
+Reviewed-by: Mohamed Heikal <mheikal@chromium.org>
+Commit-Queue: Mohamed Heikal <mheikal@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1027878}
+---
+ .../cronet/android/api/src/org/chromium/net/CronetProvider.java | 2 ++
+ .../src/org/chromium/net/smoke/CronetSmokeTestRule.java         | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/components/cronet/android/api/src/org/chromium/net/CronetProvider.java b/components/cronet/android/api/src/org/chromium/net/CronetProvider.java
+--- a/components/cronet/android/api/src/org/chromium/net/CronetProvider.java
++++ b/components/cronet/android/api/src/org/chromium/net/CronetProvider.java
+@@ -215,6 +215,8 @@ public abstract class CronetProvider {
+      *         {@link #RES_KEY_CRONET_IMPL_CLASS} key.
+      * @throws RuntimeException if the provider cannot be found or instantiated.
+      */
++    // looking up resources from other apps requires the use of getIdentifier()
++    @SuppressWarnings("DiscouragedApi")
+     private static boolean addCronetProviderFromResourceFile(
+             Context context, Set<CronetProvider> providers) {
+         int resId = context.getResources().getIdentifier(
+diff --git a/components/cronet/android/test/smoketests/src/org/chromium/net/smoke/CronetSmokeTestRule.java b/components/cronet/android/test/smoketests/src/org/chromium/net/smoke/CronetSmokeTestRule.java
+--- a/components/cronet/android/test/smoketests/src/org/chromium/net/smoke/CronetSmokeTestRule.java
++++ b/components/cronet/android/test/smoketests/src/org/chromium/net/smoke/CronetSmokeTestRule.java
+@@ -107,6 +107,7 @@ public class CronetSmokeTestRule implements TestRule {
+      *
+      * @throws Exception if the class cannot be instantiated.
+      */
++    @SuppressWarnings("DiscouragedApi")
+     private void initTestSupport() throws Exception {
+         Context ctx = InstrumentationRegistry.getTargetContext();
+         String packageName = ctx.getPackageName();
+-- 
+2.37.3
+

--- a/build/patches/Suppress-lint-in-DarkModeHelper-for-T-SDK.patch
+++ b/build/patches/Suppress-lint-in-DarkModeHelper-for-T-SDK.patch
@@ -1,0 +1,34 @@
+From: "Torne (Richard Coles)" <torne@google.com>
+Date: Fri, 22 Jul 2022 21:59:58 +0000
+Subject: Suppress lint in DarkModeHelper for T SDK.
+
+Linting against the T SDK results in a new lint in DarkModeHelper;
+suppress it as we have no alternative here.
+
+Bug: 1339376
+Change-Id: Id0785fb3ea10e9de4d8fd1c4c13ffa5e2fe6dfc0
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3780314
+Auto-Submit: Richard Coles <torne@chromium.org>
+Reviewed-by: Michael Bai <michaelbai@chromium.org>
+Commit-Queue: Richard Coles <torne@chromium.org>
+Commit-Queue: Michael Bai <michaelbai@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1027430}
+---
+ .../java/src/org/chromium/android_webview/DarkModeHelper.java   | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/android_webview/java/src/org/chromium/android_webview/DarkModeHelper.java b/android_webview/java/src/org/chromium/android_webview/DarkModeHelper.java
+--- a/android_webview/java/src/org/chromium/android_webview/DarkModeHelper.java
++++ b/android_webview/java/src/org/chromium/android_webview/DarkModeHelper.java
+@@ -64,6 +64,8 @@ public class DarkModeHelper {
+         }
+     }
+ 
++    // must use getIdentifier to access resources from another app
++    @SuppressWarnings("DiscouragedApi")
+     @LightTheme
+     public static int getLightTheme(Context context) {
+         if (sLightThemeForTesting != null) return sLightThemeForTesting;
+-- 
+2.37.3
+

--- a/build/patches/Suppress-lints-for-Android-T-SDK-update.patch
+++ b/build/patches/Suppress-lints-for-Android-T-SDK-update.patch
@@ -1,0 +1,203 @@
+From: "Torne (Richard Coles)" <torne@google.com>
+Date: Mon, 25 Jul 2022 16:39:37 +0000
+Subject: Suppress lints for Android T SDK update.
+
+A number of new lints trigger when updating the SDK to Android T. Most
+of these are uses of Resources.getIdentifier which is discouraged
+because name-based resource lookups are slow, but most of our callsites
+have no alternative.
+
+Bug: 1339376
+Change-Id: I29b32a580c3ab45e236615065ef1306474c0cba5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3780794
+Commit-Queue: Peter Wen <wnwen@chromium.org>
+Auto-Submit: Richard Coles <torne@chromium.org>
+Reviewed-by: Peter Wen <wnwen@chromium.org>
+Reviewed-by: Yaron Friedman <yfriedman@chromium.org>
+Reviewed-by: Michael Bai <michaelbai@chromium.org>
+Reviewed-by: Clemens Arbesser <arbesser@google.com>
+Cr-Commit-Position: refs/heads/main@{#1027796}
+---
+ .../org/chromium/android_webview/AndroidProtocolHandler.java  | 2 ++
+ .../chromium/android_webview/nonembedded/LicenseActivity.java | 1 +
+ .../browser/customtabs/PartialCustomTabHeightStrategy.java    | 2 ++
+ .../chrome/browser/password_manager/AccountChooserDialog.java | 2 ++
+ .../java/src/org/chromium/chrome/browser/tab/TabUtils.java    | 2 ++
+ .../browser/webapps/WebApkIntentDataProviderFactory.java      | 4 ++++
+ .../components/autofill/AutofillActionModeCallback.java       | 2 ++
+ .../autofill_assistant/generic_ui/AssistantColor.java         | 2 ++
+ .../autofill_assistant/generic_ui/AssistantDrawable.java      | 2 ++
+ .../qr_code/permission/AssistantQrCodePermissionView.java     | 1 +
+ .../external_intents/ExternalNavigationHandler.java           | 3 ++-
+ .../strictmode/ReflectiveThreadStrictModeInterceptor.java     | 2 +-
+ 12 files changed, 23 insertions(+), 2 deletions(-)
+
+diff --git a/android_webview/java/src/org/chromium/android_webview/AndroidProtocolHandler.java b/android_webview/java/src/org/chromium/android_webview/AndroidProtocolHandler.java
+--- a/android_webview/java/src/org/chromium/android_webview/AndroidProtocolHandler.java
++++ b/android_webview/java/src/org/chromium/android_webview/AndroidProtocolHandler.java
+@@ -93,6 +93,8 @@ public class AndroidProtocolHandler {
+                 packageName + ".R$" + assetType);
+     }
+ 
++    // file://android_res/ has no choice but to do name-based resource lookups
++    @SuppressWarnings("DiscouragedApi")
+     private static int getFieldId(String assetType, String assetName)
+             throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
+         Context appContext = ContextUtils.getApplicationContext();
+diff --git a/android_webview/nonembedded/java/src/org/chromium/android_webview/nonembedded/LicenseActivity.java b/android_webview/nonembedded/java/src/org/chromium/android_webview/nonembedded/LicenseActivity.java
+--- a/android_webview/nonembedded/java/src/org/chromium/android_webview/nonembedded/LicenseActivity.java
++++ b/android_webview/nonembedded/java/src/org/chromium/android_webview/nonembedded/LicenseActivity.java
+@@ -24,6 +24,7 @@ public class LicenseActivity extends Activity {
+     private static final String LICENSES_CONTENT_TYPE = "text/html";
+ 
+     @Override
++    @SuppressWarnings("DiscouragedApi")
+     protected void onCreate(Bundle savedInstanceState) {
+         super.onCreate(savedInstanceState);
+         final String packageName = getPackageName();
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/PartialCustomTabHeightStrategy.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/PartialCustomTabHeightStrategy.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/PartialCustomTabHeightStrategy.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/PartialCustomTabHeightStrategy.java
+@@ -830,6 +830,8 @@ public class PartialCustomTabHeightStrategy extends CustomTabHeightStrategy
+         return displayMetrics.heightPixels;
+     }
+ 
++    // status_bar_height is not a public framework resource, so we have to getIdentifier()
++    @SuppressWarnings("DiscouragedApi")
+     private @Px int getStatusBarHeight() {
+         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+             return mActivity.getWindowManager()
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/password_manager/AccountChooserDialog.java b/chrome/android/java/src/org/chromium/chrome/browser/password_manager/AccountChooserDialog.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/password_manager/AccountChooserDialog.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/password_manager/AccountChooserDialog.java
+@@ -213,6 +213,8 @@ public class AccountChooserDialog
+         mDialog.show();
+     }
+ 
++    // status_bar_height is not a public framework resource, so we have to getIdentifier()
++    @SuppressWarnings("DiscouragedApi")
+     private void showTooltip(View view, String message, int layoutId) {
+         Context context = view.getContext();
+         Resources resources = context.getResources();
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabUtils.java b/chrome/android/java/src/org/chromium/chrome/browser/tab/TabUtils.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabUtils.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tab/TabUtils.java
+@@ -82,6 +82,8 @@ public class TabUtils {
+      * @param context The application context.
+      * @return The estimated prerender size in pixels.
+      */
++    // status_bar_height is not a public framework resource, so we have to getIdentifier()
++    @SuppressWarnings("DiscouragedApi")
+     public static Rect estimateContentSize(Context context) {
+         // The size is estimated as:
+         // X = screenSizeX
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebApkIntentDataProviderFactory.java b/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebApkIntentDataProviderFactory.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebApkIntentDataProviderFactory.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebApkIntentDataProviderFactory.java
+@@ -162,6 +162,8 @@ public class WebApkIntentDataProviderFactory {
+      * @param resources
+      * @return A list of shortcut items derived from the parser.
+      */
++    // looking up resources from other apps requires the use of getIdentifier()
++    @SuppressWarnings("DiscouragedApi")
+     private static List<ShortcutItem> parseShortcutItems(String webApkPackageName, Resources res) {
+         int shortcutsResId =
+                 res.getIdentifier(RESOURCE_SHORTCUTS, RESOURCE_XML_TYPE, webApkPackageName);
+@@ -223,6 +225,8 @@ public class WebApkIntentDataProviderFactory {
+      * @param shareData Shared information from the share intent.
+      * @param shareDataActivityClassName Name of WebAPK activity which received share intent.
+      */
++    // looking up resources from other apps requires the use of getIdentifier()
++    @SuppressWarnings("DiscouragedApi")
+     public static BrowserServicesIntentDataProvider create(Intent intent, String webApkPackageName,
+             String url, int source, boolean forceNavigation,
+             boolean canUseSplashFromContentProvider, ShareData shareData,
+diff --git a/components/android_autofill/browser/java/src/org/chromium/components/autofill/AutofillActionModeCallback.java b/components/android_autofill/browser/java/src/org/chromium/components/autofill/AutofillActionModeCallback.java
+--- a/components/android_autofill/browser/java/src/org/chromium/components/autofill/AutofillActionModeCallback.java
++++ b/components/android_autofill/browser/java/src/org/chromium/components/autofill/AutofillActionModeCallback.java
+@@ -19,6 +19,8 @@ public class AutofillActionModeCallback implements ActionMode.Callback {
+     private final int mAutofillMenuItemTitle;
+     private final int mAutofillMenuItem;
+ 
++    // using getIdentifier to work around not-exposed framework resource ID
++    @SuppressWarnings("DiscouragedApi")
+     public AutofillActionModeCallback(Context context, AutofillProvider autofillProvider) {
+         mContext = context;
+         mAutofillProvider = autofillProvider;
+diff --git a/components/autofill_assistant/android/java/src/org/chromium/components/autofill_assistant/generic_ui/AssistantColor.java b/components/autofill_assistant/android/java/src/org/chromium/components/autofill_assistant/generic_ui/AssistantColor.java
+--- a/components/autofill_assistant/android/java/src/org/chromium/components/autofill_assistant/generic_ui/AssistantColor.java
++++ b/components/autofill_assistant/android/java/src/org/chromium/components/autofill_assistant/generic_ui/AssistantColor.java
+@@ -33,6 +33,7 @@ public abstract class AssistantColor {
+     }
+ 
+     @CalledByNative
++    @SuppressWarnings("DiscouragedApi")
+     public static boolean isValidResourceIdentifier(Context context, String resourceIdentifier) {
+         int colorId = context.getResources().getIdentifier(
+                 resourceIdentifier, "color", context.getPackageName());
+@@ -64,6 +65,7 @@ public abstract class AssistantColor {
+     @Nullable
+     @ColorInt
+     @CalledByNative
++    @SuppressWarnings("DiscouragedApi")
+     public static Integer createFromResource(Context context, String resourceIdentifier) {
+         int colorId = context.getResources().getIdentifier(
+                 resourceIdentifier, "color", context.getPackageName());
+diff --git a/components/autofill_assistant/android/java/src/org/chromium/components/autofill_assistant/generic_ui/AssistantDrawable.java b/components/autofill_assistant/android/java/src/org/chromium/components/autofill_assistant/generic_ui/AssistantDrawable.java
+--- a/components/autofill_assistant/android/java/src/org/chromium/components/autofill_assistant/generic_ui/AssistantDrawable.java
++++ b/components/autofill_assistant/android/java/src/org/chromium/components/autofill_assistant/generic_ui/AssistantDrawable.java
+@@ -57,6 +57,7 @@ public abstract class AssistantDrawable {
+ 
+     /** Returns whether {@code resourceId} is a valid resource identifier. */
+     @CalledByNative
++    @SuppressWarnings("DiscouragedApi")
+     public static boolean isValidDrawableResource(Context context, String resourceId) {
+         int drawableId = context.getResources().getIdentifier(
+                 resourceId, "drawable", context.getPackageName());
+@@ -167,6 +168,7 @@ public abstract class AssistantDrawable {
+         }
+ 
+         @Override
++        @SuppressWarnings("DiscouragedApi")
+         public void getDrawable(Context context, Callback<Drawable> callback) {
+             int drawableId = context.getResources().getIdentifier(
+                     mResourceId, "drawable", context.getPackageName());
+diff --git a/components/autofill_assistant/guided_browsing/android/java/src/org/chromium/components/autofill_assistant/guided_browsing/qr_code/permission/AssistantQrCodePermissionView.java b/components/autofill_assistant/guided_browsing/android/java/src/org/chromium/components/autofill_assistant/guided_browsing/qr_code/permission/AssistantQrCodePermissionView.java
+--- a/components/autofill_assistant/guided_browsing/android/java/src/org/chromium/components/autofill_assistant/guided_browsing/qr_code/permission/AssistantQrCodePermissionView.java
++++ b/components/autofill_assistant/guided_browsing/android/java/src/org/chromium/components/autofill_assistant/guided_browsing/qr_code/permission/AssistantQrCodePermissionView.java
+@@ -42,6 +42,7 @@ public class AssistantQrCodePermissionView {
+     /**
+      * The AssistantQrCodePermissionView constructor.
+      */
++    @SuppressWarnings("DiscouragedApi")
+     public AssistantQrCodePermissionView(Context context, AssistantQrCodePermissionType permission,
+             AssistantQrCodePermissionView.Delegate delegate,
+             AssistantQrCodePermissionCallback permissionCallback) {
+diff --git a/components/external_intents/android/java/src/org/chromium/components/external_intents/ExternalNavigationHandler.java b/components/external_intents/android/java/src/org/chromium/components/external_intents/ExternalNavigationHandler.java
+--- a/components/external_intents/android/java/src/org/chromium/components/external_intents/ExternalNavigationHandler.java
++++ b/components/external_intents/android/java/src/org/chromium/components/external_intents/ExternalNavigationHandler.java
+@@ -2117,7 +2117,8 @@ public class ExternalNavigationHandler {
+         return OverrideUrlLoadingResult.forExternalIntent();
+     }
+ 
+-    @SuppressWarnings("UseCompatLoadingForDrawables")
++    // looking up resources from other apps requires the use of getIdentifier()
++    @SuppressWarnings({"UseCompatLoadingForDrawables", "DiscouragedApi"})
+     private OverrideUrlLoadingResult startActivityWithChooser(final Intent intent,
+             QueryIntentActivitiesSupplier resolvingInfos, ResolveActivitySupplier resolveActivity,
+             GURL browserFallbackUrl, GURL intentDataUrl, GURL referrerUrl, Context context,
+diff --git a/components/strictmode/android/java/src/org/chromium/components/strictmode/ReflectiveThreadStrictModeInterceptor.java b/components/strictmode/android/java/src/org/chromium/components/strictmode/ReflectiveThreadStrictModeInterceptor.java
+--- a/components/strictmode/android/java/src/org/chromium/components/strictmode/ReflectiveThreadStrictModeInterceptor.java
++++ b/components/strictmode/android/java/src/org/chromium/components/strictmode/ReflectiveThreadStrictModeInterceptor.java
+@@ -107,7 +107,7 @@ final class ReflectiveThreadStrictModeInterceptor implements ThreadStrictModeInt
+     }
+ 
+     /** @param o {@code android.os.StrictMode.ViolationInfo} */
+-    @SuppressWarnings({"unchecked", "DiscouragedPrivateApi", "PrivateApi"})
++    @SuppressWarnings({"unchecked", "DiscouragedPrivateApi", "PrivateApi", "BlockedPrivateApi"})
+     private int getViolationType(Object violationInfo) {
+         try {
+             Class<?> violationInfoClass = Class.forName("android.os.StrictMode$ViolationInfo");
+-- 
+2.37.3
+

--- a/build/patches/Update-to-Android-T-SDK.patch
+++ b/build/patches/Update-to-Android-T-SDK.patch
@@ -1,0 +1,668 @@
+From: "Torne (Richard Coles)" <torne@google.com>
+Date: Tue, 26 Jul 2022 16:54:54 +0000
+Subject: Update to Android T SDK.
+
+Switch Android builds over to using the public Android T SDK.
+Upstream the WebView changes required to support T.
+
+Binary-Size: +66 methods; the SDK roll changes many things.
+Bug: 1339376
+Change-Id: I893d89c8402b90386aa7e67c5deb36fcc06a0ecf
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3780308
+Commit-Queue: Richard Coles <torne@chromium.org>
+Reviewed-by: Peter Wen <wnwen@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1028316}
+---
+ DEPS                                          | 14 ++++----
+ ...em_webview_bundle.AndroidManifest.expected |  6 ++--
+ ...me_webview_bundle.AndroidManifest.expected |  6 ++--
+ android_webview/glue/BUILD.gn                 |  1 +
+ .../chromium/ContentSettingsAdapter.java      | 36 +++++++++++++++++--
+ .../chromium/WebViewChromiumAwInit.java       |  7 ++--
+ .../WebViewChromiumFactoryProvider.java       | 12 -------
+ .../WebViewChromiumFactoryProviderForT.java   | 15 ++++++++
+ .../java/src/org/chromium/base/BuildInfo.java |  4 +--
+ .../src/org/chromium/base/ContextUtils.java   | 18 +++-------
+ build/android/pylib/constants/__init__.py     |  2 +-
+ build/config/android/config.gni               | 10 +++---
+ build/config/android/sdk.gni                  |  4 +--
+ ...utofill_assistant.AndroidManifest.expected |  6 ++--
+ ...blic_bundle__base.AndroidManifest.expected |  6 ++--
+ ...ev2_authenticator.AndroidManifest.expected |  6 ++--
+ ...ic_bundle__chrome.AndroidManifest.expected |  6 ++--
+ ...ic_bundle__dev_ui.AndroidManifest.expected |  6 ++--
+ ...e__stack_unwinder.AndroidManifest.expected |  6 ++--
+ ...undle__test_dummy.AndroidManifest.expected |  6 ++--
+ ...public_bundle__vr.AndroidManifest.expected |  6 ++--
+ ..._bundle__weblayer.AndroidManifest.expected |  6 ++--
+ ...rome_bundle__base.AndroidManifest.expected |  6 ++--
+ ...hrome_library_apk.AndroidManifest.expected |  6 ++--
+ third_party/android_sdk/README.chromium       | 12 +++----
+ .../android_system_sdk/README.chromium        |  2 +-
+ 26 files changed, 122 insertions(+), 93 deletions(-)
+ create mode 100644 android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumFactoryProviderForT.java
+
+diff --git a/DEPS b/DEPS
+--- a/DEPS
++++ b/DEPS
+@@ -384,11 +384,11 @@ vars = {
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling android_sdk_build-tools_version
+   # and whatever else without interference from each other.
+-  'android_sdk_build-tools_version': 'tRoD45SCi7UleQqSV7MrMQO1_e5P8ysphkCcj6z_cCQC',
++  'android_sdk_build-tools_version': '-VRKr36Uw8L_iFqqo9nevIBgNMggND5iWxjidyjnCgsC',
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling android_sdk_emulator_version
+   # and whatever else without interference from each other.
+-  'android_sdk_emulator_version': 'gMHhUuoQRKfxr-MBn3fNNXZtkAVXtOwMwT7kfx8jkIgC',
++  'android_sdk_emulator_version': '9lGp8nTUCRRWGMnI_96HcKfzjnxEJKUcfvfwmA3wXNkC',
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling android_sdk_extras_version
+   # and whatever else without interference from each other.
+@@ -400,11 +400,11 @@ vars = {
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling android_sdk_platform-tools_version
+   # and whatever else without interference from each other.
+-  'android_sdk_platform-tools_version': 'g7n_-r6yJd_SGRklujGB1wEt8iyr77FZTUJVS9w6O34C',
++  'android_sdk_platform-tools_version': 'RSI3iwryh7URLGRgJHsCvUxj092woTPnKt4pwFcJ6L8C',
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling android_sdk_platforms_version
+   # and whatever else without interference from each other.
+-  'android_sdk_platforms_version': 'lL3IGexKjYlwjO_1Ga-xwxgwbE_w-lmi2Zi1uOlWUIAC',
++  'android_sdk_platforms_version': 'eo5KvW6UVor92LwZai8Zulc624BQZoCu-yn7wa1z_YcC',
+   # Three lines of non-changing comments so that
+   # the commit queue can handle CLs rolling android_sdk_sources_version
+   # and whatever else without interference from each other.
+@@ -974,7 +974,7 @@ deps = {
+       'packages': [
+           {
+               'package': 'chromium/third_party/android_system_sdk/public',
+-              'version': 'oSfDIvHlCa6W0gS79Q5OOfB9E4eBg3uAvi3BEDN21U0C',
++              'version': 'RGY8Vyf8jjszRIJRFxZj7beXSUEHTQM90MtYejUvdMgC',
+           },
+       ],
+       'condition': 'checkout_android',
+@@ -1033,7 +1033,7 @@ deps = {
+   'src/third_party/android_sdk/public': {
+       'packages': [
+           {
+-              'package': 'chromium/third_party/android_sdk/public/build-tools/31.0.0',
++              'package': 'chromium/third_party/android_sdk/public/build-tools/33.0.0',
+               'version': Var('android_sdk_build-tools_version'),
+           },
+           {
+@@ -1049,7 +1049,7 @@ deps = {
+               'version': Var('android_sdk_platform-tools_version'),
+           },
+           {
+-              'package': 'chromium/third_party/android_sdk/public/platforms/android-31',
++              'package': 'chromium/third_party/android_sdk/public/platforms/android-33',
+               'version': Var('android_sdk_platforms_version'),
+           },
+           {
+diff --git a/android_webview/expectations/system_webview_bundle.AndroidManifest.expected b/android_webview/expectations/system_webview_bundle.AndroidManifest.expected
+--- a/android_webview/expectations/system_webview_bundle.AndroidManifest.expected
++++ b/android_webview/expectations/system_webview_bundle.AndroidManifest.expected
+@@ -2,8 +2,8 @@
+ <manifest
+     xmlns:android="http://schemas.android.com/apk/res/android"
+     package="com.android.webview"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12"
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13"
+     android:isolatedSplits="true">
+   <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
+   <uses-feature android:name="android.software.leanback" android:required="false"/>
+@@ -11,7 +11,7 @@
+   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+   <uses-permission android:name="android.permission.INTERNET"/>
+   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+-  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="33"/>
+   <application
+       android:name="org.chromium.android_webview.nonembedded.WebViewApkApplication"
+       android:extractNativeLibs="True"
+diff --git a/android_webview/expectations/trichrome_webview_bundle.AndroidManifest.expected b/android_webview/expectations/trichrome_webview_bundle.AndroidManifest.expected
+--- a/android_webview/expectations/trichrome_webview_bundle.AndroidManifest.expected
++++ b/android_webview/expectations/trichrome_webview_bundle.AndroidManifest.expected
+@@ -2,8 +2,8 @@
+ <manifest
+     xmlns:android="http://schemas.android.com/apk/res/android"
+     package="com.android.webview"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12"
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13"
+     android:isolatedSplits="true">
+   <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
+   <uses-feature android:name="android.software.leanback" android:required="false"/>
+@@ -11,7 +11,7 @@
+   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+   <uses-permission android:name="android.permission.INTERNET"/>
+   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+-  <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="33"/>
+   <application
+       android:name="org.chromium.android_webview.nonembedded.WebViewApkApplication"
+       android:extractNativeLibs="False"
+diff --git a/android_webview/glue/BUILD.gn b/android_webview/glue/BUILD.gn
+--- a/android_webview/glue/BUILD.gn
++++ b/android_webview/glue/BUILD.gn
+@@ -75,6 +75,7 @@ android_library("glue_java") {
+     "java/src/com/android/webview/chromium/WebViewChromiumFactoryProviderForQ.java",
+     "java/src/com/android/webview/chromium/WebViewChromiumFactoryProviderForR.java",
+     "java/src/com/android/webview/chromium/WebViewChromiumFactoryProviderForS.java",
++    "java/src/com/android/webview/chromium/WebViewChromiumFactoryProviderForT.java",
+     "java/src/com/android/webview/chromium/WebViewContentsClientAdapter.java",
+     "java/src/com/android/webview/chromium/WebViewDatabaseAdapter.java",
+     "java/src/com/android/webview/chromium/WebViewLibraryPreloader.java",
+diff --git a/android_webview/glue/java/src/com/android/webview/chromium/ContentSettingsAdapter.java b/android_webview/glue/java/src/com/android/webview/chromium/ContentSettingsAdapter.java
+--- a/android_webview/glue/java/src/com/android/webview/chromium/ContentSettingsAdapter.java
++++ b/android_webview/glue/java/src/com/android/webview/chromium/ContentSettingsAdapter.java
+@@ -439,17 +439,20 @@ public class ContentSettingsAdapter extends android.webkit.WebSettings {
+         // Intentional no-op.
+     }
+ 
+-    @Override
++    // removed from the public SDK in 33, so cannot @Override, but must remain
++    // to not break apps compiled against previous SDKs.
+     public synchronized void setAppCacheEnabled(boolean flag) {
+         // Intentional no-op.
+     }
+ 
+-    @Override
++    // removed from the public SDK in 33, so cannot @Override, but must remain
++    // to not break apps compiled against previous SDKs.
+     public synchronized void setAppCachePath(String appCachePath) {
+         // Intentional no-op.
+     }
+ 
+-    @Override
++    // removed from the public SDK in 33, so cannot @Override, but must remain
++    // to not break apps compiled against previous SDKs.
+     public synchronized void setAppCacheMaxSize(long appCacheMaxSize) {
+         // Intentional no-op.
+     }
+@@ -651,4 +654,31 @@ public class ContentSettingsAdapter extends android.webkit.WebSettings {
+         }
+         return WebSettings.FORCE_DARK_AUTO;
+     }
++
++    // Lint thinks we are targeting 32 so complains that this only overrides in 33, suppress until
++    // b/239952654 is resolved
++    @SuppressWarnings("Override")
++    @Override
++    public void setAlgorithmicDarkeningAllowed(boolean allow) {
++        if (!AwDarkMode.isSimplifiedDarkModeEnabled()) {
++            Log.w(TAG,
++                    "setAlgorithmicDarkeningAllowed() is a no-op in an app with "
++                            + "targetSdkVersion<T");
++            return;
++        }
++        getAwSettings().setAlgorithmicDarkeningAllowed(allow);
++    }
++
++    // Lint thinks we are targeting 32 so complains that this only overrides in 33, suppress until
++    // b/239952654 is resolved
++    @SuppressWarnings("Override")
++    @Override
++    public boolean isAlgorithmicDarkeningAllowed() {
++        if (!AwDarkMode.isSimplifiedDarkModeEnabled()) {
++            Log.w(TAG,
++                    "isAlgorithmicDarkeningAllowed() is a no-op in an app with targetSdkVersion<T");
++            return false;
++        }
++        return getAwSettings().isAlgorithmicDarkeningAllowed();
++    }
+ }
+diff --git a/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumAwInit.java b/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumAwInit.java
+--- a/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumAwInit.java
++++ b/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumAwInit.java
+@@ -5,6 +5,7 @@
+ package com.android.webview.chromium;
+ 
+ import android.Manifest;
++import android.app.compat.CompatChanges;
+ import android.content.Context;
+ import android.content.pm.PackageManager;
+ import android.content.res.Resources;
+@@ -15,6 +16,7 @@ import android.os.SystemClock;
+ import android.util.Log;
+ import android.webkit.CookieManager;
+ import android.webkit.GeolocationPermissions;
++import android.webkit.WebSettings;
+ import android.webkit.WebStorage;
+ import android.webkit.WebViewDatabase;
+ 
+@@ -234,8 +236,9 @@ public class WebViewChromiumAwInit {
+ 
+             mFactory.getRunQueue().drainQueue();
+ 
+-            if (BuildInfo.isAtLeastT() ? mFactory.shouldEnableSimplifiedDarkMode()
+-                                       : BuildInfo.targetsAtLeastT()) {
++            if (BuildInfo.isAtLeastT()
++                            ? CompatChanges.isChangeEnabled(WebSettings.ENABLE_SIMPLIFIED_DARK_MODE)
++                            : BuildInfo.targetsAtLeastT()) {
+                 AwDarkMode.enableSimplifiedDarkMode();
+             }
+ 
+diff --git a/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumFactoryProvider.java b/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumFactoryProvider.java
+--- a/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumFactoryProvider.java
++++ b/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumFactoryProvider.java
+@@ -331,7 +331,6 @@ public class WebViewChromiumFactoryProvider implements WebViewFactoryProvider {
+             // WebView needs to make sure to always use the wrapped application context.
+             ctx = ClassLoaderContextWrapperFactory.get(ctx);
+             ContextUtils.initApplicationContext(ctx);
+-            ContextUtils.setSdkSandboxProcess(isSdkSandboxProcess());
+ 
+             // Find the package ID for the package that WebView's resources come from.
+             // This will be the donor package if there is one, not our main package.
+@@ -877,15 +876,4 @@ public class WebViewChromiumFactoryProvider implements WebViewFactoryProvider {
+     public PacProcessor createPacProcessor() {
+         return GlueApiHelperForR.createPacProcessor();
+     }
+-
+-    boolean shouldEnableSimplifiedDarkMode() {
+-        // TODO: Put the downstream implementation inline and remove this method.
+-        return false;
+-    }
+-
+-    boolean isSdkSandboxProcess() {
+-        // TODO: This shall be removed and ContextUtil.isSdkSandboxProcess() calls
+-        // Process.isSdkSandbox() directly.
+-        return false;
+-    }
+ }
+diff --git a/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumFactoryProviderForT.java b/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumFactoryProviderForT.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..09401720fe43728c003a451940fc9c38796edaae
+--- /dev/null
++++ b/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumFactoryProviderForT.java
+@@ -0,0 +1,15 @@
++// Copyright 2022 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++package com.android.webview.chromium;
++
++class WebViewChromiumFactoryProviderForT extends WebViewChromiumFactoryProvider {
++    public static WebViewChromiumFactoryProvider create(android.webkit.WebViewDelegate delegate) {
++        return new WebViewChromiumFactoryProviderForT(delegate);
++    }
++
++    protected WebViewChromiumFactoryProviderForT(android.webkit.WebViewDelegate delegate) {
++        super(delegate);
++    }
++}
+diff --git a/base/android/java/src/org/chromium/base/BuildInfo.java b/base/android/java/src/org/chromium/base/BuildInfo.java
+--- a/base/android/java/src/org/chromium/base/BuildInfo.java
++++ b/base/android/java/src/org/chromium/base/BuildInfo.java
+@@ -252,12 +252,12 @@ public class BuildInfo {
+         // just hardcode the appropriate SDK integer. This will include Android
+         // builds with the finalized SDK, and also pre-API-finalization builds
+         // (because CUR_DEVELOPMENT == 10000).
+-        return target >= 33;
++        // return target >= 33;
+ 
+         // Once the public SDK is upstreamed we can use the defined constant,
+         // deprecate this, then eventually inline this at all callsites and
+         // remove it.
+-        // return target >= Build.VERSION_CODES.TIRAMISU;
++        return target >= Build.VERSION_CODES.TIRAMISU;
+     }
+ 
+     public static void setFirebaseAppId(String id) {
+diff --git a/base/android/java/src/org/chromium/base/ContextUtils.java b/base/android/java/src/org/chromium/base/ContextUtils.java
+--- a/base/android/java/src/org/chromium/base/ContextUtils.java
++++ b/base/android/java/src/org/chromium/base/ContextUtils.java
+@@ -34,8 +34,6 @@ public class ContextUtils {
+     private static final String TAG = "ContextUtils";
+     private static Context sApplicationContext;
+ 
+-    private static boolean sSdkSandboxProcess;
+-
+     /**
+      * Flag for {@link Context#registerReceiver}: The receiver can receive broadcasts from other
+      * Apps. Has the same behavior as marking a statically registered receiver with "exported=true".
+@@ -168,21 +166,15 @@ public class ContextUtils {
+         return Process.isIsolated();
+     }
+ 
+-    /**
+-     * Set current process as SdkSandbox process or not.
+-     *
+-     * TODO: This method shall be removed once Android Sdk is in, refer to isSdkSandboxProcess().
+-     */
+-    public static void setSdkSandboxProcess(boolean sdkSandboxProcess) {
+-        sSdkSandboxProcess = sdkSandboxProcess;
+-    }
+-
+     /**
+      * @return if current process is SdkSandbox process.
+      */
+     public static boolean isSdkSandboxProcess() {
+-        // TODO: Call android.os.Process.isSdkSandbox() directly once Android Sdk is in.
+-        return sSdkSandboxProcess;
++        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
++            return Process.isSdkSandbox();
++        } else {
++            return false;
++        }
+     }
+ 
+     /** @return The name of the current process. E.g. "org.chromium.chrome:privileged_process0". */
+diff --git a/build/android/pylib/constants/__init__.py b/build/android/pylib/constants/__init__.py
+--- a/build/android/pylib/constants/__init__.py
++++ b/build/android/pylib/constants/__init__.py
+@@ -115,7 +115,7 @@ DEVICE_PERF_OUTPUT_DIR = (
+ 
+ SCREENSHOTS_DIR = os.path.join(DIR_SOURCE_ROOT, 'out_screenshots')
+ 
+-ANDROID_SDK_BUILD_TOOLS_VERSION = '31.0.0'
++ANDROID_SDK_BUILD_TOOLS_VERSION = '33.0.0'
+ ANDROID_SDK_ROOT = os.path.join(DIR_SOURCE_ROOT, 'third_party', 'android_sdk',
+                                 'public')
+ ANDROID_SDK_TOOLS = os.path.join(ANDROID_SDK_ROOT,
+diff --git a/build/config/android/config.gni b/build/config/android/config.gni
+--- a/build/config/android/config.gni
++++ b/build/config/android/config.gni
+@@ -106,12 +106,12 @@ if (is_android || is_chromeos) {
+ 
+   public_android_sdk_root = "//third_party/android_sdk/public"
+   public_android_sdk_build_tools =
+-      "${public_android_sdk_root}/build-tools/31.0.0"
+-  public_android_sdk_version = "31"
+-  if (android_sdk_release == "s") {
++      "${public_android_sdk_root}/build-tools/33.0.0"
++  public_android_sdk_version = "33"
++  if (android_sdk_release == "t") {
+     default_android_sdk_root = public_android_sdk_root
+     default_android_sdk_version = public_android_sdk_version
+-    default_android_sdk_build_tools_version = "31.0.0"
++    default_android_sdk_build_tools_version = "33.0.0"
+     public_android_sdk = true
+   }
+ 
+@@ -124,7 +124,7 @@ if (is_android || is_chromeos) {
+     # Purposefully repeated so that downstream can change
+     # default_android_sdk_root without changing lint version.
+     default_lint_android_sdk_root = public_android_sdk_root
+-    default_lint_android_sdk_version = 32
++    default_lint_android_sdk_version = 33
+   }
+ 
+   if (!defined(default_extras_android_sdk_root)) {
+diff --git a/build/config/android/sdk.gni b/build/config/android/sdk.gni
+--- a/build/config/android/sdk.gni
++++ b/build/config/android/sdk.gni
+@@ -4,7 +4,7 @@
+ 
+ # The default SDK release used by public builds. Value may differ in
+ # internal builds.
+-default_android_sdk_release = "s"
++default_android_sdk_release = "t"
+ 
+ # SDK releases against which public builds are supported.
+-public_sdk_releases = [ "s" ]
++public_sdk_releases = [ "t" ]
+diff --git a/chrome/android/expectations/monochrome_public_bundle__autofill_assistant.AndroidManifest.expected b/chrome/android/expectations/monochrome_public_bundle__autofill_assistant.AndroidManifest.expected
+--- a/chrome/android/expectations/monochrome_public_bundle__autofill_assistant.AndroidManifest.expected
++++ b/chrome/android/expectations/monochrome_public_bundle__autofill_assistant.AndroidManifest.expected
+@@ -4,8 +4,8 @@
+     xmlns:dist="http://schemas.android.com/apk/distribution"
+     featureSplit="autofill_assistant"
+     package="org.chromium.chrome.stable"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12">
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13">
+   <dist:module dist:title="@string/autofill_assistant_module_title">  # DIFF-ANCHOR: 328f25a9
+     <dist:delivery>  # DIFF-ANCHOR: 62b39bbe
+       <dist:install-time>  # DIFF-ANCHOR: a4752ed3
+@@ -17,7 +17,7 @@
+     </dist:delivery>  # DIFF-ANCHOR: 62b39bbe
+     <dist:fusing dist:include="true"/>
+   </dist:module>  # DIFF-ANCHOR: 328f25a9
+-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33"/>
+   <uses-split android:name="chrome"/>
+   <application/>
+ </manifest>
+diff --git a/chrome/android/expectations/monochrome_public_bundle__base.AndroidManifest.expected b/chrome/android/expectations/monochrome_public_bundle__base.AndroidManifest.expected
+--- a/chrome/android/expectations/monochrome_public_bundle__base.AndroidManifest.expected
++++ b/chrome/android/expectations/monochrome_public_bundle__base.AndroidManifest.expected
+@@ -2,8 +2,8 @@
+ <manifest
+     xmlns:android="http://schemas.android.com/apk/res/android"
+     package="org.chromium.chrome.stable"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12"
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13"
+     android:isolatedSplits="true">
+   <permission android:name="$PACKAGE.TOS_ACKED" android:protectionLevel="signatureOrSystem"/>
+   <permission android:name="$PACKAGE.permission.C2D_MESSAGE" android:protectionLevel="signature"/>
+@@ -66,7 +66,7 @@
+   <uses-permission-sdk-23 android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
+   <uses-permission-sdk-23 android:name="android.permission.USE_BIOMETRIC"/>
+   <uses-permission-sdk-23 android:name="android.permission.USE_FINGERPRINT"/>
+-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33"/>
+   <application
+       android:name="org.chromium.chrome.browser.base.SplitMonochromeApplication"
+       android:allowAudioPlaybackCapture="false"
+diff --git a/chrome/android/expectations/monochrome_public_bundle__cablev2_authenticator.AndroidManifest.expected b/chrome/android/expectations/monochrome_public_bundle__cablev2_authenticator.AndroidManifest.expected
+--- a/chrome/android/expectations/monochrome_public_bundle__cablev2_authenticator.AndroidManifest.expected
++++ b/chrome/android/expectations/monochrome_public_bundle__cablev2_authenticator.AndroidManifest.expected
+@@ -4,12 +4,12 @@
+     xmlns:dist="http://schemas.android.com/apk/distribution"
+     featureSplit="cablev2_authenticator"
+     package="org.chromium.chrome.stable"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12">
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13">
+   <dist:module dist:onDemand="false" dist:title="@string/cablev2_authenticator_module_title">  # DIFF-ANCHOR: 4362cefb
+     <dist:fusing dist:include="true"/>
+   </dist:module>  # DIFF-ANCHOR: 4362cefb
+-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33"/>
+   <uses-split android:name="chrome"/>
+   <application/>
+ </manifest>
+diff --git a/chrome/android/expectations/monochrome_public_bundle__chrome.AndroidManifest.expected b/chrome/android/expectations/monochrome_public_bundle__chrome.AndroidManifest.expected
+--- a/chrome/android/expectations/monochrome_public_bundle__chrome.AndroidManifest.expected
++++ b/chrome/android/expectations/monochrome_public_bundle__chrome.AndroidManifest.expected
+@@ -4,12 +4,12 @@
+     xmlns:dist="http://schemas.android.com/apk/distribution"
+     featureSplit="chrome"
+     package="org.chromium.chrome.stable"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12">
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13">
+   <dist:module dist:onDemand="false">  # DIFF-ANCHOR: 2805007f
+     <dist:fusing dist:include="true"/>
+   </dist:module>  # DIFF-ANCHOR: 2805007f
+-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33"/>
+   <application>
+     <activity  # DIFF-ANCHOR: 93d41352
+         android:name="org.chromium.chrome.browser.BrowserRestartActivity"
+diff --git a/chrome/android/expectations/monochrome_public_bundle__dev_ui.AndroidManifest.expected b/chrome/android/expectations/monochrome_public_bundle__dev_ui.AndroidManifest.expected
+--- a/chrome/android/expectations/monochrome_public_bundle__dev_ui.AndroidManifest.expected
++++ b/chrome/android/expectations/monochrome_public_bundle__dev_ui.AndroidManifest.expected
+@@ -4,11 +4,11 @@
+     xmlns:dist="http://schemas.android.com/apk/distribution"
+     featureSplit="dev_ui"
+     package="org.chromium.chrome.stable"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12">
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13">
+   <dist:module dist:onDemand="true" dist:title="@string/dev_ui_module_title">  # DIFF-ANCHOR: 671a5c9f
+     <dist:fusing dist:include="true"/>
+   </dist:module>  # DIFF-ANCHOR: 671a5c9f
+-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33"/>
+   <application/>
+ </manifest>
+diff --git a/chrome/android/expectations/monochrome_public_bundle__stack_unwinder.AndroidManifest.expected b/chrome/android/expectations/monochrome_public_bundle__stack_unwinder.AndroidManifest.expected
+--- a/chrome/android/expectations/monochrome_public_bundle__stack_unwinder.AndroidManifest.expected
++++ b/chrome/android/expectations/monochrome_public_bundle__stack_unwinder.AndroidManifest.expected
+@@ -4,11 +4,11 @@
+     xmlns:dist="http://schemas.android.com/apk/distribution"
+     featureSplit="stack_unwinder"
+     package="org.chromium.chrome.stable"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12">
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13">
+   <dist:module dist:onDemand="true" dist:title="@string/stack_unwinder_module_title">  # DIFF-ANCHOR: 2d9e963c
+     <dist:fusing dist:include="true"/>
+   </dist:module>  # DIFF-ANCHOR: 2d9e963c
+-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33"/>
+   <application/>
+ </manifest>
+diff --git a/chrome/android/expectations/monochrome_public_bundle__test_dummy.AndroidManifest.expected b/chrome/android/expectations/monochrome_public_bundle__test_dummy.AndroidManifest.expected
+--- a/chrome/android/expectations/monochrome_public_bundle__test_dummy.AndroidManifest.expected
++++ b/chrome/android/expectations/monochrome_public_bundle__test_dummy.AndroidManifest.expected
+@@ -4,11 +4,11 @@
+     xmlns:dist="http://schemas.android.com/apk/distribution"
+     featureSplit="test_dummy"
+     package="org.chromium.chrome.stable"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12">
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13">
+   <dist:module dist:onDemand="true" dist:title="@string/test_dummy_module_title">  # DIFF-ANCHOR: d029b25b
+     <dist:fusing dist:include="true"/>
+   </dist:module>  # DIFF-ANCHOR: d029b25b
+-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33"/>
+   <application/>
+ </manifest>
+diff --git a/chrome/android/expectations/monochrome_public_bundle__vr.AndroidManifest.expected b/chrome/android/expectations/monochrome_public_bundle__vr.AndroidManifest.expected
+--- a/chrome/android/expectations/monochrome_public_bundle__vr.AndroidManifest.expected
++++ b/chrome/android/expectations/monochrome_public_bundle__vr.AndroidManifest.expected
+@@ -4,8 +4,8 @@
+     xmlns:dist="http://schemas.android.com/apk/distribution"
+     featureSplit="vr"
+     package="org.chromium.chrome.stable"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12">
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13">
+   <dist:module dist:instant="false" dist:title="@string/vr_module_title">  # DIFF-ANCHOR: aac219ae
+     <dist:delivery>  # DIFF-ANCHOR: ea157ece
+       <dist:install-time>  # DIFF-ANCHOR: eab09dbe
+@@ -22,7 +22,7 @@
+     <package android:name="com.google.vr.vrcore"/>
+   </queries>  # DIFF-ANCHOR: 4f65d672
+     {% endif %}
+-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33"/>
+   <uses-split android:name="chrome"/>
+   <application/>
+ </manifest>
+diff --git a/chrome/android/expectations/monochrome_public_bundle__weblayer.AndroidManifest.expected b/chrome/android/expectations/monochrome_public_bundle__weblayer.AndroidManifest.expected
+--- a/chrome/android/expectations/monochrome_public_bundle__weblayer.AndroidManifest.expected
++++ b/chrome/android/expectations/monochrome_public_bundle__weblayer.AndroidManifest.expected
+@@ -4,12 +4,12 @@
+     xmlns:dist="http://schemas.android.com/apk/distribution"
+     featureSplit="weblayer"
+     package="org.chromium.chrome.stable"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12">
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13">
+   <dist:module dist:onDemand="false">  # DIFF-ANCHOR: 2805007f
+     <dist:fusing dist:include="true"/>
+   </dist:module>  # DIFF-ANCHOR: 2805007f
+-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33"/>
+   <uses-split android:name="chrome"/>
+   <application/>
+ </manifest>
+diff --git a/chrome/android/expectations/trichrome_chrome_bundle__base.AndroidManifest.expected b/chrome/android/expectations/trichrome_chrome_bundle__base.AndroidManifest.expected
+--- a/chrome/android/expectations/trichrome_chrome_bundle__base.AndroidManifest.expected
++++ b/chrome/android/expectations/trichrome_chrome_bundle__base.AndroidManifest.expected
+@@ -2,8 +2,8 @@
+ <manifest
+     xmlns:android="http://schemas.android.com/apk/res/android"
+     package="org.chromium.chrome.stable"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12"
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13"
+     android:isolatedSplits="true">
+   <permission android:name="$PACKAGE.TOS_ACKED" android:protectionLevel="signatureOrSystem"/>
+   <permission android:name="$PACKAGE.permission.C2D_MESSAGE" android:protectionLevel="signature"/>
+@@ -66,7 +66,7 @@
+   <uses-permission-sdk-23 android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
+   <uses-permission-sdk-23 android:name="android.permission.USE_BIOMETRIC"/>
+   <uses-permission-sdk-23 android:name="android.permission.USE_FINGERPRINT"/>
+-  <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="33"/>
+   <application
+       android:name="org.chromium.chrome.browser.base.SplitChromeApplication"
+       android:allowAudioPlaybackCapture="false"
+diff --git a/chrome/android/expectations/trichrome_library_apk.AndroidManifest.expected b/chrome/android/expectations/trichrome_library_apk.AndroidManifest.expected
+--- a/chrome/android/expectations/trichrome_library_apk.AndroidManifest.expected
++++ b/chrome/android/expectations/trichrome_library_apk.AndroidManifest.expected
+@@ -2,12 +2,12 @@
+ <manifest
+     xmlns:android="http://schemas.android.com/apk/res/android"
+     package="org.chromium.trichromelibrary"
+-    platformBuildVersionCode="31"
+-    platformBuildVersionName="12">
++    platformBuildVersionCode="33"
++    platformBuildVersionName="13">
+   <uses-feature android:glEsVersion="0x00020000"/>
+   <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
+   <uses-feature android:name="android.software.leanback" android:required="false"/>
+-  <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="31"/>
++  <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="33"/>
+   <application
+       android:extractNativeLibs="false"
+       android:hasCode="false"
+diff --git a/third_party/android_sdk/README.chromium b/third_party/android_sdk/README.chromium
+--- a/third_party/android_sdk/README.chromium
++++ b/third_party/android_sdk/README.chromium
+@@ -1,13 +1,13 @@
+ Name: Android SDK
+ URL: http://developer.android.com/sdk/index.html
+ Version: 31
+-  Android SDK Build-Tools 31.0.0
+-  Android SDK Command-line Tools 5.0
+-  Android SDK Emulator 30.7.5
++  Android SDK Build-Tools 33.0.0
++  Android SDK Command-line Tools 7.0
++  Android SDK Emulator 31.2.10
+   Android SDK Patch Applier v4
+-  Android SDK Platform-Tools 31.0.3
+-  Android SDK Platform API 31
+-  Android SDK Sources 30
++  Android SDK Platform-Tools 33.0.2
++  Android SDK Platform API 33
++  Android SDK Sources 31
+   Google Cloud Messaging for Android Library, rev 3
+ Security Critical: no
+ License: Apache Version 2.0
+diff --git a/third_party/android_system_sdk/README.chromium b/third_party/android_system_sdk/README.chromium
+--- a/third_party/android_system_sdk/README.chromium
++++ b/third_party/android_system_sdk/README.chromium
+@@ -2,7 +2,7 @@ Name: Android System SDK
+ URL: https://android.googlesource.com/platform/frameworks/base
+ Short Name:  Android System SDK
+ Version: 0
+-Revision: SPB3.210618.010
++Revision: TPB3.220513.017
+ License: GPL v2
+ License File: LICENSE
+ Security Critical: No
+-- 
+2.37.3
+


### PR DESCRIPTION
This is for M105

* Patches are from M106
* Needed to make WebView work on Android 13
* Still works on Android 12 as well.

Change-Id: I275f7a6f28c0dd0fb9ef8eb3aafe2d796a9d5da7

## Description

*Please explain here what feature or bugfix these changes are addressing and why they should be included*

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [ ] Bromite can be built with these changes
* [x] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [x] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
