### PR TITLE
Added Android 13 to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,6 +76,7 @@ body:
       multiple: false
       description: What version of Android are you running?
       options:
+        - 13
         - 12.1
         - 12.0
         - 11


### PR DESCRIPTION
## Description

Android 13 was missing from the bug template, this PR adds it.

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [x] Bromite can be built with these changes
* [x] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [x] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
