### PR TITLE
v107 fix some build errors

### DIFF
--- a/build/patches/Disable-all-predictors-code.patch
+++ b/build/patches/Disable-all-predictors-code.patch
@@ -6,7 +6,7 @@ Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
  .../chrome_hints_manager.cc                   |  1 +
- .../optimization_guide_keyed_service.cc       |  1 -
+ .../optimization_guide_keyed_service.cc       |  5 ----
  chrome/common/chrome_features.cc              |  6 ++---
  .../optimization_guide/core/hints_fetcher.cc  |  1 +
  .../optimization_guide/core/hints_manager.cc  |  4 ++++
@@ -17,7 +17,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  components/permissions/features.cc            |  8 +++----
  .../segmentation_platform/public/features.cc  |  2 +-
  third_party/blink/common/features.cc          |  2 +-
- 12 files changed, 33 insertions(+), 27 deletions(-)
+ 12 files changed, 33 insertions(+), 31 deletions(-)
 
 diff --git a/chrome/browser/optimization_guide/chrome_hints_manager.cc b/chrome/browser/optimization_guide/chrome_hints_manager.cc
 --- a/chrome/browser/optimization_guide/chrome_hints_manager.cc
@@ -33,7 +33,18 @@ diff --git a/chrome/browser/optimization_guide/chrome_hints_manager.cc b/chrome/
 diff --git a/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc b/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
 --- a/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
 +++ b/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
