### PR TITLE
Userscripts: fix injection with back-forward cache enabled

### DIFF
--- a/build/patches/Experimental-user-scripts-support.patch
+++ b/build/patches/Experimental-user-scripts-support.patch
@@ -133,12 +133,12 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../renderer/user_scripts_dispatcher.cc       |  36 +
  .../renderer/user_scripts_dispatcher.h        |  49 ++
  .../renderer/user_scripts_renderer_client.cc  | 105 +++
- .../renderer/user_scripts_renderer_client.h   |  37 +
+ .../renderer/user_scripts_renderer_client.h   |  36 +
  .../renderer/web_ui_injection_host.cc         |  40 +
  .../renderer/web_ui_injection_host.h          |  27 +
  .../strings/userscripts_strings.grdp          |  57 ++
  tools/gritsettings/resource_ids.spec          |   6 +
- 111 files changed, 9595 insertions(+), 2 deletions(-)
+ 111 files changed, 9594 insertions(+), 2 deletions(-)
  create mode 100644 components/user_scripts/README.md
  create mode 100755 components/user_scripts/android/BUILD.gn
  create mode 100644 components/user_scripts/android/java/res/layout/accept_script_item.xml
@@ -10405,15 +10405,15 @@ new file mode 100755
 +  enabled_ = params.allow_userscript;
 +  if (!enabled_) return;
 +
-+  if (loaded_ == false) {
-+    loaded_ = true;
++  ExtensionFrameHelper* frame_helper = ExtensionFrameHelper::Get(render_frame);
++  if (!frame_helper) {
 +    new user_scripts::ExtensionFrameHelper(render_frame);
 +    dispatcher_->OnRenderFrameCreated(render_frame);
 +  }
 +}
 +
 +void UserScriptsRendererClient::RunScriptsAtDocumentStart(content::RenderFrame* render_frame) {
-+  if (!enabled_ || !loaded_) return;
++  if (!enabled_) return;
 +
 +  ExtensionFrameHelper* frame_helper = ExtensionFrameHelper::Get(render_frame);
 +  if (!frame_helper)
@@ -10424,7 +10424,7 @@ new file mode 100755
 +}
 +
 +void UserScriptsRendererClient::RunScriptsAtDocumentEnd(content::RenderFrame* render_frame) {
-+  if (!enabled_ || !loaded_) return;
++  if (!enabled_) return;
 +
 +  ExtensionFrameHelper* frame_helper = ExtensionFrameHelper::Get(render_frame);
 +  if (!frame_helper)
@@ -10435,7 +10435,7 @@ new file mode 100755
 +}
 +
 +void UserScriptsRendererClient::RunScriptsAtDocumentIdle(content::RenderFrame* render_frame) {
-+  if (!enabled_ || !loaded_) return;
++  if (!enabled_) return;
 +
 +  ExtensionFrameHelper* frame_helper = ExtensionFrameHelper::Get(render_frame);
 +  if (!frame_helper)
@@ -10446,12 +10446,11 @@ new file mode 100755
 +}
 +
 +}
-\ No newline at end of file
 diff --git a/components/user_scripts/renderer/user_scripts_renderer_client.h b/components/user_scripts/renderer/user_scripts_renderer_client.h
 new file mode 100755
 --- /dev/null
 +++ b/components/user_scripts/renderer/user_scripts_renderer_client.h
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,36 @@
 +#ifndef USERSCRIPTS_RENDER_CLIENT_H_
 +#define USERSCRIPTS_RENDER_CLIENT_H_
 +
@@ -10483,7 +10482,6 @@ new file mode 100755
 + private:
 +  std::unique_ptr<UserScriptsDispatcher> dispatcher_;
 +  bool enabled_ = false;
-+  bool loaded_ = false;
 +};
 +
 +}


### PR DESCRIPTION
## Description

fix injection with back-forward cache enabled
Related discussion: https://github.com/bromite/bromite/discussions/2137

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
