### PR TITLE
Add missed changes for Remove-navigator.connection-info.patch

### DIFF
--- a/build/patches/Remove-navigator.connection-info.patch
+++ b/build/patches/Remove-navigator.connection-info.patch
@@ -8,8 +8,11 @@ and disable observers
 Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- .../blink/renderer/modules/netinfo/network_information.cc  | 7 ++++++-
- 1 file changed, 6 insertions(+), 1 deletion(-)
+ .../renderer/modules/netinfo/network_information.cc   |  7 ++++++-
+ .../renderer/modules/netinfo/network_information.h    |  1 +
+ .../platform/network/network_state_notifier.cc        | 11 +++++++++++
+ .../platform/network/network_state_notifier.h         |  2 +-
+ 4 files changed, 19 insertions(+), 2 deletions(-)
 
 diff --git a/third_party/blink/renderer/modules/netinfo/network_information.cc b/third_party/blink/renderer/modules/netinfo/network_information.cc
 --- a/third_party/blink/renderer/modules/netinfo/network_information.cc
@@ -19,7 +22,7 @@ diff --git a/third_party/blink/renderer/modules/netinfo/network_information.cc b
  
  bool NetworkInformation::IsObserving() const {
 -  return !!connection_observer_handle_;
-+  return false;
++  return !!connection_observer_handle_ || is_fake_observing_;
  }
  
  String NetworkInformation::type() const {
@@ -35,7 +38,7 @@ diff --git a/third_party/blink/renderer/modules/netinfo/network_information.cc b
  }
  
  void NetworkInformation::StartObserving() {
-+  //is_fake_observing_ = true;
++  is_fake_observing_ = true;
 +  if ((true)) return;
    if (!IsObserving() && !context_stopped_) {
      type_ = GetNetworkStateNotifier().ConnectionType();
@@ -44,10 +47,54 @@ diff --git a/third_party/blink/renderer/modules/netinfo/network_information.cc b
  }
  
  void NetworkInformation::StopObserving() {
-+  //is_fake_observing_ = false;
++  is_fake_observing_ = false;
 +  if ((true)) return;
    if (IsObserving()) {
      DCHECK(connection_observer_handle_);
      connection_observer_handle_ = nullptr;
+diff --git a/third_party/blink/renderer/modules/netinfo/network_information.h b/third_party/blink/renderer/modules/netinfo/network_information.h
+--- a/third_party/blink/renderer/modules/netinfo/network_information.h
++++ b/third_party/blink/renderer/modules/netinfo/network_information.h
+@@ -118,6 +118,7 @@ class NetworkInformation final
+ 
+   std::unique_ptr<NetworkStateNotifier::NetworkStateObserverHandle>
+       connection_observer_handle_;
++  bool is_fake_observing_ = false;
+ };
+ 
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/platform/network/network_state_notifier.cc b/third_party/blink/renderer/platform/network/network_state_notifier.cc
+--- a/third_party/blink/renderer/platform/network/network_state_notifier.cc
++++ b/third_party/blink/renderer/platform/network/network_state_notifier.cc
+@@ -522,6 +522,17 @@ NetworkStateNotifier::GetWebHoldbackDownlinkThroughputMbps() const {
+   return absl::nullopt;
+ }
+ 
++NetworkStateNotifier::NetworkStateNotifier() : has_override_(false) {
++  // set default data
++  // see third_party/blink/renderer/platform/network/network_state_notifier_test.cc
++  SetNetworkConnectionInfoOverride(
++    /*on_line*/true,
++    /*type*/WebConnectionType::kWebConnectionTypeUnknown,
++    /*effective_type*/absl::nullopt,
++    /*http_rtt_msec*/0,
++    /*max_bandwidth_mbps*/0);
++}
++
+ void NetworkStateNotifier::GetMetricsWithWebHoldback(
+     WebConnectionType* type,
+     double* downlink_max_mbps,
+diff --git a/third_party/blink/renderer/platform/network/network_state_notifier.h b/third_party/blink/renderer/platform/network/network_state_notifier.h
+--- a/third_party/blink/renderer/platform/network/network_state_notifier.h
++++ b/third_party/blink/renderer/platform/network/network_state_notifier.h
+@@ -122,7 +122,7 @@ class PLATFORM_EXPORT NetworkStateNotifier {
+     scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
+   };
+ 
+-  NetworkStateNotifier() : has_override_(false) {}
++  NetworkStateNotifier();
+   NetworkStateNotifier(const NetworkStateNotifier&) = delete;
+   NetworkStateNotifier& operator=(const NetworkStateNotifier&) = delete;
+ 
 --
 2.25.1


### PR DESCRIPTION
## Description

we missed a change from https://github.com/bromite/bromite/pull/2172. without that the patch does nothing.
I propose it again here

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
