### PR TITLE
Disable all predictors code: remove another method

### DIFF
--- a/build/patches/Disable-all-predictors-code.patch
+++ b/build/patches/Disable-all-predictors-code.patch
@@ -6,10 +6,10 @@ Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
  .../chrome_hints_manager.cc                   |  1 +
- .../optimization_guide_keyed_service.cc       |  1 -
+ .../optimization_guide_keyed_service.cc       |  5 ----
  chrome/common/chrome_features.cc              |  6 ++---
  .../optimization_guide/core/hints_fetcher.cc  |  1 +
- .../optimization_guide/core/hints_manager.cc  |  4 ++++
+ .../optimization_guide/core/hints_manager.cc  |  5 ++++
  .../core/optimization_guide_features.cc       | 24 +++++++++----------
  .../core/prediction_model_download_manager.cc |  6 +++--
  .../core/prediction_model_fetcher_impl.cc     |  1 +
@@ -17,7 +17,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  components/permissions/features.cc            |  8 +++----
  .../segmentation_platform/public/features.cc  |  2 +-
  third_party/blink/common/features.cc          |  2 +-
- 12 files changed, 33 insertions(+), 27 deletions(-)
+ 12 files changed, 34 insertions(+), 31 deletions(-)
 
 diff --git a/chrome/browser/optimization_guide/chrome_hints_manager.cc b/chrome/browser/optimization_guide/chrome_hints_manager.cc
 --- a/chrome/browser/optimization_guide/chrome_hints_manager.cc
@@ -33,7 +33,18 @@ diff --git a/chrome/browser/optimization_guide/chrome_hints_manager.cc b/chrome/
 diff --git a/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc b/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
 --- a/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
 +++ b/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
-@@ -324,7 +324,6 @@ void OptimizationGuideKeyedService::RemoveObserverForOptimizationTargetModel(
+@@ -113,10 +113,6 @@ OptimizationGuideKeyedService::MaybeCreatePushNotificationManager(
+   if (optimization_guide::features::IsPushNotificationsEnabled()) {
+     auto push_notification_manager =
+         std::make_unique<optimization_guide::PushNotificationManager>();
+-#if BUILDFLAG(IS_ANDROID)
+-    push_notification_manager->AddObserver(
+-        PriceTrackingNotificationBridge::GetForBrowserContext(profile));
+-#endif
+     return push_notification_manager;
+   }
+   return nullptr;
+@@ -324,7 +320,6 @@ void OptimizationGuideKeyedService::RemoveObserverForOptimizationTargetModel(
  void OptimizationGuideKeyedService::RegisterOptimizationTypes(
      const std::vector<optimization_guide::proto::OptimizationType>&
          optimization_types) {
@@ -86,7 +97,15 @@ diff --git a/components/optimization_guide/core/hints_manager.cc b/components/op
    switch (optimization_type_decision) {
      case OptimizationTypeDecision::kAllowedByOptimizationFilter:
      case OptimizationTypeDecision::kAllowedByHint:
-@@ -1271,6 +1272,9 @@ OptimizationTypeDecision HintsManager::CanApplyOptimization(
+@@ -1064,6 +1065,7 @@ void HintsManager::CanApplyOptimizationOnDemand(
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+ 
+   // TODO(crbug/1275612): Check whether we have consent to fetch.
++  if ((true)) return; // no consent on bromite
+ 
+   // This set contains URLs that require some information to be fetched, whether
+   // that be a URL-keyed hint or a host-keyed hint.
+@@ -1271,6 +1273,9 @@ OptimizationTypeDecision HintsManager::CanApplyOptimization(
      proto::OptimizationType optimization_type,
      OptimizationMetadata* optimization_metadata) {
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);


### PR DESCRIPTION
## Description

found another method to remove

## All submissions

* [ ] there are no other open [Pull Requests](../../../pulls) for the same update/change
part of the patch code is also present in #2447
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
