### PR TITLE
Aligns requestAnimationFrame's callback to the w3c specification

### DIFF
--- a/build/patches/Fix-WebWorker-requestAnimationFrame.patch
+++ b/build/patches/Fix-WebWorker-requestAnimationFrame.patch
@@ -1,0 +1,38 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Mon, 3 Oct 2022 09:39:07 +0000
+Subject: Fix WebWorker requestAnimationFrame
+
+Aligns requestAnimationFrame's callback to the w3c specification
+See bugid 1236113
+---
+ .../animation_frame/worker_animation_frame_provider.cc    | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/third_party/blink/renderer/core/animation_frame/worker_animation_frame_provider.cc b/third_party/blink/renderer/core/animation_frame/worker_animation_frame_provider.cc
+--- a/third_party/blink/renderer/core/animation_frame/worker_animation_frame_provider.cc
++++ b/third_party/blink/renderer/core/animation_frame/worker_animation_frame_provider.cc
+@@ -7,7 +7,9 @@
+ #include "base/trace_event/trace_event.h"
+ #include "third_party/blink/renderer/core/offscreencanvas/offscreen_canvas.h"
+ #include "third_party/blink/renderer/core/timing/worker_global_scope_performance.h"
++#include "third_party/blink/renderer/core/workers/worker_global_scope.h"
+ #include "third_party/blink/renderer/platform/bindings/microtask.h"
++#include "third_party/blink/renderer/platform/wtf/casting.h"
+ #include "third_party/blink/renderer/platform/wtf/cross_thread_functional.h"
+ 
+ namespace blink {
+@@ -62,7 +64,11 @@ void WorkerAnimationFrameProvider::BeginFrame(const viz::BeginFrameArgs& args) {
+             }
+           }
+ 
+-          double time = (args.frame_time - base::TimeTicks()).InMillisecondsF();
++          auto* global_scope = DynamicTo<WorkerGlobalScope>(provider->context_.Get());
++          DCHECK(global_scope);
++          double time = Performance::ClampTimeResolution(
++                          args.frame_time - global_scope->TimeOrigin(),
++                          provider->context_->CrossOriginIsolatedCapability());
+           provider->callback_collection_.ExecuteFrameCallbacks(time, time);
+         }
+         provider->begin_frame_provider_->FinishBeginFrame(args);
+--
+2.25.1


### PR DESCRIPTION
## Description

In the end, the google team took my changes as they are (and I am glad).
this is the temporary patch until we get there.

Fix for #2370

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [ ] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