-@@ -324,7 +324,6 @@ void OptimizationGuideKeyedService::RemoveObserverForOptimizationTargetModel(
+@@ -113,10 +113,6 @@ OptimizationGuideKeyedService::MaybeCreatePushNotificationManager(
+   if (optimization_guide::features::IsPushNotificationsEnabled()) {
+     auto push_notification_manager =
+         std::make_unique<optimization_guide::PushNotificationManager>();
+-#if BUILDFLAG(IS_ANDROID)
+-    push_notification_manager->AddObserver(
+-        PriceTrackingNotificationBridge::GetForBrowserContext(profile));
+-#endif
+     return push_notification_manager;
+   }
+   return nullptr;
+@@ -324,7 +320,6 @@ void OptimizationGuideKeyedService::RemoveObserverForOptimizationTargetModel(
  void OptimizationGuideKeyedService::RegisterOptimizationTypes(
      const std::vector<optimization_guide::proto::OptimizationType>&
          optimization_types) {

--- a/build/patches/Disable-safe-browsing.patch
+++ b/build/patches/Disable-safe-browsing.patch
@@ -42,7 +42,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../extensions/api/downloads/downloads_api.cc | 41 +--------
  .../extensions/api/downloads/downloads_api.h  | 12 ---
  .../webstore_private/webstore_private_api.cc  | 18 +---
- ...e_file_system_access_permission_context.cc | 10 +++
+ ...e_file_system_access_permission_context.cc | 12 ++-
  ...me_file_system_access_permission_context.h |  5 +-
  .../lookalike_url_controller_client.cc        |  4 -
  .../metrics/chrome_metrics_service_client.cc  |  3 -
@@ -95,7 +95,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../file_system_access_permission_context.h   |  6 --
  weblayer/BUILD.gn                             |  4 -
  weblayer/test/BUILD.gn                        |  1 -
- 86 files changed, 212 insertions(+), 674 deletions(-)
+ 86 files changed, 213 insertions(+), 675 deletions(-)
 
 diff --git a/chrome/android/java/res/xml/google_services_preferences.xml b/chrome/android/java/res/xml/google_services_preferences.xml
 --- a/chrome/android/java/res/xml/google_services_preferences.xml
@@ -1687,17 +1687,26 @@ diff --git a/chrome/browser/extensions/api/webstore_private/webstore_private_api
 diff --git a/chrome/browser/file_system_access/chrome_file_system_access_permission_context.cc b/chrome/browser/file_system_access/chrome_file_system_access_permission_context.cc
 --- a/chrome/browser/file_system_access/chrome_file_system_access_permission_context.cc
 +++ b/chrome/browser/file_system_access/chrome_file_system_access_permission_context.cc
-@@ -37,8 +37,10 @@
+@@ -37,8 +37,11 @@
  #include "chrome/browser/file_system_access/file_system_access_permission_request_manager.h"
  #include "chrome/browser/installable/installable_utils.h"
  #include "chrome/browser/profiles/profile.h"
 +#if defined(FULL_SAFE_BROWSING)
  #include "chrome/browser/safe_browsing/download_protection/download_protection_service.h"
  #include "chrome/browser/safe_browsing/safe_browsing_service.h"
++#include "components/safe_browsing/content/common/file_type_policies.h"
 +#endif
  #include "chrome/browser/ui/file_system_access_dialogs.h"
  #include "chrome/common/chrome_paths.h"
  #include "chrome/common/pdf_util.h"
+@@ -48,7 +51,6 @@
+ #include "components/content_settings/core/common/content_settings_utils.h"
+ #include "components/permissions/permission_util.h"
+ #include "components/safe_browsing/buildflags.h"
+-#include "components/safe_browsing/content/common/file_type_policies.h"
+ #include "content/public/browser/browser_task_traits.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/disallow_activation_reason.h"
 @@ -146,6 +148,7 @@ void ShowFileSystemAccessRestrictedDirectoryDialogOnUIThread(
        origin, path, handle_type, std::move(callback), web_contents);
  }

--- a/build/patches/Remove-price-shopping-commerce-integrations.patch
+++ b/build/patches/Remove-price-shopping-commerce-integrations.patch
@@ -37,12 +37,13 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../browser/toolbar/ToolbarManager.java       |  17 --
  .../chrome/browser/ui/RootUiCoordinator.java  |  19 --
  chrome/android/java_sources.gni               |   8 -
+ chrome/browser/BUILD.gn                       |   2 -
  .../price_tracking/PriceTrackingFeatures.java |   2 +-
  .../commerce/subscriptions/android/BUILD.gn   |   1 -
  .../CommerceSubscriptionsService.java         |  36 +---
  .../SubscriptionsManagerImpl.java             |  26 +--
  chrome/browser/persisted_state_db/BUILD.gn    |   1 -
- 38 files changed, 29 insertions(+), 914 deletions(-)
+ 39 files changed, 29 insertions(+), 916 deletions(-)
 
 diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
 --- a/chrome/android/BUILD.gn
@@ -2007,6 +2008,18 @@ diff --git a/chrome/android/java_sources.gni b/chrome/android/java_sources.gni
  chrome_test_java_sources += commerce_merchant_viewer_java_test_sources
  
  if (enable_arcore) {
+diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
+--- a/chrome/browser/BUILD.gn
++++ b/chrome/browser/BUILD.gn
+@@ -2908,8 +2908,6 @@ static_library("browser") {
+       "chrome_browser_main_android.h",
+       "commerce/android/shopping_service_factory_android.cc",
+       "commerce/merchant_viewer/web_contents_helper.cc",
+-      "commerce/price_tracking/android/price_tracking_notification_bridge.cc",
+-      "commerce/price_tracking/android/price_tracking_notification_bridge.h",
+       "component_updater/crow_domain_list_component_installer.cc",
+       "component_updater/crow_domain_list_component_installer.h",
+       "component_updater/desktop_sharing_hub_component_remover.cc",
 diff --git a/chrome/browser/commerce/price_tracking/android/java/src/org/chromium/chrome/browser/price_tracking/PriceTrackingFeatures.java b/chrome/browser/commerce/price_tracking/android/java/src/org/chromium/chrome/browser/price_tracking/PriceTrackingFeatures.java
 --- a/chrome/browser/commerce/price_tracking/android/java/src/org/chromium/chrome/browser/price_tracking/PriceTrackingFeatures.java
 +++ b/chrome/browser/commerce/price_tracking/android/java/src/org/chromium/chrome/browser/price_tracking/PriceTrackingFeatures.java

--- a/build/patches/Remove-signin-and-sync-integrations.patch
+++ b/build/patches/Remove-signin-and-sync-integrations.patch
@@ -87,7 +87,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../browser/firstrun/MobileFreProgress.java   |   4 +-
  .../router/discovery/access_code/BUILD.gn     |   1 -
  .../browser/password_manager/android/BUILD.gn |   4 -
- ...sswordManagerErrorMessageHelperBridge.java |  16 --
+ ...sswordManagerErrorMessageHelperBridge.java |  41 +---
  .../PasswordManagerHelper.java                | 121 +---------
  ...swordSyncControllerDelegateBridgeImpl.java |   7 -
  chrome/browser/privacy/BUILD.gn               |   1 -
@@ -127,7 +127,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../ProfileOAuth2TokenServiceDelegate.java    |  52 ----
  .../net/HttpNegotiateAuthenticator.java       |  88 +------
  .../chromoting/base/OAuthTokenFetcher.java    |   2 -
- 108 files changed, 101 insertions(+), 2645 deletions(-)
+ 108 files changed, 102 insertions(+), 2669 deletions(-)
 
 diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
 --- a/chrome/android/BUILD.gn
@@ -3719,7 +3719,38 @@ diff --git a/chrome/browser/password_manager/android/java/src/org/chromium/chrom
  import org.chromium.components.user_prefs.UserPrefs;
  import org.chromium.ui.base.WindowAndroid;
  
-@@ -81,17 +77,5 @@ public class PasswordManagerErrorMessageHelperBridge {
+@@ -49,29 +45,7 @@ public class PasswordManagerErrorMessageHelperBridge {
+      */
+     @CalledByNative
+     static boolean shouldShowErrorUi() {
+-        Profile profile = Profile.getLastUsedRegularProfile();
+-        final CoreAccountInfo primaryAccountInfo =
+-                IdentityServicesProvider.get().getIdentityManager(profile).getPrimaryAccountInfo(
+-                        ConsentLevel.SIGNIN);
+-        // It is possible that the account is removed from Chrome between the password manager
+-        // calling the Google Play Services backend and Chrome receiving the reply. In that
+-        // case, the error is no longer relevant/fixable.
+-        if (primaryAccountInfo == null) return false;
+-
+-        if (ChromeFeatureList.getFieldTrialParamByFeatureAsBoolean(
+-                    ChromeFeatureList.UNIFIED_PASSWORD_MANAGER_ERROR_MESSAGES,
+-                    "ignore_auth_error_message_timeouts", false)) {
+-            return true;
+-        }
+-
+-        PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
+-        long lastShownTimestamp =
+-                Long.valueOf(prefService.getString(Pref.UPM_ERROR_UI_SHOWN_TIMESTAMP));
+-        long lastShownSyncErrorTimestamp = SharedPreferencesManager.getInstance().readLong(
+-                ChromePreferenceKeys.SYNC_ERROR_PROMPT_SHOWN_AT_TIME, 0);
+-        long currentTime = TimeUtils.currentTimeMillis();
+-        return (currentTime - lastShownTimestamp > MINIMAL_INTERVAL_BETWEEN_PROMPTS_MS)
+-                && (currentTime - lastShownSyncErrorTimestamp) > MINIMAL_INTERVAL_TO_SYNC_ERROR_MS;
++        return false;
+     }
+ 
+     /**
+@@ -91,18 +65,5 @@ public class PasswordManagerErrorMessageHelperBridge {
       */
      @CalledByNative
      static void startUpdateAccountCredentialsFlow(WindowAndroid windowAndroid) {
@@ -3727,8 +3758,9 @@ diff --git a/chrome/browser/password_manager/android/java/src/org/chromium/chrom
 -        final CoreAccountInfo primaryAccountInfo =
 -                IdentityServicesProvider.get().getIdentityManager(profile).getPrimaryAccountInfo(
 -                        ConsentLevel.SIGNIN);
--        // It's not possible to call updateCredentials without an account.
--        assert primaryAccountInfo != null;
+-        // If the account has been removed before calling this method, there are no credentials to
+-        // update.
+-        if (primaryAccountInfo == null) return;
 -        final Activity activity = windowAndroid.getActivity().get();
 -        AccountManagerFacadeProvider.getInstance().updateCredentials(
 -                CoreAccountInfo.getAndroidAccountFrom(primaryAccountInfo), activity, (success) -> {


### PR DESCRIPTION
## Description

I found some errors in the build (maybe you didn't clean the out directory?)
small things, but I will make the changes available to you.

```
../../chrome/browser/commerce/price_tracking/android/price_tracking_notification_bridge.cc:9:10: fatal error: 'chrome/browser
/commerce/price_tracking/android/jni_headers/PriceTrackingNotificationBridge_jni.h' file not found                           #include "chrome/browser/commerce/price_tracking/android/jni_headers/PriceTrackingNotificationBridge_jni.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

```
In file included from ../../chrome/browser/file_system_access/chrome_file_system_access_permission_context.cc:53:
../../components/safe_browsing/content/common/file_type_policies.h:14:10: fatal error: 'components/safe_browsing/content/common/proto/download_file_types.pb.h' file not found
#include "components/safe_browsing/content/common/proto/download_file_types.pb.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

```
ld.lld: error: undefined symbol: PriceTrackingNotificationBridge::GetForBrowserContext(content::BrowserContext*)
>>> referenced by optimization_guide_keyed_service.cc:118 (../../chrome/browser/optimization_guide/optimization_guide_keyed_service.cc:118)
>>>               browser/optimization_guide_keyed_service.o:(OptimizationGuideKeyedService::MaybeCreatePushNotificationManager(Profile*)) in archive obj/chrome/browser/libbrowser.a

```




## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
