### PR TITLE
uazo's patches for v108

### DIFF
--- a/build/patches/Add-AllowUserCertificates-flag.patch
+++ b/build/patches/Add-AllowUserCertificates-flag.patch
@@ -5,22 +5,22 @@ Subject: Add AllowUserCertificates flag
 Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- .../src/org/chromium/chrome/browser/app/ChromeActivity.java  | 3 +++
- .../chromium/chrome/browser/app/flags/ChromeCachedFlags.java | 1 +
- chrome/browser/about_flags.cc                                | 4 ++++
- chrome/browser/flag_descriptions.cc                          | 5 +++++
- chrome/browser/flag_descriptions.h                           | 3 +++
- chrome/browser/flags/android/chrome_feature_list.cc          | 4 ++++
- chrome/browser/flags/android/chrome_feature_list.h           | 1 +
- .../chromium/chrome/browser/flags/CachedFeatureFlags.java    | 1 +
- .../org/chromium/chrome/browser/flags/ChromeFeatureList.java | 3 +++
- net/android/java/src/org/chromium/net/X509Util.java          | 5 +++++
- 10 files changed, 30 insertions(+)
+ .../src/org/chromium/chrome/browser/app/ChromeActivity.java | 3 +++
+ .../chrome/browser/app/flags/ChromeCachedFlags.java         | 1 +
+ chrome/browser/about_flags.cc                               | 6 +++++-
+ chrome/browser/flag_descriptions.cc                         | 5 +++++
+ chrome/browser/flag_descriptions.h                          | 3 +++
+ chrome/browser/flags/android/chrome_feature_list.cc         | 5 +++++
+ chrome/browser/flags/android/chrome_feature_list.h          | 1 +
+ .../chromium/chrome/browser/flags/CachedFeatureFlags.java   | 1 +
+ .../chromium/chrome/browser/flags/ChromeFeatureList.java    | 3 +++
+ net/android/java/src/org/chromium/net/X509Util.java         | 5 +++++
+ 10 files changed, 32 insertions(+), 1 deletion(-)
 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
-@@ -225,6 +225,7 @@ import org.chromium.content_public.browser.ScreenOrientationProvider;
+@@ -226,6 +226,7 @@ import org.chromium.content_public.browser.ScreenOrientationProvider;
  import org.chromium.content_public.browser.SelectionPopupController;
  import org.chromium.content_public.browser.WebContents;
  import org.chromium.content_public.common.ContentSwitches;
@@ -28,7 +28,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActiv
  import org.chromium.printing.PrintManagerDelegateImpl;
  import org.chromium.printing.PrintingController;
  import org.chromium.printing.PrintingControllerImpl;
-@@ -955,6 +956,8 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
+@@ -951,6 +952,8 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
          UpdateMenuItemHelper.getInstance().onStart();
          ChromeActivitySessionTracker.getInstance().onStartWithNative();
          ChromeCachedFlags.getInstance().cacheNativeFlags();
@@ -40,7 +40,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActiv
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java b/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
-@@ -77,6 +77,7 @@ public class ChromeCachedFlags {
+@@ -78,6 +78,7 @@ public class ChromeCachedFlags {
                  add(ChromeFeatureList.sAndroidAuxiliarySearch);
                  add(ChromeFeatureList.sAnonymousUpdateChecks);
                  add(ChromeFeatureList.sAppMenuMobileSiteOption);
@@ -51,17 +51,19 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/flags/Chrom
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -3595,6 +3595,10 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -3695,7 +3695,11 @@ const FeatureEntry kFeatureEntries[] = {
+      flag_descriptions::kExtensionsOnChromeUrlsDescription, kOsAll,
       SINGLE_VALUE_TYPE(extensions::switches::kExtensionsOnChromeURLs)},
  #endif  // ENABLE_EXTENSIONS
- #if BUILDFLAG(IS_ANDROID)
+-#if BUILDFLAG(IS_ANDROID)
++#if BUILDFLAG(IS_ANDROID) // Bromite allow user certificates
 +    {"allow-user-certificates",
 +     flag_descriptions::kAllowUserCertificatesName,
 +     flag_descriptions::kAllowUserCertificatesDescription, kOsAndroid,
 +     FEATURE_VALUE_TYPE(chrome::android::kAllowUserCertificates)},
-     {"osk-resizes-visual-viewport",
-      flag_descriptions::kEnableOskResizesVisualViewportName,
-      flag_descriptions::kEnableOskResizesVisualViewportDescription, kOsAndroid,
+     {"osk-resizes-visual-viewport-by-default",
+      flag_descriptions::kEnableOskResizesVisualViewportByDefaultName,
+      flag_descriptions::kEnableOskResizesVisualViewportByDefaultDescription,
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
@@ -101,16 +103,17 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browse
      &feed::kInterestFeedV1ClicksAndViewsConditionalUpload,
      &feed::kInterestFeedV2,
      &feed::kInterestFeedV2Autoplay,
-@@ -453,6 +454,9 @@ const base::Feature kAdaptiveButtonInTopToolbarCustomizationV2{
-     "AdaptiveButtonInTopToolbarCustomizationV2",
-     base::FEATURE_ENABLED_BY_DEFAULT};
+@@ -467,6 +468,10 @@ BASE_FEATURE(kAdaptiveButtonInTopToolbarCustomizationV2,
+              "AdaptiveButtonInTopToolbarCustomizationV2",
+              base::FEATURE_ENABLED_BY_DEFAULT);
  
-+const base::Feature kAllowUserCertificates = {
-+    "AllowUserCertificates", base::FEATURE_DISABLED_BY_DEFAULT};
++BASE_FEATURE(kAllowUserCertificates,
++             "AllowUserCertificates",
++             base::FEATURE_DISABLED_BY_DEFAULT);
 +
- const base::Feature kAddToHomescreenIPH{"AddToHomescreenIPH",
-                                         base::FEATURE_DISABLED_BY_DEFAULT};
- 
+ BASE_FEATURE(kAddToHomescreenIPH,
+              "AddToHomescreenIPH",
+              base::FEATURE_DISABLED_BY_DEFAULT);
 diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser/flags/android/chrome_feature_list.h
 --- a/chrome/browser/flags/android/chrome_feature_list.h
 +++ b/chrome/browser/flags/android/chrome_feature_list.h
@@ -120,8 +123,8 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser
  
 +extern const base::Feature kAllowUserCertificates;
  // Alphabetical:
- extern const base::Feature kAdaptiveButtonInTopToolbar;
- extern const base::Feature kAdaptiveButtonInTopToolbarCustomizationV2;
+ BASE_DECLARE_FEATURE(kAdaptiveButtonInTopToolbar);
+ BASE_DECLARE_FEATURE(kAdaptiveButtonInTopToolbarCustomizationV2);
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
@@ -144,7 +147,7 @@ diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/f
      public static final String ABOUT_THIS_SITE_BANNER = "AboutThisSiteBanner";
      public static final String ADAPTIVE_BUTTON_IN_TOP_TOOLBAR = "AdaptiveButtonInTopToolbar";
      public static final String ADAPTIVE_BUTTON_IN_TOP_TOOLBAR_CUSTOMIZATION_V2 =
-@@ -637,6 +638,8 @@ public abstract class ChromeFeatureList {
+@@ -646,6 +647,8 @@ public abstract class ChromeFeatureList {
      public static final String FEED_REPLACE_ALL = "FeedReplaceAll";
  
      /* Alphabetical: */

--- a/build/patches/Add-IsCleartextPermitted-flag.patch
+++ b/build/patches/Add-IsCleartextPermitted-flag.patch
@@ -8,15 +8,15 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  chrome/browser/about_flags.cc           | 4 ++++
  chrome/browser/flag_descriptions.cc     | 4 ++++
  chrome/browser/flag_descriptions.h      | 3 +++
- net/base/features.cc                    | 3 +++
+ net/base/features.cc                    | 4 ++++
  net/base/features.h                     | 2 ++
  net/url_request/url_request_http_job.cc | 4 ++++
- 6 files changed, 20 insertions(+)
+ 6 files changed, 21 insertions(+)
 
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -8862,6 +8862,10 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -9071,6 +9071,10 @@ const FeatureEntry kFeatureEntries[] = {
       flag_descriptions::kRequestDesktopSiteExceptionsName,
       flag_descriptions::kRequestDesktopSiteExceptionsDescription, kOsAndroid,
       FEATURE_VALUE_TYPE(features::kRequestDesktopSiteExceptions)},
@@ -30,7 +30,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
-@@ -1661,6 +1661,10 @@ const char kHttpsOnlyModeDescription[] =
+@@ -1710,6 +1710,10 @@ const char kHttpsOnlyModeDescription[] =
      "Adds a setting under chrome://settings/security to opt-in to HTTPS-First "
      "Mode.";
  
@@ -44,7 +44,7 @@ diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descripti
 diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
 --- a/chrome/browser/flag_descriptions.h
 +++ b/chrome/browser/flag_descriptions.h
-@@ -927,6 +927,9 @@ extern const char kHideShelfControlsInTabletModeDescription[];
+@@ -957,6 +957,9 @@ extern const char kHideShelfControlsInTabletModeDescription[];
  extern const char kHttpsOnlyModeName[];
  extern const char kHttpsOnlyModeDescription[];
  
@@ -57,28 +57,29 @@ diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptio
 diff --git a/net/base/features.cc b/net/base/features.cc
 --- a/net/base/features.cc
 +++ b/net/base/features.cc
-@@ -113,6 +113,9 @@ const base::Feature kEnableTLS13EarlyData{"EnableTLS13EarlyData",
- const base::Feature kEncryptedClientHello{"EncryptedClientHello",
-                                           base::FEATURE_DISABLED_BY_DEFAULT};
+@@ -73,6 +73,10 @@ BASE_FEATURE(kEncryptedClientHello,
+              "EncryptedClientHello",
+              base::FEATURE_DISABLED_BY_DEFAULT);
  
-+const base::Feature kIsCleartextPermitted{"IsCleartextPermitted",
-+                                      base::FEATURE_ENABLED_BY_DEFAULT};
++BASE_FEATURE(kIsCleartextPermitted,
++             "IsCleartextPermitted",
++             base::FEATURE_ENABLED_BY_DEFAULT);
 +
- const base::Feature kNetworkQualityEstimator{"NetworkQualityEstimator",
-                                              base::FEATURE_DISABLED_BY_DEFAULT};
- 
+ BASE_FEATURE(kNetworkQualityEstimator,
+              "NetworkQualityEstimator",
+              base::FEATURE_DISABLED_BY_DEFAULT);
 diff --git a/net/base/features.h b/net/base/features.h
 --- a/net/base/features.h
 +++ b/net/base/features.h
-@@ -29,6 +29,8 @@ NET_EXPORT extern const base::Feature kAvoidH2Reprioritization;
+@@ -29,6 +29,8 @@ NET_EXPORT BASE_DECLARE_FEATURE(kAvoidH2Reprioritization);
  // origin requests are restricted to contain at most the source origin.
- NET_EXPORT extern const base::Feature kCapReferrerToOriginOnCrossOrigin;
+ NET_EXPORT BASE_DECLARE_FEATURE(kCapReferrerToOriginOnCrossOrigin);
  
 +NET_EXPORT extern const base::Feature kIsCleartextPermitted;
 +
  // Support for altering the parameters used for DNS transaction timeout. See
  // ResolveContext::SecureTransactionTimeout().
- NET_EXPORT extern const base::Feature kDnsTransactionDynamicTimeouts;
+ NET_EXPORT BASE_DECLARE_FEATURE(kDnsTransactionDynamicTimeouts);
 diff --git a/net/url_request/url_request_http_job.cc b/net/url_request/url_request_http_job.cc
 --- a/net/url_request/url_request_http_job.cc
 +++ b/net/url_request/url_request_http_job.cc

--- a/build/patches/Add-an-always-incognito-mode.patch
+++ b/build/patches/Add-an-always-incognito-mode.patch
@@ -24,7 +24,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../java/res/xml/incognito_preferences.xml    |  37 ++++
  .../java/res/xml/privacy_preferences.xml      |   5 +
  .../AlwaysIncognitoLinkInterceptor.java       |  53 ++++++
- .../chrome/browser/ChromeTabbedActivity.java  |   6 +-
+ .../chrome/browser/ChromeTabbedActivity.java  |   9 +-
  .../chrome/browser/app/ChromeActivity.java    |   4 +
  .../AppMenuPropertiesDelegateImpl.java        |  26 ++-
  .../ChromeContextMenuPopulator.java           |   7 +-
@@ -35,19 +35,20 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../browser/history/HistoryManager.java       |  18 +-
  .../chrome/browser/history/HistoryPage.java   |  16 ++
  .../native_page/NativePageFactory.java        |   4 +-
- .../chrome/browser/ntp/RecentTabsManager.java |   3 +-
+ .../chrome/browser/ntp/RecentTabsManager.java |  27 ++-
  .../privacy/settings/IncognitoSettings.java   | 160 ++++++++++++++++++
  .../browser/settings/SettingsActivity.java    |   4 +
- .../HistoricalTabModelObserver.java           |   8 +-
+ .../HistoricalTabModelObserver.java           |   6 +-
  .../tab/tab_restore/HistoricalTabSaver.java   |   2 +-
- .../tab_restore/HistoricalTabSaverImpl.java   |  16 +-
+ .../tab_restore/HistoricalTabSaverImpl.java   |  17 +-
  .../tabbed_mode/TabbedRootUiCoordinator.java  |   4 +-
  .../browser/tabmodel/ChromeTabCreator.java    |   5 +-
  .../tabmodel/TabModelSelectorImpl.java        |   3 +
  .../browser/tabmodel/TabPersistentStore.java  |   9 +
+ .../browser/toolbar/ToolbarManager.java       |   4 +-
  .../webapps/WebappIntentDataProvider.java     |  14 ++
  chrome/browser/about_flags.cc                 |   4 +
- .../browser/android/historical_tab_saver.cc   |  21 ++-
+ .../browser/android/historical_tab_saver.cc   |  22 ++-
  .../chrome_autocomplete_provider_client.cc    |   7 +
  .../chrome_autocomplete_provider_client.h     |   1 +
  .../host_content_settings_map_factory.cc      |  20 ++-
@@ -56,9 +57,9 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../flags/android/chrome_feature_list.cc      |   4 +-
  chrome/browser/history/history_tab_helper.cc  |  18 ++
  chrome/browser/history/history_tab_helper.h   |  10 +-
- .../android/offline_page_bridge.cc            |  13 +-
- .../android/offline_page_model_factory.cc     |  21 ++-
- .../android/request_coordinator_factory.cc    |  21 ++-
+ .../android/offline_page_bridge.cc            |  11 +-
+ .../android/offline_page_model_factory.cc     |  20 ++-
+ .../android/request_coordinator_factory.cc    |  26 ++-
  .../offline_page_model_factory.h              |   1 +
  .../offline_pages/recent_tab_helper.cc        |  19 ++-
  .../browser/offline_pages/recent_tab_helper.h |   3 +
@@ -67,6 +68,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../browser/ui/android/native_page/BUILD.gn   |   2 +
  .../browser/ui/native_page/NativePage.java    |  12 +-
  .../strings/android_chrome_strings.grd        |  31 ++++
+ .../browser/toolbar/LocationBarModel.java     |  11 +-
  chrome/browser/ui/messages/android/BUILD.gn   |   1 +
  .../snackbar/INeedSnackbarManager.java        |  27 +++
  chrome/common/pref_names.cc                   |   6 +
@@ -82,7 +84,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../omnibox/browser/base_search_provider.cc   |   2 +-
  components/omnibox/browser/search_provider.cc |   4 +-
  .../host_content_settings_map_factory.cc      |   1 +
- 63 files changed, 680 insertions(+), 74 deletions(-)
+ 65 files changed, 721 insertions(+), 77 deletions(-)
  create mode 100644 chrome/android/java/res/xml/incognito_preferences.xml
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/AlwaysIncognitoLinkInterceptor.java
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/IncognitoSettings.java
@@ -91,7 +93,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/chrome/android/chrome_java_resources.gni b/chrome/android/chrome_java_resources.gni
 --- a/chrome/android/chrome_java_resources.gni
 +++ b/chrome/android/chrome_java_resources.gni
-@@ -654,6 +654,7 @@ chrome_java_resources = [
+@@ -661,6 +661,7 @@ chrome_java_resources = [
    "java/res/xml/main_preferences.xml",
    "java/res/xml/manage_sync_preferences.xml",
    "java/res/xml/phone_as_a_security_key_accessory_filter.xml",
@@ -110,7 +112,7 @@ diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java
    "java/src/com/google/android/apps/chrome/appwidget/bookmarks/BookmarkThumbnailWidgetProvider.java",
    "java/src/org/chromium/chrome/browser/ActivityTabProvider.java",
    "java/src/org/chromium/chrome/browser/ActivityUtils.java",
-@@ -912,6 +913,7 @@ chrome_java_sources = [
+@@ -964,6 +965,7 @@ chrome_java_sources = [
    "java/src/org/chromium/chrome/browser/privacy/settings/IncognitoLockSettings.java",
    "java/src/org/chromium/chrome/browser/privacy/settings/PrivacyPreferencesManagerImpl.java",
    "java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java",
@@ -236,7 +238,7 @@ new file mode 100644
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
-@@ -57,6 +57,7 @@ import org.chromium.base.task.PostTask;
+@@ -58,6 +58,7 @@ import org.chromium.base.task.PostTask;
  import org.chromium.build.annotations.UsedByReflection;
  import org.chromium.cc.input.BrowserControlsState;
  import org.chromium.chrome.R;
@@ -244,7 +246,18 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedAct
  import org.chromium.chrome.browser.IntentHandler.IntentHandlerDelegate;
  import org.chromium.chrome.browser.IntentHandler.TabOpenType;
  import org.chromium.chrome.browser.accessibility_tab_switcher.OverviewListLayout;
-@@ -1899,8 +1900,9 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
+@@ -578,8 +579,9 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
+             mTabModelOrchestrator.onNativeLibraryReady(getTabContentManager());
+ 
+             // For saving non-incognito tab closures for Recent Tabs.
++            boolean alwaysIncognito = AlwaysIncognitoLinkInterceptor.isAlwaysIncognito();
+             mHistoricalTabModelObserver =
+-                    new HistoricalTabModelObserver(mTabModelSelector.getModel(false));
++                    new HistoricalTabModelObserver(mTabModelSelector.getModel(alwaysIncognito));
+ 
+             if (TabUiFeatureUtilities.isTabletGridTabSwitcherEnabled(this)) {
+                 mTabModelSelector.addObserver(new TabModelSelectorObserver() {
+@@ -1904,8 +1906,9 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
          Bundle savedInstanceState = getSavedInstanceState();
  
          // We determine the model as soon as possible so every systems get initialized coherently.
@@ -259,15 +272,15 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedAct
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
-@@ -93,6 +93,7 @@ import org.chromium.chrome.browser.compositor.layouts.content.ContentOffsetProvi
- import org.chromium.chrome.browser.compositor.layouts.content.TabContentManager;
- import org.chromium.chrome.browser.compositor.layouts.content.TabContentManagerHandler;
+@@ -98,6 +98,7 @@ import org.chromium.chrome.browser.contextualsearch.ContextualSearchFieldTrial;
+ import org.chromium.chrome.browser.contextualsearch.ContextualSearchManager;
+ import org.chromium.chrome.browser.contextualsearch.ContextualSearchManager.ContextualSearchTabPromotionDelegate;
  import org.chromium.chrome.browser.dependency_injection.ChromeActivityCommonsModule;
 +import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
  import org.chromium.chrome.browser.dependency_injection.ChromeActivityComponent;
  import org.chromium.chrome.browser.dependency_injection.ModuleFactoryOverrides;
  import org.chromium.chrome.browser.device.DeviceClassManager;
-@@ -1812,6 +1813,9 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
+@@ -1830,6 +1831,9 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
              throw new IllegalStateException(
                      "Attempting to access TabCreator before initialization");
          }
@@ -286,9 +299,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/App
  import org.chromium.chrome.browser.ActivityTabProvider;
 +import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
  import org.chromium.chrome.browser.banners.AppMenuVerbiage;
- import org.chromium.chrome.browser.bookmarks.BookmarkBridge;
  import org.chromium.chrome.browser.bookmarks.BookmarkFeatures;
-@@ -98,6 +99,10 @@ import java.util.ArrayList;
+ import org.chromium.chrome.browser.bookmarks.BookmarkModel;
+@@ -101,6 +102,10 @@ import java.util.ArrayList;
  import java.util.List;
  import java.util.Map;
  
@@ -299,7 +312,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/App
  /**
   * Base implementation of {@link AppMenuPropertiesDelegate} that handles hiding and showing menu
   * items based on activity state.
-@@ -558,6 +563,13 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+@@ -562,6 +567,13 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
      }
  
      private void prepareCommonMenuItems(Menu menu, @MenuGroup int menuGroup, boolean isIncognito) {
@@ -313,7 +326,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/App
          // We have to iterate all menu items since same menu item ID may be associated with more
          // than one menu items.
          boolean isOverviewModeMenu = menuGroup == MenuGroup.OVERVIEW_MODE_MENU;
-@@ -616,7 +628,15 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+@@ -640,7 +652,15 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
              }
  
              if (item.getItemId() == R.id.recent_tabs_menu_id) {
@@ -329,8 +342,8 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/App
 +                    item.setVisible(!isIncognito);
              }
              if (item.getItemId() == R.id.menu_group_tabs) {
-                 // Disable incognito group tabs when a re-authentication screen is shown.
-@@ -858,7 +878,9 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
+                 item.setVisible(isMenuGroupTabsVisible);
+@@ -880,7 +900,9 @@ public class AppMenuPropertiesDelegateImpl implements AppMenuPropertiesDelegate
          //                is not persisted when adding to the homescreen.
          // * If creating shortcuts it not supported by the current home screen.
          return WebappsUtils.isAddToHomeIntentSupported() && !isChromeScheme && !isFileScheme
@@ -352,7 +365,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/Chr
  import org.chromium.chrome.browser.compositor.bottombar.ephemeraltab.EphemeralTabCoordinator;
  import org.chromium.chrome.browser.contextmenu.ChromeContextMenuItem.Item;
  import org.chromium.chrome.browser.contextmenu.ContextMenuCoordinator.ListItemType;
-@@ -374,6 +375,9 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -364,6 +365,9 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
          boolean hasSaveImage = false;
          mShowEphemeralTabNewLabel = null;
  
@@ -362,7 +375,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/Chr
          List<Pair<Integer, ModelList>> groupedItems = new ArrayList<>();
  
          if (mParams.isAnchor()) {
-@@ -392,6 +396,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -382,6 +386,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
                              linkGroup.add(createListItem(Item.OPEN_IN_NEW_TAB_IN_GROUP));
                          }
                      }
@@ -370,7 +383,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/Chr
                      if (!mItemDelegate.isIncognito() && mItemDelegate.isIncognitoSupported()) {
                          linkGroup.add(createListItem(Item.OPEN_IN_INCOGNITO_TAB));
                      }
-@@ -416,7 +421,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -406,7 +411,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
                  }
              }
              if (FirstRunStatus.getFirstRunFlowComplete()) {
@@ -382,7 +395,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/Chr
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivityLifecycleUmaTracker.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivityLifecycleUmaTracker.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivityLifecycleUmaTracker.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivityLifecycleUmaTracker.java
-@@ -66,31 +66,6 @@ public class CustomTabActivityLifecycleUmaTracker implements PauseResumeWithNati
+@@ -68,31 +68,6 @@ public class CustomTabActivityLifecycleUmaTracker
      private boolean mIsInitialResume = true;
  
      private void recordIncognitoLaunchReason() {
@@ -424,8 +437,8 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/Cust
 +import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
  import org.chromium.chrome.browser.DefaultBrowserInfo;
  import org.chromium.chrome.browser.app.appmenu.AppMenuPropertiesDelegateImpl;
- import org.chromium.chrome.browser.bookmarks.BookmarkBridge;
-@@ -172,6 +173,9 @@ public class CustomTabAppMenuPropertiesDelegate extends AppMenuPropertiesDelegat
+ import org.chromium.chrome.browser.app.appmenu.DividerLineMenuItemViewBinder;
+@@ -176,6 +177,9 @@ public class CustomTabAppMenuPropertiesDelegate extends AppMenuPropertiesDelegat
                  downloadItemVisible = false;
                  openInChromeItemVisible = false;
              }
@@ -448,7 +461,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/Cust
  import java.lang.annotation.Retention;
  import java.lang.annotation.RetentionPolicy;
  import java.util.ArrayList;
-@@ -847,7 +850,7 @@ public class CustomTabIntentDataProvider extends BrowserServicesIntentDataProvid
+@@ -855,7 +858,7 @@ public class CustomTabIntentDataProvider extends BrowserServicesIntentDataProvid
  
      @Override
      public boolean isIncognito() {
@@ -500,7 +513,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/download/Downlo
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryManager.java b/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryManager.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryManager.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/history/HistoryManager.java
-@@ -33,6 +33,7 @@ import com.google.android.material.tabs.TabLayout.OnTabSelectedListener;
+@@ -35,6 +35,7 @@ import com.google.android.material.tabs.TabLayout.OnTabSelectedListener;
  import org.chromium.base.metrics.RecordHistogram;
  import org.chromium.base.metrics.RecordUserAction;
  import org.chromium.base.supplier.ObservableSupplier;
@@ -508,9 +521,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/History
  import org.chromium.base.supplier.ObservableSupplierImpl;
  import org.chromium.base.supplier.Supplier;
  import org.chromium.chrome.R;
-@@ -73,6 +74,12 @@ import org.chromium.url.GURL;
- import java.io.Serializable;
+@@ -77,6 +78,12 @@ import java.io.Serializable;
  import java.util.List;
+ import java.util.concurrent.atomic.AtomicReference;
  
 +import org.chromium.chrome.browser.profiles.Profile;
 +import org.chromium.base.ContextUtils;
@@ -521,7 +534,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/history/History
  /**
   * Combines and manages the different UI components of browsing history.
   */
-@@ -504,7 +511,16 @@ public class HistoryManager implements OnMenuItemClickListener, SelectionObserve
+@@ -551,7 +558,16 @@ public class HistoryManager implements OnMenuItemClickListener, SelectionObserve
          return mRootView;
      }
  
@@ -603,7 +616,23 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/native_page/Nat
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java b/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsManager.java
-@@ -79,7 +79,8 @@ public class RecentTabsManager {
+@@ -24,6 +24,15 @@ import org.chromium.components.signin.identitymanager.ConsentLevel;
+ import org.chromium.components.signin.metrics.SigninAccessPoint;
+ import org.chromium.url.GURL;
+ 
++import android.content.Intent;
++import android.provider.Browser;
++import android.net.Uri;
++import org.chromium.base.ContextUtils;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
++import org.chromium.chrome.browser.IntentHandler;
++import org.chromium.ui.mojom.WindowOpenDisposition;
++import org.chromium.components.embedder_support.util.UrlUtilities;
++
+ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
+@@ -81,7 +90,8 @@ public class RecentTabsManager implements AccountsChangeObserver {
       */
      public RecentTabsManager(Tab tab, TabModelSelector tabModelSelector, Profile profile,
              Context context, Runnable showHistoryManager) {
@@ -613,6 +642,28 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsM
          mActiveTab = tab;
          mTabModelSelector = tabModelSelector;
          mShowHistoryManager = showHistoryManager;
+@@ -213,6 +223,21 @@ public class RecentTabsManager implements AccountsChangeObserver {
+      */
+     public void openRecentlyClosedTab(RecentlyClosedTab tab, int windowDisposition) {
+         if (mIsDestroyed) return;
++        if (AlwaysIncognitoLinkInterceptor.isAlwaysIncognito()) {
++            // allow only http/https urls
++            if (!UrlUtilities.isHttpOrHttps(tab.getUrl())) return;
++
++            Context context = ContextUtils.getApplicationContext();
++            Intent intent = new Intent(Intent.ACTION_VIEW,
++                Uri.parse(tab.getUrl().getSpec()));
++            intent.putExtra(Browser.EXTRA_APPLICATION_ID, context.getPackageName());
++            if (windowDisposition != WindowOpenDisposition.CURRENT_TAB)
++                intent.putExtra(Browser.EXTRA_CREATE_NEW_TAB, true);
++            intent.setPackage(context.getPackageName());
++            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
++            IntentHandler.startActivityForTrustedIntent(intent);
++            return;
++        }
+         mTabSessionIdsRestored.put(tab.getSessionId(), true);
+         RecordUserAction.record("MobileRecentTabManagerRecentTabOpened");
+         // Window disposition will select which tab to open.
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/IncognitoSettings.java b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/IncognitoSettings.java
 new file mode 100644
 --- /dev/null
@@ -789,7 +840,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/Settin
  import org.chromium.chrome.browser.ui.messages.snackbar.SnackbarManager;
  import org.chromium.chrome.browser.ui.messages.snackbar.SnackbarManager.SnackbarManageable;
  import org.chromium.components.browser_ui.accessibility.AccessibilitySettings;
-@@ -254,6 +255,9 @@ public class SettingsActivity extends ChromeBaseAppCompatActivity
+@@ -253,6 +254,9 @@ public class SettingsActivity extends ChromeBaseAppCompatActivity
          if (fragment instanceof AdPersonalizationRemovedFragment) {
              ((AdPersonalizationRemovedFragment) fragment).setSnackbarManager(getSnackbarManager());
          }
@@ -802,7 +853,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/Settin
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabModelObserver.java b/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabModelObserver.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabModelObserver.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabModelObserver.java
-@@ -15,6 +15,8 @@ import java.util.ArrayList;
+@@ -14,6 +14,8 @@ import java.util.ArrayList;
  import java.util.HashMap;
  import java.util.List;
  
@@ -811,7 +862,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore
  /**
   * A tab model observer for managing bulk closures.
   */
-@@ -47,7 +49,8 @@ public class HistoricalTabModelObserver implements TabModelObserver {
+@@ -41,7 +43,8 @@ public class HistoricalTabModelObserver implements TabModelObserver {
          if (tabs.isEmpty()) return;
  
          if (tabs.size() == 1) {
@@ -821,17 +872,14 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore
              return;
          }
  
-@@ -59,8 +62,9 @@ public class HistoricalTabModelObserver implements TabModelObserver {
-      * identical to what occurred prior to {@link ChromeFeatureList.BULK_TAB_RESTORE}.
-      */
-     private void legacyCreateHistoricalTabs(List<Tab> tabs) {
-+        boolean is_always_incognito = AlwaysIncognitoLinkInterceptor.isAlwaysIncognito();
-         for (Tab tab : tabs) {
--            mHistoricalTabSaver.createHistoricalTab(tab);
-+            mHistoricalTabSaver.createHistoricalTab(tab, is_always_incognito);
+@@ -72,7 +75,6 @@ public class HistoricalTabModelObserver implements TabModelObserver {
+             entries.add(historicalGroup);
+             idToGroup.put(groupId, historicalGroup);
          }
+-
+         mHistoricalTabSaver.createHistoricalBulkClosure(entries);
      }
- 
+ }
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabSaver.java b/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabSaver.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabSaver.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabSaver.java
@@ -847,7 +895,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabSaverImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabSaverImpl.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabSaverImpl.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore/HistoricalTabSaverImpl.java
-@@ -29,6 +29,8 @@ import java.util.Arrays;
+@@ -27,6 +27,8 @@ import java.util.Arrays;
  import java.util.Collections;
  import java.util.List;
  
@@ -856,7 +904,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore
  /**
   * Creates historical entries in TabRestoreService.
   */
-@@ -62,10 +64,10 @@ public class HistoricalTabSaverImpl implements HistoricalTabSaver {
+@@ -60,10 +62,10 @@ public class HistoricalTabSaverImpl implements HistoricalTabSaver {
  
      // HistoricalTabSaver implementation.
      @Override
@@ -869,7 +917,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore
      }
  
      @Override
-@@ -106,7 +108,7 @@ public class HistoricalTabSaverImpl implements HistoricalTabSaver {
+@@ -115,7 +117,7 @@ public class HistoricalTabSaverImpl implements HistoricalTabSaver {
  
          // If there is only a single valid tab remaining save it individually.
          if (validEntries.size() == 1 && validEntries.get(0).isSingleTab()) {
@@ -878,20 +926,22 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore
              return;
          }
  
-@@ -128,10 +130,10 @@ public class HistoricalTabSaverImpl implements HistoricalTabSaver {
-                 CollectionUtil.integerListToIntArray(perTabGroupId), allTabs.toArray(new Tab[0]));
+@@ -140,11 +142,12 @@ public class HistoricalTabSaverImpl implements HistoricalTabSaver {
+                 CollectionUtil.integerListToIntArray(savedStateVersions));
      }
  
 -    private void createHistoricalTabInternal(Tab tab) {
 +    private void createHistoricalTabInternal(Tab tab, boolean is_always_incognito) {
          RecordHistogram.recordEnumeratedHistogram("Tabs.RecentlyClosed.HistoricalSaverCloseType",
                  HistoricalSaverCloseType.TAB, HistoricalSaverCloseType.COUNT);
--        HistoricalTabSaverImplJni.get().createHistoricalTab(tab);
-+        HistoricalTabSaverImplJni.get().createHistoricalTab(tab, is_always_incognito);
+         HistoricalTabSaverImplJni.get().createHistoricalTab(
+-                tab, getWebContentsState(tab).buffer(), getWebContentsState(tab).version());
++                tab, getWebContentsState(tab).buffer(), getWebContentsState(tab).version(),
++                is_always_incognito);
      }
  
      /**
-@@ -139,7 +141,7 @@ public class HistoricalTabSaverImpl implements HistoricalTabSaver {
+@@ -152,7 +155,7 @@ public class HistoricalTabSaverImpl implements HistoricalTabSaver {
       * internal Chrome scheme, about:blank, or a native page and it cannot be incognito.
       */
      private boolean shouldSave(Tab tab) {
@@ -900,19 +950,19 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/tab_restore
  
          // {@link GURL#getScheme()} is not available in unit tests.
          if (mIgnoreUrlSchemesForTesting) return true;
-@@ -217,7 +219,7 @@ public class HistoricalTabSaverImpl implements HistoricalTabSaver {
+@@ -225,7 +228,7 @@ public class HistoricalTabSaverImpl implements HistoricalTabSaver {
  
      @NativeMethods
      interface Natives {
--        void createHistoricalTab(Tab tab);
-+        void createHistoricalTab(Tab tab, boolean is_always_incognito);
-         void createHistoricalGroup(TabModel model, String title, Tab[] tabs);
-         void createHistoricalBulkClosure(
-                 TabModel model, int[] groupIds, String[] titles, int[] perTabGroupId, Tab[] tabs);
+-        void createHistoricalTab(Tab tab, ByteBuffer state, int savedStateVersion);
++        void createHistoricalTab(Tab tab, ByteBuffer state, int savedStateVersion, boolean is_always_incognito);
+         void createHistoricalGroup(TabModel model, String title, Tab[] tabs,
+                 ByteBuffer[] byteBuffers, int[] savedStationsVersions);
+         void createHistoricalBulkClosure(TabModel model, int[] groupIds, String[] titles,
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java b/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
-@@ -122,6 +122,8 @@ import org.chromium.components.webapps.bottomsheet.PwaBottomSheetControllerFacto
+@@ -126,6 +126,8 @@ import org.chromium.components.webapps.bottomsheet.PwaBottomSheetControllerFacto
  import org.chromium.content_public.browser.WebContents;
  import org.chromium.ui.base.ActivityWindowAndroid;
  import org.chromium.ui.base.DeviceFormFactor;
@@ -921,7 +971,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/Tab
  import org.chromium.ui.base.IntentRequestTracker;
  import org.chromium.ui.modaldialog.ModalDialogManager;
  
-@@ -482,7 +484,7 @@ public class TabbedRootUiCoordinator extends RootUiCoordinator {
+@@ -492,7 +494,7 @@ public class TabbedRootUiCoordinator extends RootUiCoordinator {
                      mAppMenuCoordinator == null ? null : mAppMenuCoordinator.getAppMenuHandler();
              mEmptyBackgroundViewWrapper =
                      new EmptyBackgroundViewWrapper(mTabModelSelectorSupplier.get(),
@@ -984,7 +1034,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPer
  import java.io.BufferedInputStream;
  import java.io.ByteArrayInputStream;
  import java.io.ByteArrayOutputStream;
-@@ -747,6 +749,13 @@ public class TabPersistentStore {
+@@ -757,6 +759,13 @@ public class TabPersistentStore {
                  }
              }
          }
@@ -998,6 +1048,27 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPer
          TabModel model = mTabModelSelector.getModel(isIncognito);
  
          if (model.isIncognito() != isIncognito) {
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
+@@ -38,6 +38,7 @@ import org.chromium.base.supplier.OneshotSupplier;
+ import org.chromium.base.supplier.Supplier;
+ import org.chromium.chrome.R;
+ import org.chromium.chrome.browser.ActivityTabProvider;
++import org.chromium.chrome.browser.AlwaysIncognitoLinkInterceptor;
+ import org.chromium.chrome.browser.IntentHandler;
+ import org.chromium.chrome.browser.app.tab_activity_glue.TabReparentingController;
+ import org.chromium.chrome.browser.app.tabmodel.TabWindowManagerSingleton;
+@@ -526,7 +527,8 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+                         return ret;
+                     }
+                 },
+-                SearchEngineLogoUtils.getInstance());
++                SearchEngineLogoUtils.getInstance(),
++                AlwaysIncognitoLinkInterceptor.isAlwaysIncognito());
+         mControlContainer = controlContainer;
+         assert mControlContainer != null;
+ 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappIntentDataProvider.java b/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappIntentDataProvider.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappIntentDataProvider.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappIntentDataProvider.java
@@ -1046,7 +1117,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/webapps/WebappI
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -4713,6 +4713,10 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -4886,6 +4886,10 @@ const FeatureEntry kFeatureEntries[] = {
       flag_descriptions::kOfflinePagesLivePageSharingName,
       flag_descriptions::kOfflinePagesLivePageSharingDescription, kOsAndroid,
       FEATURE_VALUE_TYPE(offline_pages::kOfflinePagesLivePageSharingFeature)},
@@ -1060,7 +1131,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 diff --git a/chrome/browser/android/historical_tab_saver.cc b/chrome/browser/android/historical_tab_saver.cc
 --- a/chrome/browser/android/historical_tab_saver.cc
 +++ b/chrome/browser/android/historical_tab_saver.cc
-@@ -25,6 +25,11 @@
+@@ -26,6 +26,11 @@
  #include "components/sessions/core/tab_restore_service.h"
  #include "content/public/browser/web_contents.h"
  
@@ -1072,16 +1143,17 @@ diff --git a/chrome/browser/android/historical_tab_saver.cc b/chrome/browser/and
  using base::android::JavaParamRef;
  using base::android::ScopedJavaLocalRef;
  
-@@ -35,7 +40,7 @@ namespace {
- // Defined in TabGroupModelFilter.java
- constexpr int kInvalidGroupId = -1;
+@@ -38,7 +43,8 @@ constexpr int kInvalidGroupId = -1;
  
--void CreateHistoricalTab(TabAndroid* tab_android) {
-+void CreateHistoricalTab(TabAndroid* tab_android, bool is_always_incognito) {
+ void CreateHistoricalTab(
+     TabAndroid* tab_android,
+-    WebContentsStateByteBuffer web_contents_state_byte_buffer) {
++    WebContentsStateByteBuffer web_contents_state_byte_buffer,
++    bool is_always_incognito) {
    if (!tab_android) {
      return;
    }
-@@ -45,9 +50,14 @@ void CreateHistoricalTab(TabAndroid* tab_android) {
+@@ -49,9 +55,14 @@ void CreateHistoricalTab(
      return;
    }
  
@@ -1098,22 +1170,28 @@ diff --git a/chrome/browser/android/historical_tab_saver.cc b/chrome/browser/and
    if (!service) {
      return;
    }
-@@ -190,8 +200,9 @@ std::unique_ptr<ScopedWebContents> ScopedWebContents::CreateForTab(
- // static
- static void JNI_HistoricalTabSaverImpl_CreateHistoricalTab(
+@@ -243,14 +254,15 @@ static void JNI_HistoricalTabSaverImpl_CreateHistoricalTab(
      JNIEnv* env,
--    const JavaParamRef<jobject>& jtab_android) {
--  CreateHistoricalTab(TabAndroid::GetNativeTab(env, jtab_android));
-+    const JavaParamRef<jobject>& jtab_android,
+     const JavaParamRef<jobject>& jtab_android,
+     const JavaParamRef<jobject>& state,
+-    jint saved_state_version) {
++    jint saved_state_version,
 +    jboolean is_always_incognito) {
-+  CreateHistoricalTab(TabAndroid::GetNativeTab(env, jtab_android), is_always_incognito);
+   void* data = env->GetDirectBufferAddress(state);
+   int size = env->GetDirectBufferCapacity(state);
+ 
+   WebContentsStateByteBuffer web_contents_state =
+       WebContentsStateByteBuffer(data, size, (int)saved_state_version);
+   CreateHistoricalTab(TabAndroid::GetNativeTab(env, jtab_android),
+-                      std::move(web_contents_state));
++                      std::move(web_contents_state), is_always_incognito);
  }
  
  // static
 diff --git a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc b/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
 --- a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
 +++ b/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
-@@ -299,6 +299,13 @@ signin::IdentityManager* ChromeAutocompleteProviderClient::GetIdentityManager()
+@@ -310,6 +310,13 @@ signin::IdentityManager* ChromeAutocompleteProviderClient::GetIdentityManager()
    return IdentityManagerFactory::GetForProfile(profile_);
  }
  
@@ -1130,7 +1208,7 @@ diff --git a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc 
 diff --git a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.h b/chrome/browser/autocomplete/chrome_autocomplete_provider_client.h
 --- a/chrome/browser/autocomplete/chrome_autocomplete_provider_client.h
 +++ b/chrome/browser/autocomplete/chrome_autocomplete_provider_client.h
-@@ -78,6 +78,7 @@ class ChromeAutocompleteProviderClient : public AutocompleteProviderClient {
+@@ -80,6 +80,7 @@ class ChromeAutocompleteProviderClient : public AutocompleteProviderClient {
        const override;
    signin::IdentityManager* GetIdentityManager() const override;
    bool IsOffTheRecord() const override;
@@ -1187,7 +1265,7 @@ diff --git a/chrome/browser/content_settings/host_content_settings_map_factory.c
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
-@@ -3758,6 +3758,12 @@ const char kOfflinePagesLivePageSharingDescription[] =
+@@ -3907,6 +3907,12 @@ const char kOfflinePagesLivePageSharingDescription[] =
      "Enables to share current loaded page as offline page by saving as MHTML "
      "first.";
  
@@ -1197,36 +1275,37 @@ diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descripti
 +    "Enables autosave of offline page, as automatic switching in case "
 +    "the device goes offline.";
 +
- const char kPageInfoDiscoverabilityTimeoutsName[] =
-     "Page info discoverability timeouts";
- const char kPageInfoDiscoverabilityTimeoutsDescription[] =
+ const char kPageInfoHistoryName[] = "Page info history";
+ const char kPageInfoHistoryDescription[] =
+     "Enable a history sub page to the page info menu, and a button to forget "
 diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
 --- a/chrome/browser/flag_descriptions.h
 +++ b/chrome/browser/flag_descriptions.h
-@@ -2141,6 +2141,9 @@ extern const char kNotificationPermissionRationaleDescription[];
+@@ -2227,6 +2227,9 @@ extern const char kNotificationPermissionRationaleDescription[];
  extern const char kOfflinePagesLivePageSharingName[];
  extern const char kOfflinePagesLivePageSharingDescription[];
  
 +extern const char kOfflinePagesAutoSaveFeatureName[];
 +extern const char kOfflinePagesAutoSaveFeatureDescription[];
 +
- extern const char kPageInfoDiscoverabilityTimeoutsName[];
- extern const char kPageInfoDiscoverabilityTimeoutsDescription[];
+ extern const char kPageInfoHistoryName[];
+ extern const char kPageInfoHistoryDescription[];
  
 diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
 --- a/chrome/browser/flags/android/chrome_feature_list.cc
 +++ b/chrome/browser/flags/android/chrome_feature_list.cc
-@@ -535,8 +535,8 @@ const base::Feature kCCTNewDownloadTab{"CCTNewDownloadTab",
- const base::Feature kCCTIncognito{"CCTIncognito",
-                                   base::FEATURE_ENABLED_BY_DEFAULT};
+@@ -570,9 +570,9 @@ BASE_FEATURE(kCCTNewDownloadTab,
  
--const base::Feature kCCTIncognitoAvailableToThirdParty{
--    "CCTIncognitoAvailableToThirdParty", base::FEATURE_DISABLED_BY_DEFAULT};
-+const base::Feature kCCTIncognitoAvailableToThirdParty{                     // Enabled by default in Bromite
-+    "CCTIncognitoAvailableToThirdParty", base::FEATURE_ENABLED_BY_DEFAULT};
+ BASE_FEATURE(kCCTIncognito, "CCTIncognito", base::FEATURE_ENABLED_BY_DEFAULT);
  
- const base::Feature kCCTPackageNameRecording{"CCTPackageNameRecording",
-                                              base::FEATURE_ENABLED_BY_DEFAULT};
+-BASE_FEATURE(kCCTIncognitoAvailableToThirdParty,
++BASE_FEATURE(kCCTIncognitoAvailableToThirdParty,                     // Enabled by default in Bromite
+              "CCTIncognitoAvailableToThirdParty",
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kCCTPackageNameRecording,
+              "CCTPackageNameRecording",
 diff --git a/chrome/browser/history/history_tab_helper.cc b/chrome/browser/history/history_tab_helper.cc
 --- a/chrome/browser/history/history_tab_helper.cc
 +++ b/chrome/browser/history/history_tab_helper.cc
@@ -1316,38 +1395,23 @@ diff --git a/chrome/browser/offline_pages/android/offline_page_bridge.cc b/chrom
  
  using base::android::ConvertJavaStringToUTF8;
  using base::android::ConvertUTF16ToJavaString;
-@@ -156,7 +159,13 @@ void ValidateFileCallback(
-     int64_t offline_id,
-     const GURL& url,
-     const base::FilePath& file_path,
-+    SimpleFactoryKey* key,
-     bool is_trusted) {
-+  // in always incognito, never trust input file (show file name in url)
-+  ProfileKey* profile_key = ProfileKey::FromSimpleFactoryKey(key);
-+  if(profile_key->GetPrefs()->GetBoolean(prefs::kIncognitoTabHistoryEnabled))
-+    is_trusted = false;
-+
-   // If trusted, the launch url will be the http/https url of the offline
-   // page. If the file path is content URI, directly open it. Otherwise, the
-   // launch url will be the file URL pointing to the archive file of the offline
-@@ -787,7 +796,7 @@ void OfflinePageBridge::GetPageByOfflineIdDone(
+@@ -785,9 +788,15 @@ void OfflinePageBridge::GetPageByOfflineIdDone(
+   }
+ 
    if (offline_page_model_->IsArchiveInInternalDir(offline_page->file_path)) {
++    bool is_trusted = true;
++    // in always incognito, never trust input file (show file name in url)
++    ProfileKey* profile_key = ProfileKey::FromSimpleFactoryKey(key_);
++    if(profile_key->GetPrefs()->GetBoolean(prefs::kIncognitoTabHistoryEnabled))
++      is_trusted = false;
++
      ValidateFileCallback(launch_location, j_callback_obj,
                           offline_page->offline_id, offline_page->url,
 -                         offline_page->file_path, true /* is_trusted*/);
-+                         offline_page->file_path, key_, true /* is_trusted*/);
++                         offline_page->file_path, is_trusted);
      return;
    }
  
-@@ -797,7 +806,7 @@ void OfflinePageBridge::GetPageByOfflineIdDone(
-                      offline_page->file_size, offline_page->digest),
-       base::BindOnce(&ValidateFileCallback, launch_location, j_callback_obj,
-                      offline_page->offline_id, offline_page->url,
--                     offline_page->file_path));
-+                     offline_page->file_path, key_));
- }
- 
- void OfflinePageBridge::GetSizeAndComputeDigestDone(
 diff --git a/chrome/browser/offline_pages/android/offline_page_model_factory.cc b/chrome/browser/offline_pages/android/offline_page_model_factory.cc
 --- a/chrome/browser/offline_pages/android/offline_page_model_factory.cc
 +++ b/chrome/browser/offline_pages/android/offline_page_model_factory.cc
@@ -1361,15 +1425,7 @@ diff --git a/chrome/browser/offline_pages/android/offline_page_model_factory.cc 
  
  namespace offline_pages {
  
-@@ -46,6 +49,7 @@ OfflinePageModel* OfflinePageModelFactory::GetForKey(SimpleFactoryKey* key) {
- OfflinePageModel* OfflinePageModelFactory::GetForBrowserContext(
-     content::BrowserContext* browser_context) {
-   Profile* profile = Profile::FromBrowserContext(browser_context);
-+  profile = profile->GetOriginalProfile();
-   return GetForKey(profile->GetProfileKey());
- }
- 
-@@ -54,13 +58,15 @@ std::unique_ptr<KeyedService> OfflinePageModelFactory::BuildServiceInstanceFor(
+@@ -54,13 +57,15 @@ std::unique_ptr<KeyedService> OfflinePageModelFactory::BuildServiceInstanceFor(
    scoped_refptr<base::SequencedTaskRunner> background_task_runner =
        base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()});
  
@@ -1387,7 +1443,7 @@ diff --git a/chrome/browser/offline_pages/android/offline_page_model_factory.cc 
    // If base::PathService::Get returns false, the temporary_archives_dir will be
    // empty, and no temporary pages will be saved during this chrome lifecycle.
    base::FilePath temporary_archives_dir;
-@@ -69,7 +75,6 @@ std::unique_ptr<KeyedService> OfflinePageModelFactory::BuildServiceInstanceFor(
+@@ -69,7 +74,6 @@ std::unique_ptr<KeyedService> OfflinePageModelFactory::BuildServiceInstanceFor(
          temporary_archives_dir.Append(chrome::kOfflinePageArchivesDirname);
    }
  
@@ -1395,7 +1451,7 @@ diff --git a/chrome/browser/offline_pages/android/offline_page_model_factory.cc 
    auto archive_manager = std::make_unique<DownloadArchiveManager>(
        temporary_archives_dir, persistent_archives_dir,
        DownloadPrefs::GetDefaultDownloadDirectory(), background_task_runner,
-@@ -87,4 +92,14 @@ std::unique_ptr<KeyedService> OfflinePageModelFactory::BuildServiceInstanceFor(
+@@ -87,4 +91,14 @@ std::unique_ptr<KeyedService> OfflinePageModelFactory::BuildServiceInstanceFor(
    return model;
  }
  
@@ -1443,7 +1499,19 @@ diff --git a/chrome/browser/offline_pages/android/request_coordinator_factory.cc
    // Depends on OfflinePageModelFactory in SimpleDependencyManager.
  }
  
-@@ -111,4 +118,16 @@ KeyedService* RequestCoordinatorFactory::BuildServiceInstanceFor(
+@@ -79,6 +86,11 @@ RequestCoordinator* RequestCoordinatorFactory::GetForBrowserContext(
+ 
+ KeyedService* RequestCoordinatorFactory::BuildServiceInstanceFor(
+     content::BrowserContext* context) const {
++  if(context->IsOffTheRecord() &&
++      Profile::FromBrowserContext(context)->GetOriginalProfile()
++        ->GetPrefs()->GetBoolean(prefs::kIncognitoTabHistoryEnabled) == false) {
++    return nullptr;
++  }
+   std::unique_ptr<OfflinerPolicy> policy(new OfflinerPolicy());
+   std::unique_ptr<Offliner> offliner;
+   OfflinePageModel* model =
+@@ -111,4 +123,16 @@ KeyedService* RequestCoordinatorFactory::BuildServiceInstanceFor(
    return request_coordinator;
  }
  
@@ -1551,7 +1619,7 @@ diff --git a/chrome/browser/offline_pages/request_coordinator_factory.h b/chrome
 diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browser_prefs.cc
 --- a/chrome/browser/prefs/browser_prefs.cc
 +++ b/chrome/browser/prefs/browser_prefs.cc
-@@ -226,6 +226,7 @@
+@@ -229,6 +229,7 @@
  #include "components/feed/core/shared_prefs/pref_names.h"
  
  #if BUILDFLAG(IS_ANDROID)
@@ -1559,7 +1627,7 @@ diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browse
  #include "chrome/browser/android/bookmarks/partner_bookmarks_shim.h"
  #include "chrome/browser/android/explore_sites/history_statistics_reporter.h"
  #include "chrome/browser/android/ntp/recent_tabs_page_prefs.h"
-@@ -1416,6 +1417,10 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
+@@ -1390,6 +1391,10 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
    usage_stats::UsageStatsBridge::RegisterProfilePrefs(registry);
    variations::VariationsService::RegisterProfilePrefs(registry);
    video_tutorials::RegisterPrefs(registry);
@@ -1567,9 +1635,9 @@ diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browse
 +  registry->RegisterBooleanPref(prefs::kAlwaysIncognitoEnabled,
 +                              /*default_value=*/false);
 +  HistoryTabHelper::RegisterProfilePrefs(registry);
- #else   // BUILDFLAG(IS_ANDROID)
-   autofill_assistant::AutofillAssistant::RegisterProfilePrefs(registry);
+ #else  // BUILDFLAG(IS_ANDROID)
    AppShortcutManager::RegisterProfilePrefs(registry);
+   browser_sync::ForeignSessionHandler::RegisterProfilePrefs(registry);
 diff --git a/chrome/browser/ui/android/native_page/BUILD.gn b/chrome/browser/ui/android/native_page/BUILD.gn
 --- a/chrome/browser/ui/android/native_page/BUILD.gn
 +++ b/chrome/browser/ui/android/native_page/BUILD.gn
@@ -1633,7 +1701,7 @@ diff --git a/chrome/browser/ui/android/native_page/java/src/org/chromium/chrome/
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -1151,6 +1151,37 @@ Your Google account may have other forms of browsing history like searches and a
+@@ -1177,6 +1177,37 @@ Your Google account may have other forms of browsing history like searches and a
        <message name="IDS_CLEAR_BROWSING_HISTORY_SUMMARY_SYNCED_NO_LINK" desc="A text for the basic tab explaining browsing history for users with history sync. This version is shown when the link to MyActivity is displayed separately.">
          Clears history from all synced devices.
        </message>
@@ -1671,6 +1739,55 @@ diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chro
        <message name="IDS_CLEAR_SEARCH_HISTORY_LINK" desc="Text informing the user that they can clear search history and other data using MyActivity.">
          <ph name="BEGIN_LINK1">&lt;link1&gt;</ph>Search history<ph name="END_LINK1">&lt;/link1&gt;</ph> and <ph name="BEGIN_LINK2">&lt;link2&gt;</ph>other forms of activity<ph name="END_LINK2">&lt;/link2&gt;</ph> may be saved in your Google Account when you’re signed in. You can delete them anytime.
        </message>
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/LocationBarModel.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/LocationBarModel.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/LocationBarModel.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/LocationBarModel.java
+@@ -178,6 +178,7 @@ public class LocationBarModel implements ToolbarDataProvider, LocationBarDataPro
+     protected GURL mVisibleGurl = GURL.emptyGURL();
+     protected String mFormattedFullUrl;
+     protected String mUrlForDisplay;
++    private boolean mIsAlwaysIncognito;
+ 
+     /**
+      * Default constructor for this class.
+@@ -192,7 +193,8 @@ public class LocationBarModel implements ToolbarDataProvider, LocationBarDataPro
+     public LocationBarModel(Context context, NewTabPageDelegate newTabPageDelegate,
+             @NonNull UrlFormatter urlFormatter, @NonNull ProfileProvider profileProvider,
+             @NonNull OfflineStatus offlineStatus,
+-            @NonNull SearchEngineLogoUtils searchEngineLogoUtils) {
++            @NonNull SearchEngineLogoUtils searchEngineLogoUtils,
++            boolean isAlwaysIncognito) {
+         mContext = context;
+         mNtpDelegate = newTabPageDelegate;
+         mUrlFormatter = urlFormatter;
+@@ -200,6 +202,7 @@ public class LocationBarModel implements ToolbarDataProvider, LocationBarDataPro
+         mOfflineStatus = offlineStatus;
+         mPrimaryColor = ChromeColors.getDefaultThemeColor(context, false);
+         mSearchEngineLogoUtils = searchEngineLogoUtils;
++        mIsAlwaysIncognito = isAlwaysIncognito;
+     }
+ 
+     /**
+@@ -429,6 +432,10 @@ public class LocationBarModel implements ToolbarDataProvider, LocationBarDataPro
+             if (mOptimizationsEnabled) {
+                 autocompleteSchemeClassifier = mChromeAutocompleteSchemeClassifier;
+                 cachedSpannableDisplayText = mSpannableDisplayTextCache.get(cacheKey);
++                if (mIsAlwaysIncognito) {
++                    // the profile may be destroyed and no longer be valid
++                    autocompleteSchemeClassifier = new ChromeAutocompleteSchemeClassifier(getProfile());
++                }
+             } else {
+                 autocompleteSchemeClassifier = new ChromeAutocompleteSchemeClassifier(getProfile());
+             }
+@@ -446,7 +453,7 @@ public class LocationBarModel implements ToolbarDataProvider, LocationBarDataPro
+                     }
+                 }
+             } finally {
+-                if (!mOptimizationsEnabled) {
++                if (!mOptimizationsEnabled || mIsAlwaysIncognito) {
+                     autocompleteSchemeClassifier.destroy();
+                 }
+             }
 diff --git a/chrome/browser/ui/messages/android/BUILD.gn b/chrome/browser/ui/messages/android/BUILD.gn
 --- a/chrome/browser/ui/messages/android/BUILD.gn
 +++ b/chrome/browser/ui/messages/android/BUILD.gn
@@ -1717,7 +1834,7 @@ new file mode 100644
 diff --git a/chrome/common/pref_names.cc b/chrome/common/pref_names.cc
 --- a/chrome/common/pref_names.cc
 +++ b/chrome/common/pref_names.cc
-@@ -3437,6 +3437,12 @@ const char kShowCaretBrowsingDialog[] =
+@@ -3458,6 +3458,12 @@ const char kShowCaretBrowsingDialog[] =
  const char kLacrosLaunchSwitch[] = "lacros_launch_switch";
  #endif
  
@@ -1733,7 +1850,7 @@ diff --git a/chrome/common/pref_names.cc b/chrome/common/pref_names.cc
 diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1214,6 +1214,8 @@ extern const char kDiscountConsentShowInterestIn[];
+@@ -1219,6 +1219,8 @@ extern const char kDiscountConsentShowInterestIn[];
  
  #if BUILDFLAG(IS_ANDROID)
  extern const char kWebXRImmersiveArEnabled[];
@@ -1742,7 +1859,7 @@ diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
  #endif
  
  #if !BUILDFLAG(IS_ANDROID)
-@@ -1251,6 +1253,10 @@ extern const char kPrivacyGuideViewed[];
+@@ -1256,6 +1258,10 @@ extern const char kPrivacyGuideViewed[];
  
  extern const char kCorsNonWildcardRequestHeadersSupport[];
  
@@ -1756,7 +1873,7 @@ diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
 diff --git a/components/content_settings/core/browser/content_settings_pref_provider.cc b/components/content_settings/core/browser/content_settings_pref_provider.cc
 --- a/components/content_settings/core/browser/content_settings_pref_provider.cc
 +++ b/components/content_settings/core/browser/content_settings_pref_provider.cc
-@@ -119,10 +119,12 @@ void PrefProvider::RegisterProfilePrefs(
+@@ -120,10 +120,12 @@ void PrefProvider::RegisterProfilePrefs(
  
  PrefProvider::PrefProvider(PrefService* prefs,
                             bool off_the_record,
@@ -1769,7 +1886,7 @@ diff --git a/components/content_settings/core/browser/content_settings_pref_prov
        store_last_modified_(store_last_modified),
        clock_(base::DefaultClock::GetInstance()) {
    TRACE_EVENT_BEGIN("startup", "PrefProvider::PrefProvider");
-@@ -156,7 +158,9 @@ PrefProvider::PrefProvider(PrefService* prefs,
+@@ -157,7 +159,9 @@ PrefProvider::PrefProvider(PrefService* prefs,
        content_settings_prefs_.insert(std::make_pair(
            info->type(), std::make_unique<ContentSettingsPref>(
                              info->type(), prefs_, &pref_change_registrar_,
@@ -1791,7 +1908,7 @@ diff --git a/components/content_settings/core/browser/content_settings_pref_prov
                 bool store_last_modified,
                 bool restore_session);
  
-@@ -88,6 +89,7 @@ class PrefProvider : public UserModifiableProvider {
+@@ -85,6 +86,7 @@ class PrefProvider : public UserModifiableProvider {
    raw_ptr<PrefService> prefs_;
  
    const bool off_the_record_;
@@ -1838,7 +1955,7 @@ diff --git a/components/content_settings/core/browser/host_content_settings_map.
                           bool store_last_modified,
                           bool restore_session);
  
-@@ -442,6 +443,8 @@ class HostContentSettingsMap : public content_settings::Observer,
+@@ -439,6 +440,8 @@ class HostContentSettingsMap : public content_settings::Observer,
    // Whether this settings map is for an incognito or guest session.
    bool is_off_the_record_;
  
@@ -1850,9 +1967,9 @@ diff --git a/components/content_settings/core/browser/host_content_settings_map.
 diff --git a/components/offline_pages/core/offline_page_feature.cc b/components/offline_pages/core/offline_page_feature.cc
 --- a/components/offline_pages/core/offline_page_feature.cc
 +++ b/components/offline_pages/core/offline_page_feature.cc
-@@ -44,6 +44,9 @@ const base::Feature kOfflineIndicatorFeature{"OfflineIndicator",
- const base::Feature kOfflinePagesNetworkStateLikelyUnknown{
-     "OfflinePagesNetworkStateLikelyUnknown", base::FEATURE_DISABLED_BY_DEFAULT};
+@@ -52,6 +52,9 @@ BASE_FEATURE(kOfflinePagesNetworkStateLikelyUnknown,
+              "OfflinePagesNetworkStateLikelyUnknown",
+              base::FEATURE_DISABLED_BY_DEFAULT);
  
 +const base::Feature kOfflinePagesAutoSaveFeature{
 +    "OfflinePagesAutoSaveEnabled", base::FEATURE_DISABLED_BY_DEFAULT};
@@ -1863,10 +1980,10 @@ diff --git a/components/offline_pages/core/offline_page_feature.cc b/components/
 diff --git a/components/offline_pages/core/offline_page_feature.h b/components/offline_pages/core/offline_page_feature.h
 --- a/components/offline_pages/core/offline_page_feature.h
 +++ b/components/offline_pages/core/offline_page_feature.h
-@@ -21,6 +21,7 @@ extern const base::Feature kOfflinePagesDescriptiveFailStatusFeature;
- extern const base::Feature kOfflineIndicatorFeature;
- extern const base::Feature kOnTheFlyMhtmlHashComputationFeature;
- extern const base::Feature kOfflinePagesNetworkStateLikelyUnknown;
+@@ -21,6 +21,7 @@ BASE_DECLARE_FEATURE(kOfflinePagesDescriptiveFailStatusFeature);
+ BASE_DECLARE_FEATURE(kOfflineIndicatorFeature);
+ BASE_DECLARE_FEATURE(kOnTheFlyMhtmlHashComputationFeature);
+ BASE_DECLARE_FEATURE(kOfflinePagesNetworkStateLikelyUnknown);
 +extern const base::Feature kOfflinePagesAutoSaveFeature;
  
  // The parameter name used to find the experiment tag for prefetching offline
@@ -1885,7 +2002,7 @@ diff --git a/components/omnibox/browser/autocomplete_provider_client.cc b/compon
 diff --git a/components/omnibox/browser/autocomplete_provider_client.h b/components/omnibox/browser/autocomplete_provider_client.h
 --- a/components/omnibox/browser/autocomplete_provider_client.h
 +++ b/components/omnibox/browser/autocomplete_provider_client.h
-@@ -125,6 +125,7 @@ class AutocompleteProviderClient : public OmniboxAction::Client {
+@@ -128,6 +128,7 @@ class AutocompleteProviderClient : public OmniboxAction::Client {
    virtual signin::IdentityManager* GetIdentityManager() const = 0;
  
    virtual bool IsOffTheRecord() const = 0;
@@ -1896,10 +2013,10 @@ diff --git a/components/omnibox/browser/autocomplete_provider_client.h b/compone
 diff --git a/components/omnibox/browser/base_search_provider.cc b/components/omnibox/browser/base_search_provider.cc
 --- a/components/omnibox/browser/base_search_provider.cc
 +++ b/components/omnibox/browser/base_search_provider.cc
-@@ -272,7 +272,7 @@ bool BaseSearchProvider::CanSendRequest(
+@@ -273,7 +273,7 @@ bool BaseSearchProvider::CanSendZeroSuggestRequest(
    }
  
-   // Don't run if in incognito mode.
+   // Don't make a suggest request if in incognito mode.
 -  if (client->IsOffTheRecord()) {
 +  if (client->IsOffTheRecord() && client->IsAlwaysIncognitoEnabled() == false) {
      return false;
@@ -1908,7 +2025,7 @@ diff --git a/components/omnibox/browser/base_search_provider.cc b/components/omn
 diff --git a/components/omnibox/browser/search_provider.cc b/components/omnibox/browser/search_provider.cc
 --- a/components/omnibox/browser/search_provider.cc
 +++ b/components/omnibox/browser/search_provider.cc
-@@ -836,7 +836,9 @@ bool SearchProvider::IsQuerySuitableForSuggest(bool* query_is_private) const {
+@@ -832,7 +832,9 @@ bool SearchProvider::IsQuerySuitableForSuggest(bool* query_is_private) const {
    // keyword input to a keyword suggest server, if any.)
    const TemplateURL* default_url = providers_.GetDefaultProviderURL();
    const TemplateURL* keyword_url = providers_.GetKeywordProviderURL();

--- a/build/patches/Add-kill-switch-for-unsupported-clangd-flags.patch
+++ b/build/patches/Add-kill-switch-for-unsupported-clangd-flags.patch
@@ -1,0 +1,43 @@
+From: Your Name <you@example.com>
+Date: Thu, 20 Oct 2022 09:34:48 +0000
+Subject: Add kill switch for unsupported clangd flags
+
+Allows build with clangd by suppressing unsupported parameters
+
+Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
+License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
+---
+ build/config/compiler/BUILD.gn | 5 +++++
+ build_overrides/build.gni      | 3 +++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -1580,6 +1580,11 @@ config("default_warnings") {
+           # TODO(crbug.com/1352183) Evaluate and possibly enable.
+           "-Wno-bitfield-constant-conversion",
+         ]
++        if (skip_clangd_unsupported_options) {
++          cflags -= [
++            "-Wno-deprecated-builtins",
++          ]
++        }
+       }
+     }
+   }
+diff --git a/build_overrides/build.gni b/build_overrides/build.gni
+--- a/build_overrides/build.gni
++++ b/build_overrides/build.gni
+@@ -42,6 +42,9 @@ declare_args() {
+   # Allows googletest to pretty-print various absl types.  Disabled for nacl due
+   # to lack of toolchain support.
+   gtest_enable_absl_printers = !is_nacl
++
++  # Allows clangd builds by suppressing unsupported parameters
++  skip_clangd_unsupported_options = false
+ }
+ 
+ # Allows different projects to specify their own suppression/ignore lists for
+--
+2.25.1

--- a/build/patches/Add-lifetime-options-for-permissions.patch
+++ b/build/patches/Add-lifetime-options-for-permissions.patch
@@ -181,7 +181,7 @@ diff --git a/chrome/browser/permissions/last_tab_standing_tracker_factory.cc b/c
 diff --git a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc b/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
 --- a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
 +++ b/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
-@@ -410,10 +410,7 @@ void ChromeBrowserMainExtraPartsProfiles::
+@@ -411,10 +411,7 @@ void ChromeBrowserMainExtraPartsProfiles::
    LacrosFirstRunServiceFactory::GetInstance();
  #endif
    LanguageModelManagerFactory::GetInstance();
@@ -196,9 +196,9 @@ diff --git a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
 diff --git a/chrome/browser/ui/tab_helpers.cc b/chrome/browser/ui/tab_helpers.cc
 --- a/chrome/browser/ui/tab_helpers.cc
 +++ b/chrome/browser/ui/tab_helpers.cc
-@@ -503,6 +503,7 @@ void TabHelpers::AttachTabHelpers(WebContents* web_contents) {
-         web_contents);
-   }
+@@ -491,6 +491,7 @@ void TabHelpers::AttachTabHelpers(WebContents* web_contents) {
+   PolicyAuditorBridge::CreateForWebContents(web_contents);
+   PluginObserverAndroid::CreateForWebContents(web_contents);
    video_tutorials::VideoTutorialTabHelper::CreateForWebContents(web_contents);
 +  LastTabStandingTrackerTabHelper::CreateForWebContents(web_contents);
  #else
@@ -250,15 +250,15 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SingleWebsiteSettings.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SingleWebsiteSettings.java
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SingleWebsiteSettings.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SingleWebsiteSettings.java
-@@ -34,6 +34,7 @@ import org.chromium.components.browser_ui.settings.ManagedPreferencesUtils;
- import org.chromium.components.browser_ui.settings.SettingsUtils;
+@@ -35,6 +35,7 @@ import org.chromium.components.browser_ui.settings.SettingsUtils;
+ import org.chromium.components.browser_ui.settings.TextMessagePreference;
  import org.chromium.components.content_settings.ContentSettingValues;
  import org.chromium.components.content_settings.ContentSettingsType;
 +import org.chromium.components.content_settings.SessionModel;
  import org.chromium.components.embedder_support.util.Origin;
  import org.chromium.content_public.browser.BrowserContextHandle;
  import org.chromium.content_public.browser.ContentFeatureList;
-@@ -528,6 +529,11 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
+@@ -537,6 +538,11 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
          }
      }
  
@@ -270,7 +270,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
      private void setUpClearDataPreference() {
          ClearWebsiteStorage preference = findPreference(PREF_CLEAR_DATA);
          long usage = mSite.getTotalUsage();
-@@ -926,6 +932,10 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
+@@ -955,6 +961,10 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
          if (contentType == mHighlightedPermission) {
              switchPreference.setBackgroundColor(mHighlightColor);
          }
@@ -292,7 +292,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
  import org.chromium.components.location.LocationUtils;
  import org.chromium.content_public.browser.BrowserContextHandle;
  import org.chromium.url.GURL;
-@@ -54,7 +55,8 @@ public class WebsitePreferenceBridge {
+@@ -55,7 +56,8 @@ public class WebsitePreferenceBridge {
  
      @CalledByNative
      private static void insertPermissionInfoIntoList(@ContentSettingsType int type,
@@ -302,7 +302,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
          if (type == ContentSettingsType.MEDIASTREAM_CAMERA
                  || type == ContentSettingsType.MEDIASTREAM_MIC) {
              for (PermissionInfo info : list) {
-@@ -63,7 +65,7 @@ public class WebsitePreferenceBridge {
+@@ -64,7 +66,7 @@ public class WebsitePreferenceBridge {
                  }
              }
          }
@@ -314,7 +314,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
 diff --git a/components/browser_ui/site_settings/android/website_preference_bridge.cc b/components/browser_ui/site_settings/android/website_preference_bridge.cc
 --- a/components/browser_ui/site_settings/android/website_preference_bridge.cc
 +++ b/components/browser_ui/site_settings/android/website_preference_bridge.cc
-@@ -120,7 +120,8 @@ typedef void (*InfoListInsertionFunction)(
+@@ -122,7 +122,8 @@ typedef void (*InfoListInsertionFunction)(
      const base::android::JavaRef<jobject>&,
      const base::android::JavaRef<jstring>&,
      const base::android::JavaRef<jstring>&,
@@ -324,7 +324,7 @@ diff --git a/components/browser_ui/site_settings/android/website_preference_brid
  
  void GetOrigins(JNIEnv* env,
                  const JavaParamRef<jobject>& jbrowser_context_handle,
-@@ -162,7 +163,7 @@ void GetOrigins(JNIEnv* env,
+@@ -164,7 +165,7 @@ void GetOrigins(JNIEnv* env,
      seen_origins.push_back(origin);
      insertionFunc(env, static_cast<int>(content_type), list,
                    ConvertOriginToJavaString(env, origin), jembedder,
@@ -333,7 +333,7 @@ diff --git a/components/browser_ui/site_settings/android/website_preference_brid
    }
  
    // Add any origins which have a default content setting value (thus skipped
-@@ -184,7 +185,7 @@ void GetOrigins(JNIEnv* env,
+@@ -186,7 +187,7 @@ void GetOrigins(JNIEnv* env,
        seen_origins.push_back(origin);
        insertionFunc(env, static_cast<int>(content_type), list,
                      ConvertOriginToJavaString(env, origin), jembedder,
@@ -345,7 +345,7 @@ diff --git a/components/browser_ui/site_settings/android/website_preference_brid
 diff --git a/components/browser_ui/strings/android/browser_ui_strings.grd b/components/browser_ui/strings/android/browser_ui_strings.grd
 --- a/components/browser_ui/strings/android/browser_ui_strings.grd
 +++ b/components/browser_ui/strings/android/browser_ui_strings.grd
-@@ -602,6 +602,11 @@
+@@ -606,6 +606,11 @@
        <message name="IDS_PAGE_INFO_URL_TRUNCATED" desc="Accessibility announcement when the URL in PageInfo switches from full to truncated display">
          URL truncated
        </message>
@@ -371,7 +371,7 @@ diff --git a/components/content_settings/android/BUILD.gn b/components/content_s
 diff --git a/components/content_settings/core/browser/content_settings_utils.cc b/components/content_settings/core/browser/content_settings_utils.cc
 --- a/components/content_settings/core/browser/content_settings_utils.cc
 +++ b/components/content_settings/core/browser/content_settings_utils.cc
-@@ -189,6 +189,35 @@ base::Time GetConstraintExpiration(const base::TimeDelta duration) {
+@@ -185,6 +185,35 @@ base::Time GetConstraintExpiration(const base::TimeDelta duration) {
    return base::Time::Now() + duration;
  }
  
@@ -492,7 +492,7 @@ diff --git a/components/page_info/android/java/src/org/chromium/components/page_
              }
          }
  
-@@ -124,13 +129,15 @@ public class PermissionParamsListBuilder {
+@@ -123,13 +128,15 @@ public class PermissionParamsListBuilder {
          public final String nameMidSentence;
          public final int type;
          public final @ContentSettingValues int setting;
@@ -512,7 +512,7 @@ diff --git a/components/page_info/android/java/src/org/chromium/components/page_
 diff --git a/components/page_info/android/page_info_controller_android.cc b/components/page_info/android/page_info_controller_android.cc
 --- a/components/page_info/android/page_info_controller_android.cc
 +++ b/components/page_info/android/page_info_controller_android.cc
-@@ -171,6 +171,8 @@ void PageInfoControllerAndroid::SetPermissionInfo(
+@@ -162,6 +162,8 @@ void PageInfoControllerAndroid::SetPermissionInfo(
  
    std::map<ContentSettingsType, ContentSetting>
        user_specified_settings_to_display;
@@ -521,7 +521,7 @@ diff --git a/components/page_info/android/page_info_controller_android.cc b/comp
  
    for (const auto& permission : permission_info_list) {
      if (base::Contains(permissions_to_display, permission.type)) {
-@@ -179,6 +181,8 @@ void PageInfoControllerAndroid::SetPermissionInfo(
+@@ -170,6 +172,8 @@ void PageInfoControllerAndroid::SetPermissionInfo(
        if (setting_to_display) {
          user_specified_settings_to_display[permission.type] =
              *setting_to_display;
@@ -530,7 +530,7 @@ diff --git a/components/page_info/android/page_info_controller_android.cc b/comp
        }
      }
    }
-@@ -195,7 +199,8 @@ void PageInfoControllerAndroid::SetPermissionInfo(
+@@ -186,7 +190,8 @@ void PageInfoControllerAndroid::SetPermissionInfo(
            ConvertUTF16ToJavaString(env, setting_title),
            ConvertUTF16ToJavaString(env, setting_title_mid_sentence),
            static_cast<jint>(permission),
@@ -540,7 +540,7 @@ diff --git a/components/page_info/android/page_info_controller_android.cc b/comp
      }
    }
  
-@@ -208,7 +213,8 @@ void PageInfoControllerAndroid::SetPermissionInfo(
+@@ -199,7 +204,8 @@ void PageInfoControllerAndroid::SetPermissionInfo(
          env, controller_jobject_, ConvertUTF16ToJavaString(env, object_title),
          ConvertUTF16ToJavaString(env, object_title),
          static_cast<jint>(chosen_object->ui_info.content_settings_type),
@@ -553,7 +553,7 @@ diff --git a/components/page_info/android/page_info_controller_android.cc b/comp
 diff --git a/components/page_info/page_info.cc b/components/page_info/page_info.cc
 --- a/components/page_info/page_info.cc
 +++ b/components/page_info/page_info.cc
-@@ -1151,6 +1151,8 @@ void PageInfo::PresentSitePermissions() {
+@@ -1168,6 +1168,8 @@ void PageInfo::PresentSitePermissions() {
      permission_info.source = info.source;
      permission_info.is_one_time = (info.metadata.session_model ==
                                     content_settings::SessionModel::OneTime);
@@ -771,7 +771,7 @@ diff --git a/components/permissions/android/permission_prompt/permission_dialog_
 diff --git a/components/permissions/android/permission_prompt/permission_prompt_android.cc b/components/permissions/android/permission_prompt/permission_prompt_android.cc
 --- a/components/permissions/android/permission_prompt/permission_prompt_android.cc
 +++ b/components/permissions/android/permission_prompt/permission_prompt_android.cc
-@@ -40,6 +40,14 @@ void PermissionPromptAndroid::Accept() {
+@@ -41,6 +41,14 @@ void PermissionPromptAndroid::Accept() {
    delegate_->Accept();
  }
  
@@ -958,7 +958,7 @@ diff --git a/components/permissions/contexts/geolocation_permission_context_andr
 diff --git a/components/permissions/permission_context_base.cc b/components/permissions/permission_context_base.cc
 --- a/components/permissions/permission_context_base.cc
 +++ b/components/permissions/permission_context_base.cc
-@@ -252,6 +252,20 @@ PermissionContextBase::CreatePermissionRequest(
+@@ -226,6 +226,20 @@ PermissionContextBase::CreatePermissionRequest(
        std::move(delete_callback));
  }
  
@@ -979,7 +979,7 @@ diff --git a/components/permissions/permission_context_base.cc b/components/perm
  PermissionResult PermissionContextBase::GetPermissionStatus(
      content::RenderFrameHost* render_frame_host,
      const GURL& requesting_origin,
-@@ -443,7 +457,8 @@ void PermissionContextBase::PermissionDecided(
+@@ -405,7 +419,8 @@ void PermissionContextBase::PermissionDecided(
      const GURL& embedding_origin,
      BrowserPermissionCallback callback,
      ContentSetting content_setting,
@@ -989,7 +989,7 @@ diff --git a/components/permissions/permission_context_base.cc b/components/perm
    DCHECK(content_setting == CONTENT_SETTING_ALLOW ||
           content_setting == CONTENT_SETTING_BLOCK ||
           content_setting == CONTENT_SETTING_DEFAULT);
-@@ -451,9 +466,9 @@ void PermissionContextBase::PermissionDecided(
+@@ -413,9 +428,9 @@ void PermissionContextBase::PermissionDecided(
                               content_setting);
  
    bool persist = content_setting != CONTENT_SETTING_DEFAULT;
@@ -1001,7 +1001,7 @@ diff --git a/components/permissions/permission_context_base.cc b/components/perm
  }
  
  content::BrowserContext* PermissionContextBase::browser_context() const {
-@@ -503,11 +518,26 @@ void PermissionContextBase::NotifyPermissionSet(
+@@ -465,11 +480,26 @@ void PermissionContextBase::NotifyPermissionSet(
      bool persist,
      ContentSetting content_setting,
      bool is_one_time) {
@@ -1029,7 +1029,7 @@ diff --git a/components/permissions/permission_context_base.cc b/components/perm
    }
  
    UpdateTabContext(id, requesting_origin,
-@@ -528,6 +558,15 @@ void PermissionContextBase::UpdateContentSetting(const GURL& requesting_origin,
+@@ -490,6 +520,15 @@ void PermissionContextBase::UpdateContentSetting(const GURL& requesting_origin,
                                                   const GURL& embedding_origin,
                                                   ContentSetting content_setting,
                                                   bool is_one_time) {
@@ -1045,7 +1045,7 @@ diff --git a/components/permissions/permission_context_base.cc b/components/perm
    DCHECK_EQ(requesting_origin, requesting_origin.DeprecatedGetOriginAsURL());
    DCHECK_EQ(embedding_origin, embedding_origin.DeprecatedGetOriginAsURL());
    DCHECK(content_setting == CONTENT_SETTING_ALLOW ||
-@@ -536,6 +575,8 @@ void PermissionContextBase::UpdateContentSetting(const GURL& requesting_origin,
+@@ -498,6 +537,8 @@ void PermissionContextBase::UpdateContentSetting(const GURL& requesting_origin,
    content_settings::ContentSettingConstraints constraints = {
        base::Time(), is_one_time ? content_settings::SessionModel::OneTime
                                  : content_settings::SessionModel::Durable};
@@ -1057,7 +1057,7 @@ diff --git a/components/permissions/permission_context_base.cc b/components/perm
 diff --git a/components/permissions/permission_context_base.h b/components/permissions/permission_context_base.h
 --- a/components/permissions/permission_context_base.h
 +++ b/components/permissions/permission_context_base.h
-@@ -141,6 +141,14 @@ class PermissionContextBase : public KeyedService,
+@@ -139,6 +139,14 @@ class PermissionContextBase : public content_settings::Observer {
  
    // Updates stored content setting if persist is set, updates tab indicators
    // and runs the callback to finish the request.
@@ -1072,7 +1072,7 @@ diff --git a/components/permissions/permission_context_base.h b/components/permi
    virtual void NotifyPermissionSet(const PermissionRequestID& id,
                                     const GURL& requesting_origin,
                                     const GURL& embedding_origin,
-@@ -161,6 +169,11 @@ class PermissionContextBase : public KeyedService,
+@@ -159,6 +167,11 @@ class PermissionContextBase : public content_settings::Observer {
    // Store the decided permission as a content setting.
    // virtual since the permission might be stored with different restrictions
    // (for example for desktop notifications).
@@ -1084,7 +1084,7 @@ diff --git a/components/permissions/permission_context_base.h b/components/permi
    virtual void UpdateContentSetting(const GURL& requesting_origin,
                                      const GURL& embedding_origin,
                                      ContentSetting content_setting,
-@@ -193,6 +206,14 @@ class PermissionContextBase : public KeyedService,
+@@ -191,6 +204,14 @@ class PermissionContextBase : public content_settings::Observer {
        PermissionRequest::PermissionDecidedCallback permission_decided_callback,
        base::OnceClosure delete_callback) const;
  
@@ -1099,7 +1099,7 @@ diff --git a/components/permissions/permission_context_base.h b/components/permi
    ContentSettingsType content_settings_type() const {
      return content_settings_type_;
    }
-@@ -219,7 +240,8 @@ class PermissionContextBase : public KeyedService,
+@@ -217,7 +238,8 @@ class PermissionContextBase : public content_settings::Observer {
                           const GURL& embedding_origin,
                           BrowserPermissionCallback callback,
                           ContentSetting content_setting,
@@ -1126,7 +1126,7 @@ diff --git a/components/permissions/permission_prompt.h b/components/permissions
 diff --git a/components/permissions/permission_request.cc b/components/permissions/permission_request.cc
 --- a/components/permissions/permission_request.cc
 +++ b/components/permissions/permission_request.cc
-@@ -30,6 +30,18 @@ PermissionRequest::PermissionRequest(
+@@ -31,6 +31,18 @@ PermissionRequest::PermissionRequest(
        permission_decided_callback_(std::move(permission_decided_callback)),
        delete_callback_(std::move(delete_callback)) {}
  
@@ -1145,7 +1145,7 @@ diff --git a/components/permissions/permission_request.cc b/components/permissio
  PermissionRequest::~PermissionRequest() {
    DCHECK(delete_callback_.is_null());
  }
-@@ -237,17 +249,35 @@ std::u16string PermissionRequest::GetMessageTextFragment() const {
+@@ -235,17 +247,35 @@ std::u16string PermissionRequest::GetMessageTextFragment() const {
  }
  #endif
  
@@ -1210,7 +1210,7 @@ diff --git a/components/permissions/permission_request.h b/components/permission
    PermissionRequest(const PermissionRequest&) = delete;
    PermissionRequest& operator=(const PermissionRequest&) = delete;
  
-@@ -97,10 +107,10 @@ class PermissionRequest {
+@@ -106,10 +116,10 @@ class PermissionRequest {
    // If |is_one_time| is true the permission will last until all tabs of
    // |origin| are closed or navigated away from, and then the permission will
    // automatically expire after 1 day.
@@ -1223,7 +1223,7 @@ diff --git a/components/permissions/permission_request.h b/components/permission
  
    // Called when the user has cancelled the permission request. This
    // corresponds to a denial, but is segregated in case the context needs to
-@@ -138,6 +148,9 @@ class PermissionRequest {
+@@ -147,6 +157,9 @@ class PermissionRequest {
    // Called once a decision is made about the permission.
    PermissionDecidedCallback permission_decided_callback_;
  
@@ -1236,7 +1236,7 @@ diff --git a/components/permissions/permission_request.h b/components/permission
 diff --git a/components/permissions/permission_request_manager.cc b/components/permissions/permission_request_manager.cc
 --- a/components/permissions/permission_request_manager.cc
 +++ b/components/permissions/permission_request_manager.cc
-@@ -156,7 +156,7 @@ void PermissionRequestManager::AddRequest(
+@@ -148,7 +148,7 @@ void PermissionRequestManager::AddRequest(
  
    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
            switches::kDenyPermissionPrompts)) {
@@ -1245,7 +1245,7 @@ diff --git a/components/permissions/permission_request_manager.cc b/components/p
      request->RequestFinished();
      return;
    }
-@@ -232,7 +232,7 @@ void PermissionRequestManager::AddRequest(
+@@ -224,7 +224,7 @@ void PermissionRequestManager::AddRequest(
    if (auto_approval_origin) {
      if (url::Origin::Create(request->requesting_origin()) ==
          auto_approval_origin.value()) {
@@ -1254,14 +1254,16 @@ diff --git a/components/permissions/permission_request_manager.cc b/components/p
      }
      request->RequestFinished();
      return;
-@@ -491,12 +491,13 @@ void PermissionRequestManager::Accept() {
-   for (requests_iter = requests_.begin(); requests_iter != requests_.end();
-        requests_iter++) {
+@@ -541,14 +541,15 @@ void PermissionRequestManager::Accept() {
+                                 (*requests_iter)->request_type(),
+                                 PermissionAction::GRANTED);
      PermissionGrantedIncludingDuplicates(*requests_iter,
 -                                         /*is_one_time=*/false);
 +                                         /*is_one_time=*/false,
 +                                         content_settings::LifetimeMode::Always);
    }
+ 
+   NotifyRequestDecided(PermissionAction::GRANTED);
    FinalizeCurrentRequests(PermissionAction::GRANTED);
  }
  
@@ -1270,15 +1272,17 @@ diff --git a/components/permissions/permission_request_manager.cc b/components/p
    if (ignore_callbacks_from_prompt_)
      return;
    DCHECK(view_);
-@@ -504,12 +505,22 @@ void PermissionRequestManager::AcceptThisTime() {
-   for (requests_iter = requests_.begin(); requests_iter != requests_.end();
-        requests_iter++) {
+@@ -559,7 +560,8 @@ void PermissionRequestManager::AcceptThisTime() {
+                                 (*requests_iter)->request_type(),
+                                 PermissionAction::GRANTED_ONCE);
      PermissionGrantedIncludingDuplicates(*requests_iter,
 -                                         /*is_one_time=*/true);
 +                                         /*is_one_time=*/true,
 +                                         mode);
    }
-   FinalizeCurrentRequests(PermissionAction::GRANTED_ONCE);
+ 
+   NotifyRequestDecided(PermissionAction::GRANTED_ONCE);
+@@ -567,6 +569,15 @@ void PermissionRequestManager::AcceptThisTime() {
  }
  
  void PermissionRequestManager::Deny() {
@@ -1294,16 +1298,16 @@ diff --git a/components/permissions/permission_request_manager.cc b/components/p
    if (ignore_callbacks_from_prompt_)
      return;
    DCHECK(view_);
-@@ -529,7 +540,7 @@ void PermissionRequestManager::Deny() {
-   std::vector<PermissionRequest*>::iterator requests_iter;
-   for (requests_iter = requests_.begin(); requests_iter != requests_.end();
-        requests_iter++) {
+@@ -589,7 +600,7 @@ void PermissionRequestManager::Deny() {
+     StorePermissionActionForUMA((*requests_iter)->requesting_origin(),
+                                 (*requests_iter)->request_type(),
+                                 PermissionAction::DENIED);
 -    PermissionDeniedIncludingDuplicates(*requests_iter);
 +    PermissionDeniedIncludingDuplicates(*requests_iter, is_one_time, lifetime_option);
    }
-   FinalizeCurrentRequests(PermissionAction::DENIED);
- }
-@@ -894,25 +905,25 @@ PermissionRequest* PermissionRequestManager::GetExistingRequest(
+ 
+   NotifyRequestDecided(PermissionAction::DENIED);
+@@ -967,25 +978,25 @@ PermissionRequest* PermissionRequestManager::GetExistingRequest(
  
  void PermissionRequestManager::PermissionGrantedIncludingDuplicates(
      PermissionRequest* request,
@@ -1335,7 +1339,7 @@ diff --git a/components/permissions/permission_request_manager.cc b/components/p
  }
  
  void PermissionRequestManager::CancelledIncludingDuplicates(
-@@ -1092,7 +1103,7 @@ void PermissionRequestManager::LogWarningToConsole(const char* message) {
+@@ -1187,7 +1198,7 @@ void PermissionRequestManager::LogWarningToConsole(const char* message) {
  void PermissionRequestManager::DoAutoResponseForTesting() {
    switch (auto_response_for_test_) {
      case ACCEPT_ONCE:
@@ -1347,7 +1351,7 @@ diff --git a/components/permissions/permission_request_manager.cc b/components/p
 diff --git a/components/permissions/permission_request_manager.h b/components/permissions/permission_request_manager.h
 --- a/components/permissions/permission_request_manager.h
 +++ b/components/permissions/permission_request_manager.h
-@@ -136,8 +136,10 @@ class PermissionRequestManager
+@@ -141,8 +141,10 @@ class PermissionRequestManager
    GURL GetRequestingOrigin() const override;
    GURL GetEmbeddingOrigin() const override;
    void Accept() override;
@@ -1359,7 +1363,7 @@ diff --git a/components/permissions/permission_request_manager.h b/components/pe
    void Dismiss() override;
    void Ignore() override;
    bool WasCurrentRequestAlreadyDisplayed() override;
-@@ -274,9 +276,12 @@ class PermissionRequestManager
+@@ -303,9 +305,12 @@ class PermissionRequestManager
  
    // Calls PermissionGranted on a request and all its duplicates.
    void PermissionGrantedIncludingDuplicates(PermissionRequest* request,

--- a/build/patches/Add-site-engagement-flag.patch
+++ b/build/patches/Add-site-engagement-flag.patch
@@ -21,7 +21,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -141,6 +141,7 @@
+@@ -142,6 +142,7 @@
  #include "components/segmentation_platform/public/features.h"
  #include "components/send_tab_to_self/features.h"
  #include "components/services/heap_profiling/public/cpp/switches.h"
@@ -29,7 +29,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
  #include "components/shared_highlighting/core/common/shared_highlighting_features.h"
  #include "components/signin/core/browser/dice_account_reconcilor_delegate.h"
  #include "components/signin/public/base/signin_buildflags.h"
-@@ -8966,6 +8967,11 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -9175,6 +9176,11 @@ const FeatureEntry kFeatureEntries[] = {
       flag_descriptions::kSearchReadyOmniboxDescription, kOsAndroid,
       FEATURE_VALUE_TYPE(chrome::android::kSearchReadyOmniboxFeature)},
  
@@ -44,7 +44,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
-@@ -3320,6 +3320,11 @@ const char kSkipServiceWorkerFetchHandlerDescription[] =
+@@ -3461,6 +3461,11 @@ const char kSkipServiceWorkerFetchHandlerDescription[] =
      "Skips starting the service worker and run the fetch handler if the fetch "
      "handler is recognized as skippable.";
  
@@ -59,15 +59,15 @@ diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descripti
 diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
 --- a/chrome/browser/flag_descriptions.h
 +++ b/chrome/browser/flag_descriptions.h
-@@ -1888,6 +1888,9 @@ extern const char kReduceUserAgentPlatformOsCpuDescription[];
- extern const char kSkipServiceWorkerFetchHandlerName[];
- extern const char kSkipServiceWorkerFetchHandlerDescription[];
+@@ -1969,6 +1969,9 @@ extern const char kReduceUserAgentMinorVersionDescription[];
+ extern const char kReduceUserAgentPlatformOsCpuName[];
+ extern const char kReduceUserAgentPlatformOsCpuDescription[];
  
 +extern const char kSiteEngagementName[];
 +extern const char kSiteEngagementDescription[];
 +
- extern const char kWebSQLAccessName[];
- extern const char kWebSQLAccessDescription[];
+ extern const char kSkipServiceWorkerFetchHandlerName[];
+ extern const char kSkipServiceWorkerFetchHandlerDescription[];
  
 diff --git a/components/site_engagement/content/site_engagement_score.cc b/components/site_engagement/content/site_engagement_score.cc
 --- a/components/site_engagement/content/site_engagement_score.cc

--- a/build/patches/Add-support-for-ISupportHelpAndFeedback.patch
+++ b/build/patches/Add-support-for-ISupportHelpAndFeedback.patch
@@ -12,7 +12,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsActivity.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsActivity.java
-@@ -66,6 +66,7 @@ import org.chromium.components.browser_ui.bottomsheet.BottomSheetControllerFacto
+@@ -67,6 +67,7 @@ import org.chromium.components.browser_ui.bottomsheet.BottomSheetControllerFacto
  import org.chromium.components.browser_ui.modaldialog.AppModalPresenter;
  import org.chromium.components.browser_ui.settings.FragmentSettingsLauncher;
  import org.chromium.components.browser_ui.settings.SettingsLauncher;
@@ -20,7 +20,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/Settin
  import org.chromium.components.browser_ui.site_settings.SiteSettingsPreferenceFragment;
  import org.chromium.components.browser_ui.widget.displaystyle.UiConfig;
  import org.chromium.components.browser_ui.widget.displaystyle.ViewResizer;
-@@ -329,9 +330,13 @@ public class SettingsActivity extends ChromeBaseAppCompatActivity
+@@ -333,9 +334,13 @@ public class SettingsActivity extends ChromeBaseAppCompatActivity
              finish();
              return true;
          } else if (item.getItemId() == R.id.menu_id_general_help) {

--- a/build/patches/Add-webGL-site-setting.patch
+++ b/build/patches/Add-webGL-site-setting.patch
@@ -214,11 +214,11 @@ diff --git a/components/components_strings.grd b/components/components_strings.g
 @@ -338,6 +338,7 @@
        <part file="version_ui_strings.grdp" />
        <part file="webapps_strings.grdp" />
- 
+       <part file="user_scripts/strings/userscripts_strings.grdp" />
 +      <part file="browser_ui/strings/android/webgl.grdp" />
+ 
        <if expr="not is_ios">
          <part file="history_clusters_strings.grdp" />
-       </if>
 diff --git a/components/content_settings/core/browser/content_settings_registry.cc b/components/content_settings/core/browser/content_settings_registry.cc
 --- a/components/content_settings/core/browser/content_settings_registry.cc
 +++ b/components/content_settings/core/browser/content_settings_registry.cc
@@ -414,7 +414,7 @@ diff --git a/third_party/blink/renderer/core/execution_context/execution_context
 diff --git a/third_party/blink/renderer/core/execution_context/execution_context.h b/third_party/blink/renderer/core/execution_context/execution_context.h
 --- a/third_party/blink/renderer/core/execution_context/execution_context.h
 +++ b/third_party/blink/renderer/core/execution_context/execution_context.h
-@@ -96,6 +96,7 @@ class SecurityOrigin;
+@@ -97,6 +97,7 @@ class SecurityOrigin;
  class ScriptState;
  class ScriptWrappable;
  class TrustedTypePolicyFactory;
@@ -422,7 +422,7 @@ diff --git a/third_party/blink/renderer/core/execution_context/execution_context
  
  enum ReasonForCallingCanExecuteScripts {
    kAboutToExecuteScript,
-@@ -104,6 +105,10 @@ enum ReasonForCallingCanExecuteScripts {
+@@ -105,6 +106,10 @@ enum ReasonForCallingCanExecuteScripts {
  
  enum ReferrerPolicySource { kPolicySourceHttpHeader, kPolicySourceMetaTag };
  

--- a/build/patches/Add-webRTC-site-settings.patch
+++ b/build/patches/Add-webRTC-site-settings.patch
@@ -209,12 +209,12 @@ diff --git a/components/components_strings.grd b/components/components_strings.g
 +++ b/components/components_strings.grd
 @@ -339,6 +339,7 @@
        <part file="webapps_strings.grdp" />
- 
+       <part file="user_scripts/strings/userscripts_strings.grdp" />
        <part file="browser_ui/strings/android/webgl.grdp" />
 +      <part file="browser_ui/strings/android/webrtc.grdp" />
+ 
        <if expr="not is_ios">
          <part file="history_clusters_strings.grdp" />
-       </if>
 diff --git a/components/content_settings/core/browser/content_settings_registry.cc b/components/content_settings/core/browser/content_settings_registry.cc
 --- a/components/content_settings/core/browser/content_settings_registry.cc
 +++ b/components/content_settings/core/browser/content_settings_registry.cc
@@ -385,7 +385,7 @@ diff --git a/third_party/blink/renderer/modules/peerconnection/peer_connection_d
  #include "third_party/blink/public/platform/web_url.h"
  #include "third_party/blink/public/web/modules/mediastream/media_stream_video_source.h"
  #include "third_party/blink/public/web/web_document.h"
-@@ -765,6 +766,11 @@ PeerConnectionDependencyFactory::CreatePortAllocator(
+@@ -767,6 +768,11 @@ PeerConnectionDependencyFactory::CreatePortAllocator(
        // origin.
        WebRTCIPHandlingPolicy policy =
            GetWebRTCIPHandlingPolicy(webrtc_ip_handling_policy);

--- a/build/patches/Ask-user-before-closing-all-tabs.patch
+++ b/build/patches/Ask-user-before-closing-all-tabs.patch
@@ -10,16 +10,16 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
 --- a/chrome/browser/flags/android/chrome_feature_list.cc
 +++ b/chrome/browser/flags/android/chrome_feature_list.cc
-@@ -514,8 +514,8 @@ const base::Feature kCastDeviceFilter{"CastDeviceFilter",
- const base::Feature kClearOmniboxFocusAfterNavigation{
-     "ClearOmniboxFocusAfterNavigation", base::FEATURE_DISABLED_BY_DEFAULT};
+@@ -543,8 +543,8 @@ BASE_FEATURE(kClearOmniboxFocusAfterNavigation,
+              base::FEATURE_DISABLED_BY_DEFAULT);
  
--const base::Feature kCloseTabSuggestions{"CloseTabSuggestions",
--                                         base::FEATURE_DISABLED_BY_DEFAULT};
-+const base::Feature kCloseTabSuggestions{"CloseTabSuggestions",               // Enabled by default in Bromite
-+                                         base::FEATURE_ENABLED_BY_DEFAULT};   // ^
+ BASE_FEATURE(kCloseTabSuggestions,
+-             "CloseTabSuggestions",
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             "CloseTabSuggestions",               // Enabled by default in Bromite
++             base::FEATURE_ENABLED_BY_DEFAULT);   // ^
  
- const base::Feature kCriticalPersistedTabData{
-     "CriticalPersistedTabData", base::FEATURE_DISABLED_BY_DEFAULT};
+ BASE_FEATURE(kCriticalPersistedTabData,
+              "CriticalPersistedTabData",
 --
 2.25.1

--- a/build/patches/Bromite-auto-updater.patch
+++ b/build/patches/Bromite-auto-updater.patch
@@ -24,13 +24,13 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../endpoint_fetcher_android.cc               |  52 +++-
  .../endpoint_fetcher/EndpointFetcher.java     |  22 +-
  .../EndpointHeaderResponse.java               |  31 +++
- .../flags/android/chrome_feature_list.cc      |   4 +
+ .../flags/android/chrome_feature_list.cc      |   5 +
  .../flags/android/chrome_feature_list.h       |   1 +
  .../browser/flags/ChromeFeatureList.java      |   1 +
  .../strings/android_chrome_strings.grd        |  23 +-
  .../endpoint_fetcher/endpoint_fetcher.cc      | 102 +++++++-
  .../endpoint_fetcher/endpoint_fetcher.h       |  22 +-
- 23 files changed, 896 insertions(+), 53 deletions(-)
+ 23 files changed, 897 insertions(+), 53 deletions(-)
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/omaha/inline/BromiteInlineUpdateController.java
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/omaha/inline/InlineUpdateController.java
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/omaha/inline/InlineUpdateControllerFactory.java
@@ -49,7 +49,7 @@ diff --git a/build/android/java/templates/BuildConfig.template b/build/android/j
 diff --git a/build/config/android/rules.gni b/build/config/android/rules.gni
 --- a/build/config/android/rules.gni
 +++ b/build/config/android/rules.gni
-@@ -2183,6 +2183,9 @@ if (enable_java_templates) {
+@@ -2242,6 +2242,9 @@ if (enable_java_templates) {
        if (defined(testonly) && testonly) {
          defines += [ "_IS_FOR_TEST" ]
        }
@@ -62,7 +62,7 @@ diff --git a/build/config/android/rules.gni b/build/config/android/rules.gni
 diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java_sources.gni
 --- a/chrome/android/chrome_java_sources.gni
 +++ b/chrome/android/chrome_java_sources.gni
-@@ -811,6 +811,9 @@ chrome_java_sources = [
+@@ -814,6 +814,9 @@ chrome_java_sources = [
    "java/src/org/chromium/chrome/browser/omaha/UpdateConfigs.java",
    "java/src/org/chromium/chrome/browser/omaha/UpdateMenuItemHelper.java",
    "java/src/org/chromium/chrome/browser/omaha/UpdateStatusProvider.java",
@@ -1250,7 +1250,7 @@ new file mode 100644
 diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
 --- a/chrome/browser/flags/android/chrome_feature_list.cc
 +++ b/chrome/browser/flags/android/chrome_feature_list.cc
-@@ -255,6 +255,7 @@ const base::Feature* const kFeaturesExposedToJava[] = {
+@@ -263,6 +263,7 @@ const base::Feature* const kFeaturesExposedToJava[] = {
      &kNewWindowAppMenu,
      &kNotificationPermissionVariant,
      &kPageAnnotationsService,
@@ -1258,31 +1258,32 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browse
      &kBookmarksImprovedSaveFlow,
      &kBookmarksRefresh,
      &kBackGestureRefactorAndroid,
-@@ -692,6 +693,9 @@ const base::Feature kIncognitoReauthenticationForAndroid{
- const base::Feature kIncognitoScreenshot{"IncognitoScreenshot",
-                                          base::FEATURE_DISABLED_BY_DEFAULT};
+@@ -810,6 +811,10 @@ BASE_FEATURE(kIncognitoScreenshot,
+              "IncognitoScreenshot",
+              base::FEATURE_DISABLED_BY_DEFAULT);
  
-+const base::Feature kInlineUpdateFlow{"InlineUpdateFlow",
-+                                      base::FEATURE_ENABLED_BY_DEFAULT};
++BASE_FEATURE(kInlineUpdateFlow,
++             "InlineUpdateFlow",
++             base::FEATURE_ENABLED_BY_DEFAULT);
 +
- const base::Feature kInfobarScrollOptimization{
-     "InfobarScrollOptimization", base::FEATURE_DISABLED_BY_DEFAULT};
- 
+ BASE_FEATURE(kInfobarScrollOptimization,
+              "InfobarScrollOptimization",
+              base::FEATURE_DISABLED_BY_DEFAULT);
 diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser/flags/android/chrome_feature_list.h
 --- a/chrome/browser/flags/android/chrome_feature_list.h
 +++ b/chrome/browser/flags/android/chrome_feature_list.h
-@@ -93,6 +93,7 @@ extern const base::Feature kGridTabSwitcherForTablets;
- extern const base::Feature kHandleMediaIntents;
- extern const base::Feature kImmersiveUiMode;
- extern const base::Feature kIncognitoReauthenticationForAndroid;
-+extern const base::Feature kInlineUpdateFlow;
- extern const base::Feature kIncognitoScreenshot;
- extern const base::Feature kInfobarScrollOptimization;
- extern const base::Feature kImprovedA2HS;
+@@ -102,6 +102,7 @@ BASE_DECLARE_FEATURE(kHandleMediaIntents);
+ BASE_DECLARE_FEATURE(kImmersiveUiMode);
+ BASE_DECLARE_FEATURE(kIncognitoReauthenticationForAndroid);
+ BASE_DECLARE_FEATURE(kIncognitoScreenshot);
++BASE_DECLARE_FEATURE(kInlineUpdateFlow);
+ BASE_DECLARE_FEATURE(kInfobarScrollOptimization);
+ BASE_DECLARE_FEATURE(kImprovedA2HS);
+ BASE_DECLARE_FEATURE(kInstanceSwitcher);
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
-@@ -383,6 +383,7 @@ public abstract class ChromeFeatureList {
+@@ -387,6 +387,7 @@ public abstract class ChromeFeatureList {
              "IncognitoReauthenticationForAndroid";
      public static final String INCOGNITO_SCREENSHOT = "IncognitoScreenshot";
      public static final String INFOBAR_SCROLL_OPTIMIZATION = "InfobarScrollOptimization";
@@ -1293,7 +1294,7 @@ diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/f
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -1893,6 +1893,12 @@ Your Google account may have other forms of browsing history like searches and a
+@@ -1888,6 +1888,12 @@ Your Google account may have other forms of browsing history like searches and a
        <message name="IDS_DEPRECATION_WARNING" desc="Warning about Chrome updates no longer being supported">
          Chrome updates are no longer supported for this version of Android
        </message>
@@ -1306,7 +1307,7 @@ diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chro
  
        <!-- Account management UI strings. -->
        <message name="IDS_ACCOUNT_MANAGEMENT_TITLE" desc="Header title for the account management screen. [CHAR_LIMIT=32]">
-@@ -3528,7 +3534,10 @@ To change this setting, <ph name="BEGIN_LINK">&lt;resetlink&gt;</ph>reset sync<p
+@@ -3504,7 +3510,10 @@ To change this setting, <ph name="BEGIN_LINK">&lt;resetlink&gt;</ph>reset sync<p
  
        <!-- Main menu items -->
        <message name="IDS_MENU_UPDATE" desc="Menu item for updating chrome. [CHAR_LIMIT=24]">
@@ -1318,7 +1319,7 @@ diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chro
        </message>
        <message name="IDS_MENU_UPDATE_SUMMARY_DEFAULT" desc="Summary string for update menu item explaining that a newer version of Chrome is available. [CHAR_LIMIT=30]">
          Newer version is available
-@@ -3539,6 +3548,18 @@ To change this setting, <ph name="BEGIN_LINK">&lt;resetlink&gt;</ph>reset sync<p
+@@ -3515,6 +3524,18 @@ To change this setting, <ph name="BEGIN_LINK">&lt;resetlink&gt;</ph>reset sync<p
        <message name="IDS_MENU_UPDATE_UNSUPPORTED_SUMMARY_DEFAULT" desc="Summary string for update menu item explaining that the Android version on the device is unsupported. [CHAR_LIMIT=30]">
          Android version is unsupported
        </message>

--- a/build/patches/Clamp-time-resolution-in-requestAnimationFrame.patch
+++ b/build/patches/Clamp-time-resolution-in-requestAnimationFrame.patch
@@ -14,17 +14,17 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/third_party/blink/renderer/core/animation_frame/worker_animation_frame_provider.cc b/third_party/blink/renderer/core/animation_frame/worker_animation_frame_provider.cc
 --- a/third_party/blink/renderer/core/animation_frame/worker_animation_frame_provider.cc
 +++ b/third_party/blink/renderer/core/animation_frame/worker_animation_frame_provider.cc
-@@ -7,7 +7,9 @@
- #include "base/trace_event/trace_event.h"
+@@ -8,7 +8,9 @@
+ #include "third_party/blink/renderer/core/execution_context/agent.h"
  #include "third_party/blink/renderer/core/offscreencanvas/offscreen_canvas.h"
  #include "third_party/blink/renderer/core/timing/worker_global_scope_performance.h"
 +#include "third_party/blink/renderer/core/workers/worker_global_scope.h"
- #include "third_party/blink/renderer/platform/bindings/microtask.h"
+ #include "third_party/blink/renderer/platform/scheduler/public/event_loop.h"
 +#include "third_party/blink/renderer/platform/wtf/casting.h"
  #include "third_party/blink/renderer/platform/wtf/cross_thread_functional.h"
  
  namespace blink {
-@@ -62,7 +64,11 @@ void WorkerAnimationFrameProvider::BeginFrame(const viz::BeginFrameArgs& args) {
+@@ -63,7 +65,11 @@ void WorkerAnimationFrameProvider::BeginFrame(const viz::BeginFrameArgs& args) {
              }
            }
  

--- a/build/patches/Content-settings-infrastructure.patch
+++ b/build/patches/Content-settings-infrastructure.patch
@@ -42,8 +42,8 @@ diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/b
 --- a/components/browser_ui/site_settings/android/BUILD.gn
 +++ b/components/browser_ui/site_settings/android/BUILD.gn
 @@ -88,6 +88,10 @@ android_library("java") {
-     "java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java",
      "java/src/org/chromium/components/browser_ui/site_settings/WebsiteRowPreference.java",
+     "java/src/org/chromium/components/browser_ui/site_settings/TimezoneOverrideSiteSettingsPreference.java"
    ]
 +  sources += [
 +    "java/src/org/chromium/components/browser_ui/site_settings/BromiteCustomContentSettingImpl.java",
@@ -763,7 +763,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SingleWebsiteSettings.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SingleWebsiteSettings.java
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SingleWebsiteSettings.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SingleWebsiteSettings.java
-@@ -42,6 +42,7 @@ import org.chromium.content_public.browser.ContentFeatureList;
+@@ -43,6 +43,7 @@ import org.chromium.content_public.browser.ContentFeatureList;
  import java.util.Collection;
  import java.util.HashMap;
  import java.util.Map;
@@ -771,7 +771,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
  
  /**
   * Shows the permissions and other settings for a particular website.
-@@ -171,7 +172,7 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
+@@ -172,7 +173,7 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
              case ContentSettingsType.CLIPBOARD_READ_WRITE:
                  return "clipboard_permission_list";
              default:
@@ -780,7 +780,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
          }
      }
  
-@@ -504,7 +505,8 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
+@@ -505,7 +506,8 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
  
      private void setupContentSettingsPreferences() {
          mMaxPermissionOrder = findPreference(PREF_PERMISSIONS_HEADER).getOrder();
@@ -818,7 +818,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
          switchPreference.setOnPreferenceChangeListener(this);
          @ContentSettingsType
          int contentType = getContentSettingsTypeFromPreferenceKey(preference.getKey());
-@@ -1206,7 +1214,7 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
+@@ -1216,7 +1224,7 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
          }
  
          mSite.setContentSetting(browserContextHandle, type, permission);
@@ -929,7 +929,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
-@@ -277,6 +277,10 @@ public final class Website implements WebsiteEntry {
+@@ -282,6 +282,10 @@ public final class Website implements WebsiteEntry {
                          /*isEmbargoed=*/false);
                  setContentSettingException(type, exception);
              }
@@ -955,7 +955,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java
-@@ -246,7 +246,7 @@ public class WebsitePreferenceBridge {
+@@ -248,7 +248,7 @@ public class WebsitePreferenceBridge {
              case ContentSettingsType.TIMEZONE_OVERRIDE:
                  return true;
              default:
@@ -1120,7 +1120,7 @@ diff --git a/components/content_settings/core/browser/website_settings_registry.
 diff --git a/components/page_info/android/java/src/org/chromium/components/page_info/PermissionParamsListBuilder.java b/components/page_info/android/java/src/org/chromium/components/page_info/PermissionParamsListBuilder.java
 --- a/components/page_info/android/java/src/org/chromium/components/page_info/PermissionParamsListBuilder.java
 +++ b/components/page_info/android/java/src/org/chromium/components/page_info/PermissionParamsListBuilder.java
-@@ -104,6 +104,7 @@ public class PermissionParamsListBuilder {
+@@ -109,6 +109,7 @@ public class PermissionParamsListBuilder {
                  permissionParams.allowed = true;
                  break;
              case ContentSettingValues.BLOCK:
@@ -1153,8 +1153,8 @@ diff --git a/components/page_info/android/page_info_controller_android.cc b/comp
 +
    std::map<ContentSettingsType, ContentSetting>
        user_specified_settings_to_display;
- 
-@@ -236,6 +245,15 @@ absl::optional<ContentSetting> PageInfoControllerAndroid::GetSettingToDisplay(
+   std::map<ContentSettingsType, bool>
+@@ -242,6 +251,15 @@ absl::optional<ContentSetting> PageInfoControllerAndroid::GetSettingToDisplay(
      // The images content setting should show up if it is blocked globally
      // to give users an easy way to create exceptions.
      return permission.default_setting;
@@ -1173,14 +1173,14 @@ diff --git a/components/page_info/android/page_info_controller_android.cc b/comp
 diff --git a/components/page_info/page_info.cc b/components/page_info/page_info.cc
 --- a/components/page_info/page_info.cc
 +++ b/components/page_info/page_info.cc
-@@ -24,6 +24,7 @@
- #include "components/browser_ui/util/android/url_constants.h"
+@@ -25,6 +25,7 @@
  #include "components/browsing_data/content/local_storage_helper.h"
  #include "components/content_settings/browser/page_specific_content_settings.h"
-+#include "components/content_settings/core/browser/website_settings_registry.h"
  #include "components/content_settings/browser/ui/cookie_controls_controller.h"
++#include "components/content_settings/core/browser/website_settings_registry.h"
  #include "components/content_settings/core/browser/content_settings_registry.h"
  #include "components/content_settings/core/browser/content_settings_utils.h"
+ #include "components/content_settings/core/browser/host_content_settings_map.h"
 @@ -167,6 +168,15 @@ bool ShouldShowPermission(const PageInfo::PermissionInfo& info,
      return true;
    }

--- a/build/patches/Disable-Accessibility-service-by-default.patch
+++ b/build/patches/Disable-Accessibility-service-by-default.patch
@@ -14,7 +14,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -1500,6 +1500,12 @@ Your Google account may have other forms of browsing history like searches and a
+@@ -1503,6 +1503,12 @@ Your Google account may have other forms of browsing history like searches and a
        <message name="IDS_SAFETY_CHECK_BUTTON" desc="Text for the button to start Safety check.">
          Check now
        </message>
@@ -58,7 +58,7 @@ diff --git a/components/browser_ui/accessibility/android/java/src/org/chromium/c
 diff --git a/content/public/android/java/src/org/chromium/content/browser/accessibility/WebContentsAccessibilityImpl.java b/content/public/android/java/src/org/chromium/content/browser/accessibility/WebContentsAccessibilityImpl.java
 --- a/content/public/android/java/src/org/chromium/content/browser/accessibility/WebContentsAccessibilityImpl.java
 +++ b/content/public/android/java/src/org/chromium/content/browser/accessibility/WebContentsAccessibilityImpl.java
-@@ -829,6 +829,11 @@ public class WebContentsAccessibilityImpl extends AccessibilityNodeProviderCompa
+@@ -899,6 +899,11 @@ public class WebContentsAccessibilityImpl extends AccessibilityNodeProviderCompa
              structure.setChildCount(0);
              return;
          }

--- a/build/patches/Disable-FLoC-and-privacy-sandbox.patch
+++ b/build/patches/Disable-FLoC-and-privacy-sandbox.patch
@@ -41,9 +41,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
      private static final String PREF_DO_NOT_TRACK = "do_not_track";
      private static final String PREF_CLEAR_BROWSING_DATA = "clear_browsing_data";
 -    private static final String PREF_PRIVACY_SANDBOX = "privacy_sandbox";
+     private static final String PREF_PROXY_OPTIONS = "proxy";
      private static final String PREF_PRIVACY_GUIDE = "privacy_guide";
      private static final String PREF_INCOGNITO_LOCK = "incognito_lock";
- 
 @@ -86,21 +85,6 @@ public class PrivacySettings
          SettingsUtils.addPreferencesFromResource(this, R.xml.privacy_preferences);
          getActivity().setTitle(R.string.prefs_privacy_security);
@@ -82,7 +82,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
 diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -3060,6 +3060,9 @@ bool ChromeContentBrowserClient::IsAttributionReportingOperationAllowed(
+@@ -3091,6 +3091,9 @@ bool ChromeContentBrowserClient::IsAttributionReportingOperationAllowed(
      const url::Origin* source_origin,
      const url::Origin* destination_origin,
      const url::Origin* reporting_origin) {
@@ -95,7 +95,7 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
 diff --git a/components/history/core/browser/history_backend.cc b/components/history/core/browser/history_backend.cc
 --- a/components/history/core/browser/history_backend.cc
 +++ b/components/history/core/browser/history_backend.cc
-@@ -493,18 +493,7 @@ void HistoryBackend::SetBrowsingTopicsAllowed(ContextID context_id,
+@@ -495,18 +495,7 @@ void HistoryBackend::SetBrowsingTopicsAllowed(ContextID context_id,
    if (!visit_id)
      return;
  
@@ -118,7 +118,7 @@ diff --git a/components/history/core/browser/history_backend.cc b/components/his
 diff --git a/components/privacy_sandbox/privacy_sandbox_prefs.cc b/components/privacy_sandbox/privacy_sandbox_prefs.cc
 --- a/components/privacy_sandbox/privacy_sandbox_prefs.cc
 +++ b/components/privacy_sandbox/privacy_sandbox_prefs.cc
-@@ -63,7 +63,7 @@ namespace privacy_sandbox {
+@@ -66,7 +66,7 @@ namespace privacy_sandbox {
  
  void RegisterProfilePrefs(PrefRegistrySimple* registry) {
    registry->RegisterBooleanPref(
@@ -130,7 +130,7 @@ diff --git a/components/privacy_sandbox/privacy_sandbox_prefs.cc b/components/pr
 diff --git a/components/privacy_sandbox/privacy_sandbox_settings.cc b/components/privacy_sandbox/privacy_sandbox_settings.cc
 --- a/components/privacy_sandbox/privacy_sandbox_settings.cc
 +++ b/components/privacy_sandbox/privacy_sandbox_settings.cc
-@@ -67,8 +67,7 @@ PrivacySandboxSettings::PrivacySandboxSettings(
+@@ -68,8 +68,7 @@ PrivacySandboxSettings::PrivacySandboxSettings(
      : delegate_(std::move(delegate)),
        host_content_settings_map_(host_content_settings_map),
        cookie_settings_(cookie_settings),
@@ -140,7 +140,7 @@ diff --git a/components/privacy_sandbox/privacy_sandbox_settings.cc b/components
    DCHECK(pref_service_);
    DCHECK(host_content_settings_map_);
    DCHECK(cookie_settings_);
-@@ -88,7 +87,8 @@ PrivacySandboxSettings::PrivacySandboxSettings(
+@@ -94,7 +93,8 @@ PrivacySandboxSettings::PrivacySandboxSettings(
  
  PrivacySandboxSettings::~PrivacySandboxSettings() = default;
  
@@ -150,7 +150,7 @@ diff --git a/components/privacy_sandbox/privacy_sandbox_settings.cc b/components
    // Topics API calculation should be prevented if the user has blocked 3PC
    // cookies, as there will be no context specific check.
    const auto cookie_controls_mode =
-@@ -113,7 +113,8 @@ bool PrivacySandboxSettings::IsTopicsAllowedForContext(
+@@ -119,7 +119,8 @@ bool PrivacySandboxSettings::IsTopicsAllowedForContext(
           IsPrivacySandboxEnabledForContext(url, top_frame_origin);
  }
  
@@ -160,7 +160,7 @@ diff --git a/components/privacy_sandbox/privacy_sandbox_settings.cc b/components
    const auto& blocked_topics =
        pref_service_->GetList(prefs::kPrivacySandboxBlockedTopics);
  
-@@ -181,9 +182,8 @@ base::Time PrivacySandboxSettings::TopicsDataAccessibleSince() const {
+@@ -187,9 +188,8 @@ base::Time PrivacySandboxSettings::TopicsDataAccessibleSince() const {
  
  bool PrivacySandboxSettings::IsAttributionReportingAllowed(
      const url::Origin& top_frame_origin,
@@ -172,17 +172,17 @@ diff --git a/components/privacy_sandbox/privacy_sandbox_settings.cc b/components
  }
  
  bool PrivacySandboxSettings::MaySendAttributionReport(
-@@ -277,7 +277,8 @@ void PrivacySandboxSettings::ClearFledgeJoiningAllowedSettings(
+@@ -278,7 +278,8 @@ void PrivacySandboxSettings::ClearFledgeJoiningAllowedSettings(
  }
  
  bool PrivacySandboxSettings::IsFledgeJoiningAllowed(
 -    const url::Origin& top_frame_origin) const {
 +    const url::Origin& top_frame_origin) const { // disabled in Bromite
 +  if ((true)) return false;
-   DictionaryPrefUpdate scoped_pref_update(
+   ScopedDictPrefUpdate scoped_pref_update(
        pref_service_, prefs::kPrivacySandboxFledgeJoinBlocked);
-   auto* pref_data = scoped_pref_update.Get();
-@@ -335,7 +336,9 @@ bool PrivacySandboxSettings::IsPrivateAggregationAllowed(
+   auto& pref_data = scoped_pref_update.Get();
+@@ -334,7 +335,9 @@ bool PrivacySandboxSettings::IsPrivateAggregationAllowed(
                                             top_frame_origin);
  }
  
@@ -193,7 +193,7 @@ diff --git a/components/privacy_sandbox/privacy_sandbox_settings.cc b/components
    // If the delegate is restricting access the Privacy Sandbox is disabled.
    if (delegate_->IsPrivacySandboxRestricted())
      return false;
-@@ -350,7 +353,7 @@ bool PrivacySandboxSettings::IsPrivacySandboxEnabled() const {
+@@ -349,7 +352,7 @@ bool PrivacySandboxSettings::IsPrivacySandboxEnabled() const {
    // settings is available.
    if (base::FeatureList::IsEnabled(privacy_sandbox::kPrivacySandboxSettings3)) {
      // For Privacy Sandbox Settings 3, APIs are disabled in incognito.
@@ -202,7 +202,7 @@ diff --git a/components/privacy_sandbox/privacy_sandbox_settings.cc b/components
        return false;
  
      if (should_override_setting_for_local_testing) {
-@@ -368,7 +371,8 @@ bool PrivacySandboxSettings::IsPrivacySandboxEnabled() const {
+@@ -367,7 +370,8 @@ bool PrivacySandboxSettings::IsPrivacySandboxEnabled() const {
    return pref_service_->GetBoolean(prefs::kPrivacySandboxApisEnabled);
  }
  
@@ -212,7 +212,7 @@ diff --git a/components/privacy_sandbox/privacy_sandbox_settings.cc b/components
    // Only apply the decision to the appropriate preference.
    if (base::FeatureList::IsEnabled(privacy_sandbox::kPrivacySandboxSettings3)) {
      pref_service_->SetBoolean(prefs::kPrivacySandboxApisEnabledV2, enabled);
-@@ -377,7 +381,8 @@ void PrivacySandboxSettings::SetPrivacySandboxEnabled(bool enabled) {
+@@ -376,7 +380,8 @@ void PrivacySandboxSettings::SetPrivacySandboxEnabled(bool enabled) {
    }
  }
  
@@ -222,7 +222,7 @@ diff --git a/components/privacy_sandbox/privacy_sandbox_settings.cc b/components
    // The PrivacySandboxSettings is only involved in Trust Token access
    // decisions when the Release 3 flag is enabled.
    if (!base::FeatureList::IsEnabled(privacy_sandbox::kPrivacySandboxSettings3))
-@@ -432,9 +437,9 @@ bool PrivacySandboxSettings::IsPrivacySandboxEnabledForContext(
+@@ -441,9 +446,9 @@ bool PrivacySandboxSettings::IsPrivacySandboxEnabledForContext(
        content_settings::CookieSettings::QueryReason::kPrivacySandbox);
  }
  
@@ -238,7 +238,7 @@ diff --git a/components/privacy_sandbox/privacy_sandbox_settings.cc b/components
 diff --git a/components/privacy_sandbox/privacy_sandbox_settings.h b/components/privacy_sandbox/privacy_sandbox_settings.h
 --- a/components/privacy_sandbox/privacy_sandbox_settings.h
 +++ b/components/privacy_sandbox/privacy_sandbox_settings.h
-@@ -220,7 +220,6 @@ class PrivacySandboxSettings : public KeyedService {
+@@ -227,7 +227,6 @@ class PrivacySandboxSettings : public KeyedService {
    scoped_refptr<content_settings::CookieSettings> cookie_settings_;
    raw_ptr<PrefService> pref_service_;
    PrefChangeRegistrar pref_change_registrar_;

--- a/build/patches/Disable-TLS-resumption.patch
+++ b/build/patches/Disable-TLS-resumption.patch
@@ -28,18 +28,18 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  chrome/browser/about_flags.cc        |  6 +++
  chrome/browser/flag_descriptions.cc  |  8 ++++
  chrome/browser/flag_descriptions.h   |  6 +++
- net/base/features.cc                 |  6 +++
+ net/base/features.cc                 |  8 ++++
  net/base/features.h                  |  6 +++
  net/http/http_network_session.cc     |  1 +
  net/quic/quic_stream_factory.cc      | 35 ++++++++++++++++-
  net/socket/ssl_client_socket_impl.cc | 59 ++++++++++++++++++++++++++++
  net/socket/ssl_client_socket_impl.h  |  2 +
- 9 files changed, 128 insertions(+), 1 deletion(-)
+ 9 files changed, 130 insertions(+), 1 deletion(-)
 
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -4896,6 +4896,12 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -5021,6 +5021,12 @@ const FeatureEntry kFeatureEntries[] = {
      {"enable-tls13-early-data", flag_descriptions::kEnableTLS13EarlyDataName,
       flag_descriptions::kEnableTLS13EarlyDataDescription, kOsAll,
       FEATURE_VALUE_TYPE(net::features::kEnableTLS13EarlyData)},
@@ -55,7 +55,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
-@@ -1015,6 +1015,14 @@ const char kEnableTLS13EarlyDataDescription[] =
+@@ -1036,6 +1036,14 @@ const char kEnableTLS13EarlyDataDescription[] =
      "during the handshake when resuming a connection to a compatible TLS 1.3 "
      "server.";
  
@@ -73,7 +73,7 @@ diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descripti
 diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
 --- a/chrome/browser/flag_descriptions.h
 +++ b/chrome/browser/flag_descriptions.h
-@@ -580,6 +580,12 @@ extern const char kEnablePreinstalledWebAppDuplicationFixerDescription[];
+@@ -592,6 +592,12 @@ extern const char kEnablePreinstalledWebAppDuplicationFixerDescription[];
  extern const char kEnableTLS13EarlyDataName[];
  extern const char kEnableTLS13EarlyDataDescription[];
  
@@ -89,35 +89,37 @@ diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptio
 diff --git a/net/base/features.cc b/net/base/features.cc
 --- a/net/base/features.cc
 +++ b/net/base/features.cc
-@@ -110,6 +110,12 @@ const base::Feature kUseDnsHttpsSvcbAlpn{"UseDnsHttpsSvcbAlpn",
- const base::Feature kEnableTLS13EarlyData{"EnableTLS13EarlyData",
-                                           base::FEATURE_DISABLED_BY_DEFAULT};
+@@ -69,6 +69,14 @@ BASE_FEATURE(kEnableTLS13EarlyData,
+              "EnableTLS13EarlyData",
+              base::FEATURE_DISABLED_BY_DEFAULT);
  
-+const base::Feature kDisableTLSResumption{"DisableTLSResumption",
-+                                          base::FEATURE_ENABLED_BY_DEFAULT};
++BASE_FEATURE(kDisableTLSResumption,
++             "DisableTLSResumption",
++             base::FEATURE_ENABLED_BY_DEFAULT);
 +
-+const base::Feature kLogTLSResumption{"LogTLSResumption",
-+                                      base::FEATURE_DISABLED_BY_DEFAULT};
++BASE_FEATURE(kLogTLSResumption,
++             "LogTLSResumption",
++             base::FEATURE_DISABLED_BY_DEFAULT);
 +
- const base::Feature kEncryptedClientHello{"EncryptedClientHello",
-                                           base::FEATURE_DISABLED_BY_DEFAULT};
- 
+ BASE_FEATURE(kEncryptedClientHello,
+              "EncryptedClientHello",
+              base::FEATURE_DISABLED_BY_DEFAULT);
 diff --git a/net/base/features.h b/net/base/features.h
 --- a/net/base/features.h
 +++ b/net/base/features.h
-@@ -170,6 +170,12 @@ NET_EXPORT extern const base::Feature kUseDnsHttpsSvcbAlpn;
+@@ -91,6 +91,12 @@ NET_EXPORT BASE_DECLARE_FEATURE(kUseDnsHttpsSvcbAlpn);
  // Enables TLS 1.3 early data.
- NET_EXPORT extern const base::Feature kEnableTLS13EarlyData;
+ NET_EXPORT BASE_DECLARE_FEATURE(kEnableTLS13EarlyData);
  
 +// Disables TLS resumption.
-+NET_EXPORT extern const base::Feature kDisableTLSResumption;
++NET_EXPORT BASE_DECLARE_FEATURE(kDisableTLSResumption);
 +
 +// Log TLS resumption.
-+NET_EXPORT extern const base::Feature kLogTLSResumption;
++NET_EXPORT BASE_DECLARE_FEATURE(kLogTLSResumption);
 +
  // Enables the TLS Encrypted ClientHello feature.
  // https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-13
- NET_EXPORT extern const base::Feature kEncryptedClientHello;
+ NET_EXPORT BASE_DECLARE_FEATURE(kEncryptedClientHello);
 diff --git a/net/http/http_network_session.cc b/net/http/http_network_session.cc
 --- a/net/http/http_network_session.cc
 +++ b/net/http/http_network_session.cc
@@ -132,7 +134,7 @@ diff --git a/net/http/http_network_session.cc b/net/http/http_network_session.cc
 diff --git a/net/quic/quic_stream_factory.cc b/net/quic/quic_stream_factory.cc
 --- a/net/quic/quic_stream_factory.cc
 +++ b/net/quic/quic_stream_factory.cc
-@@ -73,6 +73,7 @@
+@@ -72,6 +72,7 @@
  #include "net/third_party/quiche/src/quiche/quic/core/quic_utils.h"
  #include "net/third_party/quiche/src/quiche/quic/platform/api/quic_flags.h"
  #include "third_party/boringssl/src/include/openssl/aead.h"
@@ -140,7 +142,7 @@ diff --git a/net/quic/quic_stream_factory.cc b/net/quic/quic_stream_factory.cc
  #include "url/gurl.h"
  #include "url/scheme_host_port.h"
  #include "url/url_constants.h"
-@@ -246,6 +247,38 @@ quic::ParsedQuicVersion SelectQuicVersion(
+@@ -245,6 +246,38 @@ quic::ParsedQuicVersion SelectQuicVersion(
  
  }  // namespace
  
@@ -179,7 +181,7 @@ diff --git a/net/quic/quic_stream_factory.cc b/net/quic/quic_stream_factory.cc
  // Refcounted class that owns quic::QuicCryptoClientConfig and tracks how many
  // consumers are using it currently. When the last reference is freed, the
  // QuicCryptoClientConfigHandle informs the owning QuicStreamFactory, moves it
-@@ -2254,7 +2287,7 @@ QuicStreamFactory::CreateCryptoConfigHandle(
+@@ -2249,7 +2282,7 @@ QuicStreamFactory::CreateCryptoConfigHandle(
                sct_auditing_delegate_,
                HostsFromOrigins(params_.origins_to_force_quic_on),
                actual_network_anonymization_key),

--- a/build/patches/Disable-all-predictors-code.patch
+++ b/build/patches/Disable-all-predictors-code.patch
@@ -6,7 +6,7 @@ Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
  .../chrome_hints_manager.cc                   |  1 +
- .../optimization_guide_keyed_service.cc       |  5 ----
+ .../optimization_guide_keyed_service.cc       |  1 -
  chrome/common/chrome_features.cc              |  6 ++---
  .../optimization_guide/core/hints_fetcher.cc  |  1 +
  .../optimization_guide/core/hints_manager.cc  |  5 ++++
@@ -17,7 +17,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  components/permissions/features.cc            |  8 +++----
  .../segmentation_platform/public/features.cc  |  2 +-
  third_party/blink/common/features.cc          |  2 +-
- 12 files changed, 34 insertions(+), 31 deletions(-)
+ 12 files changed, 34 insertions(+), 27 deletions(-)
 
 diff --git a/chrome/browser/optimization_guide/chrome_hints_manager.cc b/chrome/browser/optimization_guide/chrome_hints_manager.cc
 --- a/chrome/browser/optimization_guide/chrome_hints_manager.cc
@@ -33,18 +33,7 @@ diff --git a/chrome/browser/optimization_guide/chrome_hints_manager.cc b/chrome/
 diff --git a/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc b/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
 --- a/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
 +++ b/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
-@@ -113,10 +113,6 @@ OptimizationGuideKeyedService::MaybeCreatePushNotificationManager(
-   if (optimization_guide::features::IsPushNotificationsEnabled()) {
-     auto push_notification_manager =
-         std::make_unique<optimization_guide::PushNotificationManager>();
--#if BUILDFLAG(IS_ANDROID)
--    push_notification_manager->AddObserver(
--        PriceTrackingNotificationBridge::GetForBrowserContext(profile));
--#endif
-     return push_notification_manager;
-   }
-   return nullptr;
-@@ -324,7 +320,6 @@ void OptimizationGuideKeyedService::RemoveObserverForOptimizationTargetModel(
+@@ -324,7 +324,6 @@ void OptimizationGuideKeyedService::RemoveObserverForOptimizationTargetModel(
  void OptimizationGuideKeyedService::RegisterOptimizationTypes(
      const std::vector<optimization_guide::proto::OptimizationType>&
          optimization_types) {
@@ -55,30 +44,30 @@ diff --git a/chrome/browser/optimization_guide/optimization_guide_keyed_service.
 diff --git a/chrome/common/chrome_features.cc b/chrome/common/chrome_features.cc
 --- a/chrome/common/chrome_features.cc
 +++ b/chrome/common/chrome_features.cc
-@@ -747,8 +747,8 @@ const base::Feature kPermissionAuditing{"PermissionAuditing",
- 
+@@ -883,8 +883,8 @@ BASE_FEATURE(kPermissionAuditing,
  // Enables using the prediction service for permission prompts. We will keep
  // this feature in order to allow us to update the holdback chance via finch.
--const base::Feature kPermissionPredictions{"PermissionPredictions",
--                                           base::FEATURE_ENABLED_BY_DEFAULT};
-+const base::Feature kPermissionPredictions{"PermissionPredictions",               // always disabled
-+                                           base::FEATURE_DISABLED_BY_DEFAULT};    // in Bromite
+ BASE_FEATURE(kPermissionPredictions,
+-             "PermissionPredictions",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             "PermissionPredictions",               // always disabled
++             base::FEATURE_DISABLED_BY_DEFAULT);    // in Bromite
  
  // The holdback chance is 30% but it can also be configured/updated
  // through finch if needed.
-@@ -759,7 +759,7 @@ const base::FeatureParam<double> kPermissionPredictionsHoldbackChance(
- 
+@@ -896,7 +896,7 @@ const base::FeatureParam<double> kPermissionPredictionsHoldbackChance(
  // Enables using the prediction service for geolocation permission prompts.
- const base::Feature kPermissionGeolocationPredictions{
--    "PermissionGeolocationPredictions", base::FEATURE_ENABLED_BY_DEFAULT};
-+    "PermissionGeolocationPredictions", base::FEATURE_DISABLED_BY_DEFAULT}; // always disabled in Bromite
+ BASE_FEATURE(kPermissionGeolocationPredictions,
+              "PermissionGeolocationPredictions",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT); // always disabled in Bromite
  
  const base::FeatureParam<double>
      kPermissionGeolocationPredictionsHoldbackChance(
 diff --git a/components/optimization_guide/core/hints_fetcher.cc b/components/optimization_guide/core/hints_fetcher.cc
 --- a/components/optimization_guide/core/hints_fetcher.cc
 +++ b/components/optimization_guide/core/hints_fetcher.cc
-@@ -176,6 +176,7 @@ bool HintsFetcher::FetchOptimizationGuideServiceHints(
+@@ -174,6 +174,7 @@ bool HintsFetcher::FetchOptimizationGuideServiceHints(
      optimization_guide::proto::RequestContext request_context,
      const std::string& locale,
      HintsFetchedCallback hints_fetched_callback) {
@@ -89,7 +78,7 @@ diff --git a/components/optimization_guide/core/hints_fetcher.cc b/components/op
 diff --git a/components/optimization_guide/core/hints_manager.cc b/components/optimization_guide/core/hints_manager.cc
 --- a/components/optimization_guide/core/hints_manager.cc
 +++ b/components/optimization_guide/core/hints_manager.cc
-@@ -360,6 +360,7 @@ void HintsManager::Shutdown() {
+@@ -352,6 +352,7 @@ void HintsManager::Shutdown() {
  OptimizationGuideDecision
  HintsManager::GetOptimizationGuideDecisionFromOptimizationTypeDecision(
      OptimizationTypeDecision optimization_type_decision) {
@@ -97,7 +86,7 @@ diff --git a/components/optimization_guide/core/hints_manager.cc b/components/op
    switch (optimization_type_decision) {
      case OptimizationTypeDecision::kAllowedByOptimizationFilter:
      case OptimizationTypeDecision::kAllowedByHint:
-@@ -1064,6 +1065,7 @@ void HintsManager::CanApplyOptimizationOnDemand(
+@@ -1056,6 +1057,7 @@ void HintsManager::CanApplyOptimizationOnDemand(
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
  
    // TODO(crbug/1275612): Check whether we have consent to fetch.
@@ -105,7 +94,7 @@ diff --git a/components/optimization_guide/core/hints_manager.cc b/components/op
  
    // This set contains URLs that require some information to be fetched, whether
    // that be a URL-keyed hint or a host-keyed hint.
-@@ -1271,6 +1273,9 @@ OptimizationTypeDecision HintsManager::CanApplyOptimization(
+@@ -1263,6 +1265,9 @@ OptimizationTypeDecision HintsManager::CanApplyOptimization(
      proto::OptimizationType optimization_type,
      OptimizationMetadata* optimization_metadata) {
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
@@ -118,72 +107,75 @@ diff --git a/components/optimization_guide/core/hints_manager.cc b/components/op
 diff --git a/components/optimization_guide/core/optimization_guide_features.cc b/components/optimization_guide/core/optimization_guide_features.cc
 --- a/components/optimization_guide/core/optimization_guide_features.cc
 +++ b/components/optimization_guide/core/optimization_guide_features.cc
-@@ -77,16 +77,16 @@ bool IsSupportedLocaleForFeature(const std::string locale,
- 
+@@ -78,17 +78,17 @@ bool IsSupportedLocaleForFeature(const std::string locale,
  // Enables the syncing of the Optimization Hints component, which provides
  // hints for what optimizations can be applied on a page load.
--const base::Feature kOptimizationHints{"OptimizationHints",
--                                       base::FEATURE_ENABLED_BY_DEFAULT};
-+const base::Feature kOptimizationHints{"OptimizationHints",                   // disabled by default
-+                                       base::FEATURE_DISABLED_BY_DEFAULT};    // in Bromite
+ BASE_FEATURE(kOptimizationHints,
+-             "OptimizationHints",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             "OptimizationHints",                   // disabled by default
++             base::FEATURE_DISABLED_BY_DEFAULT);    // in Bromite
  
  // Enables fetching from a remote Optimization Guide Service.
- const base::Feature kRemoteOptimizationGuideFetching{
--    "OptimizationHintsFetching", base::FEATURE_ENABLED_BY_DEFAULT};
-+    "OptimizationHintsFetching", base::FEATURE_DISABLED_BY_DEFAULT};          // disabled by default in Bromite
+ BASE_FEATURE(kRemoteOptimizationGuideFetching,
+              "OptimizationHintsFetching",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);          // disabled by default in Bromite
  
- const base::Feature kRemoteOptimizationGuideFetchingAnonymousDataConsent{
--    "OptimizationHintsFetchingAnonymousDataConsent",
--    base::FEATURE_ENABLED_BY_DEFAULT};
-+    "OptimizationHintsFetchingAnonymousDataConsent",                          // disabled by default
-+    base::FEATURE_DISABLED_BY_DEFAULT};                                       // in Bromite
+ BASE_FEATURE(kRemoteOptimizationGuideFetchingAnonymousDataConsent,
+-             "OptimizationHintsFetchingAnonymousDataConsent",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             "OptimizationHintsFetchingAnonymousDataConsent",                          // disabled by default
++             base::FEATURE_DISABLED_BY_DEFAULT);                                       // in Bromite
  
  // Enables performance info in the context menu and fetching from a remote
  // Optimization Guide Service.
-@@ -96,15 +96,15 @@ const base::Feature kContextMenuPerformanceInfoAndRemoteHintFetching{
- 
+@@ -99,15 +99,15 @@ BASE_FEATURE(kContextMenuPerformanceInfoAndRemoteHintFetching,
  // Enables the prediction of optimization targets.
- const base::Feature kOptimizationTargetPrediction{
--    "OptimizationTargetPrediction", base::FEATURE_ENABLED_BY_DEFAULT};
-+    "OptimizationTargetPrediction", base::FEATURE_DISABLED_BY_DEFAULT};        // disabled by default in Bromite
+ BASE_FEATURE(kOptimizationTargetPrediction,
+              "OptimizationTargetPrediction",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);        // disabled by default in Bromite
  
  // Enables the downloading of models.
- const base::Feature kOptimizationGuideModelDownloading {
-   "OptimizationGuideModelDownloading",
+ BASE_FEATURE(kOptimizationGuideModelDownloading,
+              "OptimizationGuideModelDownloading",
  #if BUILDFLAG(BUILD_WITH_TFLITE_LIB)
--      base::FEATURE_ENABLED_BY_DEFAULT
+-             base::FEATURE_ENABLED_BY_DEFAULT
 -#else   // BUILD_WITH_TFLITE_LIB
-       base::FEATURE_DISABLED_BY_DEFAULT
+              base::FEATURE_DISABLED_BY_DEFAULT
 +#else   // BUILD_WITH_TFLITE_LIB
-+      base::FEATURE_DISABLED_BY_DEFAULT // guard this
++             base::FEATURE_DISABLED_BY_DEFAULT // guard this
  #endif  // !BUILD_WITH_TFLITE_LIB
- };
+ );
  
-@@ -134,7 +134,7 @@ const base::Feature kPageEntitiesModelResetOnShutdown{
- 
+@@ -144,7 +144,7 @@ BASE_FEATURE(kPageEntitiesModelResetOnShutdown,
  // Enables push notification of hints.
- const base::Feature kPushNotifications{"OptimizationGuidePushNotifications",
--                                       base::FEATURE_DISABLED_BY_DEFAULT};
-+                                       base::FEATURE_DISABLED_BY_DEFAULT}; // guard this
+ BASE_FEATURE(kPushNotifications,
+              "OptimizationGuidePushNotifications",
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT); // guard this
  
  // This feature flag does not turn off any behavior, it is only used for
  // experiment parameters.
-@@ -146,12 +146,12 @@ const base::Feature kOptimizationGuideMetadataValidation{
-     "OptimizationGuideMetadataValidation", base::FEATURE_DISABLED_BY_DEFAULT};
+@@ -159,14 +159,14 @@ BASE_FEATURE(kOptimizationGuideMetadataValidation,
  
- const base::Feature kPageTopicsBatchAnnotations{
--    "PageTopicsBatchAnnotations", base::FEATURE_ENABLED_BY_DEFAULT};
-+    "PageTopicsBatchAnnotations", base::FEATURE_DISABLED_BY_DEFAULT};
- const base::Feature kPageVisibilityBatchAnnotations{
-     "PageVisibilityBatchAnnotations", base::FEATURE_ENABLED_BY_DEFAULT};
+ BASE_FEATURE(kPageTopicsBatchAnnotations,
+              "PageTopicsBatchAnnotations",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
+ BASE_FEATURE(kPageVisibilityBatchAnnotations,
+              "PageVisibilityBatchAnnotations",
+              base::FEATURE_ENABLED_BY_DEFAULT);
  
- const base::Feature kUseLocalPageEntitiesMetadataProvider{
--    "UseLocalPageEntitiesMetadataProvider", base::FEATURE_DISABLED_BY_DEFAULT};
-+    "UseLocalPageEntitiesMetadataProvider", base::FEATURE_DISABLED_BY_DEFAULT}; // guard this
+ BASE_FEATURE(kUseLocalPageEntitiesMetadataProvider,
+              "UseLocalPageEntitiesMetadataProvider",
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT); // guard this
  
- const base::Feature kPageContentAnnotationsValidation{
-     "PageContentAnnotationsValidation", base::FEATURE_DISABLED_BY_DEFAULT};
-@@ -390,7 +390,7 @@ size_t MaxURLKeyedHintCacheSize() {
+ BASE_FEATURE(kPageContentAnnotationsValidation,
+              "PageContentAnnotationsValidation",
+@@ -408,7 +408,7 @@ size_t MaxURLKeyedHintCacheSize() {
  
  bool ShouldPersistHintsToDisk() {
    return GetFieldTrialParamByFeatureAsBool(kOptimizationHints,
@@ -257,46 +249,46 @@ diff --git a/components/optimization_guide/features.gni b/components/optimizatio
 diff --git a/components/permissions/features.cc b/components/permissions/features.cc
 --- a/components/permissions/features.cc
 +++ b/components/permissions/features.cc
-@@ -66,12 +66,12 @@ const base::Feature kPermissionChipRequestTypeSensitive{
+@@ -85,12 +85,12 @@ BASE_FEATURE(kPermissionChipRequestTypeSensitive,
  // When enabled, use the value of the `service_url` FeatureParam as the url
  // for the Web Permission Predictions Service.
- const base::Feature kPermissionPredictionServiceUseUrlOverride{
--    "kPermissionPredictionServiceUseUrlOverride",
--    base::FEATURE_DISABLED_BY_DEFAULT};
-+    "kPermissionPredictionServiceUseUrlOverride",           // disabled by default
-+    base::FEATURE_DISABLED_BY_DEFAULT};                     // in Bromite
+ BASE_FEATURE(kPermissionPredictionServiceUseUrlOverride,
+-             "kPermissionPredictionServiceUseUrlOverride",
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             "kPermissionPredictionServiceUseUrlOverride",           // disabled by default
++             base::FEATURE_DISABLED_BY_DEFAULT);                     // in Bromite
  
- const base::Feature kPermissionOnDeviceNotificationPredictions{
--    "PermissionOnDeviceNotificationPredictions",
--    base::FEATURE_ENABLED_BY_DEFAULT};
-+    "PermissionOnDeviceNotificationPredictions",            // disabled by default
-+    base::FEATURE_DISABLED_BY_DEFAULT};                     // in Bromite
+ BASE_FEATURE(kPermissionOnDeviceNotificationPredictions,
+-             "PermissionOnDeviceNotificationPredictions",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             "PermissionOnDeviceNotificationPredictions",            // disabled by default
++             base::FEATURE_DISABLED_BY_DEFAULT);                     // in Bromite
  
- const base::Feature kPermissionOnDeviceGeolocationPredictions{
-     "PermissionOnDeviceGeolocationPredictions",
+ BASE_FEATURE(kPermissionOnDeviceGeolocationPredictions,
+              "PermissionOnDeviceGeolocationPredictions",
 diff --git a/components/segmentation_platform/public/features.cc b/components/segmentation_platform/public/features.cc
 --- a/components/segmentation_platform/public/features.cc
 +++ b/components/segmentation_platform/public/features.cc
-@@ -30,7 +30,7 @@ const base::Feature kShoppingUserSegmentFeature{
- const base::Feature kSegmentationPlatformFeedSegmentFeature{
-   "SegmentationPlatformFeedSegmentFeature",
+@@ -35,7 +35,7 @@ BASE_FEATURE(kSegmentationPlatformSearchUser,
+ BASE_FEATURE(kSegmentationPlatformFeedSegmentFeature,
+              "SegmentationPlatformFeedSegmentFeature",
  #if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
--      base::FEATURE_ENABLED_BY_DEFAULT
-+      base::FEATURE_DISABLED_BY_DEFAULT
- };
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
  #else
-       base::FEATURE_DISABLED_BY_DEFAULT
+              base::FEATURE_DISABLED_BY_DEFAULT);
+ #endif
 diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
 --- a/third_party/blink/common/features.cc
 +++ b/third_party/blink/common/features.cc
-@@ -206,7 +206,7 @@ const base::Feature kMixedContentAutoupgrade{"AutoupgradeMixedContent",
- const base::Feature kNavigationPredictor {
-   "NavigationPredictor",
+@@ -216,7 +216,7 @@ BASE_FEATURE(kMixedContentAutoupgrade,
+ BASE_FEATURE(kNavigationPredictor,
+              "NavigationPredictor",
  #if BUILDFLAG(IS_ANDROID)
--      base::FEATURE_ENABLED_BY_DEFAULT
-+      base::FEATURE_DISABLED_BY_DEFAULT
+-             base::FEATURE_ENABLED_BY_DEFAULT
++             base::FEATURE_DISABLED_BY_DEFAULT
  #else
-       base::FEATURE_DISABLED_BY_DEFAULT
+              base::FEATURE_DISABLED_BY_DEFAULT
  #endif
 --
 2.25.1

--- a/build/patches/Disable-conversion-measurement-api.patch
+++ b/build/patches/Disable-conversion-measurement-api.patch
@@ -12,42 +12,39 @@ Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
  .../browser/flags/android/chrome_feature_list.cc  |  2 +-
- .../embedder_support/origin_trials/features.cc    |  3 ++-
+ .../embedder_support/origin_trials/features.cc    |  2 +-
  .../render_view_context_menu_base.cc              |  3 ---
  .../aggregatable_report_sender.cc                 | 15 +++++++--------
  .../attribution_reporting/attribution_host.cc     |  1 +
  .../attribution_report_network_sender.cc          | 15 ++++++++-------
- .../attribution_storage_sql.cc                    |  2 +-
+ .../attribution_storage_sql.cc                    |  4 +++-
  content/browser/storage_partition_impl.cc         |  7 +------
  content/public/browser/navigation_controller.cc   |  1 -
  third_party/blink/common/features.cc              |  2 +-
  .../platform/runtime_enabled_features.json5       |  7 +++++++
- 11 files changed, 29 insertions(+), 29 deletions(-)
+ 11 files changed, 30 insertions(+), 29 deletions(-)
 
 diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
 --- a/chrome/browser/flags/android/chrome_feature_list.cc
 +++ b/chrome/browser/flags/android/chrome_feature_list.cc
-@@ -502,7 +502,7 @@ const base::Feature kAppMenuMobileSiteOption{"AppMenuMobileSiteOption",
-                                              base::FEATURE_DISABLED_BY_DEFAULT};
+@@ -530,7 +530,7 @@ BASE_FEATURE(kAppMenuMobileSiteOption,
  
- const base::Feature kAppToWebAttribution{"AppToWebAttribution",
--                                         base::FEATURE_DISABLED_BY_DEFAULT};
-+                                         base::FEATURE_DISABLED_BY_DEFAULT}; // guard this
+ BASE_FEATURE(kAppToWebAttribution,
+              "AppToWebAttribution",
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT); // guard this
  
- const base::Feature kBackgroundThreadPool{"BackgroundThreadPool",
-                                           base::FEATURE_DISABLED_BY_DEFAULT};
+ BASE_FEATURE(kBackgroundThreadPool,
+              "BackgroundThreadPool",
 diff --git a/components/embedder_support/origin_trials/features.cc b/components/embedder_support/origin_trials/features.cc
 --- a/components/embedder_support/origin_trials/features.cc
 +++ b/components/embedder_support/origin_trials/features.cc
-@@ -17,8 +17,9 @@ const base::Feature kOriginTrialsSampleAPIThirdPartyAlternativeUsage{
-     "OriginTrialsSampleAPIThirdPartyAlternativeUsage",
-     base::FEATURE_ENABLED_BY_DEFAULT};
+@@ -19,6 +19,6 @@ BASE_FEATURE(kOriginTrialsSampleAPIThirdPartyAlternativeUsage,
  
-+// When disabled, the API cannot be enabled by tokens.
- const base::Feature kConversionMeasurementAPIAlternativeUsage{
-     "ConversionMeasurementAPIAlternativeUsage",
--    base::FEATURE_ENABLED_BY_DEFAULT};
-+    base::FEATURE_DISABLED_BY_DEFAULT};
+ BASE_FEATURE(kConversionMeasurementAPIAlternativeUsage,
+              "ConversionMeasurementAPIAlternativeUsage",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
  
  }  // namespace embedder_support
 diff --git a/components/renderer_context_menu/render_view_context_menu_base.cc b/components/renderer_context_menu/render_view_context_menu_base.cc
@@ -107,7 +104,7 @@ diff --git a/content/browser/attribution_reporting/attribution_host.cc b/content
 diff --git a/content/browser/attribution_reporting/attribution_report_network_sender.cc b/content/browser/attribution_reporting/attribution_report_network_sender.cc
 --- a/content/browser/attribution_reporting/attribution_report_network_sender.cc
 +++ b/content/browser/attribution_reporting/attribution_report_network_sender.cc
-@@ -112,13 +112,8 @@ void AttributionReportNetworkSender::SendReport(
+@@ -110,13 +110,8 @@ void AttributionReportNetworkSender::SendReport(
                     network::SimpleURLLoader::RETRY_ON_NAME_NOT_RESOLVED;
    simple_url_loader_ptr->SetRetryOptions(/*max_retries=*/1, retry_mode);
  
@@ -123,7 +120,7 @@ diff --git a/content/browser/attribution_reporting/attribution_report_network_se
  }
  
  void AttributionReportNetworkSender::OnReportSent(
-@@ -127,6 +122,12 @@ void AttributionReportNetworkSender::OnReportSent(
+@@ -125,6 +120,12 @@ void AttributionReportNetworkSender::OnReportSent(
      bool is_debug_report,
      ReportSentCallback sent_callback,
      scoped_refptr<net::HttpResponseHeaders> headers) {
@@ -139,19 +136,28 @@ diff --git a/content/browser/attribution_reporting/attribution_report_network_se
 diff --git a/content/browser/attribution_reporting/attribution_storage_sql.cc b/content/browser/attribution_reporting/attribution_storage_sql.cc
 --- a/content/browser/attribution_reporting/attribution_storage_sql.cc
 +++ b/content/browser/attribution_reporting/attribution_storage_sql.cc
-@@ -416,7 +416,7 @@ DestinationLimitResult GetDestinationLimitResult(
+@@ -422,6 +422,8 @@ DestinationLimitResult GetDestinationLimitResult(
    }
  }
  
--bool g_run_in_memory = false;
 +bool g_run_in_memory = true;
- 
++
  }  // namespace
  
+ // static
+@@ -433,7 +435,7 @@ bool AttributionStorageSql::DeleteStorageForTesting(
+ AttributionStorageSql::AttributionStorageSql(
+     const base::FilePath& user_data_directory,
+     std::unique_ptr<AttributionStorageDelegate> delegate)
+-    : path_to_database_(user_data_directory.empty()
++    : path_to_database_(user_data_directory.empty() || g_run_in_memory
+                             ? base::FilePath()
+                             : DatabasePath(user_data_directory)),
+       delegate_(std::move(delegate)),
 diff --git a/content/browser/storage_partition_impl.cc b/content/browser/storage_partition_impl.cc
 --- a/content/browser/storage_partition_impl.cc
 +++ b/content/browser/storage_partition_impl.cc
-@@ -1315,12 +1315,7 @@ void StoragePartitionImpl::Initialize(
+@@ -1353,12 +1353,7 @@ void StoragePartitionImpl::Initialize(
  
    bucket_manager_ = std::make_unique<BucketManager>(this);
  
@@ -179,12 +185,12 @@ diff --git a/content/public/browser/navigation_controller.cc b/content/public/br
 diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
 --- a/third_party/blink/common/features.cc
 +++ b/third_party/blink/common/features.cc
-@@ -107,7 +107,7 @@ const base::Feature kBlockingDownloadsInAdFrameWithoutUserActivation{
- 
+@@ -106,7 +106,7 @@ BASE_FEATURE(kBlockingDownloadsInAdFrameWithoutUserActivation,
  // Controls whether the Conversion Measurement API infrastructure is enabled.
- const base::Feature kConversionMeasurement{"ConversionMeasurement",
--                                           base::FEATURE_ENABLED_BY_DEFAULT};
-+                                           base::FEATURE_DISABLED_BY_DEFAULT};
+ BASE_FEATURE(kConversionMeasurement,
+              "ConversionMeasurement",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
  
  // Controls whether LCP calculations should exclude low-entropy images. If
  // enabled, then the associated parameter sets the cutoff, expressed as the

--- a/build/patches/Enable-StrictOriginIsolation-and-SitePerProcess.patch
+++ b/build/patches/Enable-StrictOriginIsolation-and-SitePerProcess.patch
@@ -18,7 +18,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -4445,9 +4445,6 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -4561,9 +4561,6 @@ const FeatureEntry kFeatureEntries[] = {
       flag_descriptions::kSiteIsolationForPasswordSitesDescription, kOsAndroid,
       FEATURE_VALUE_TYPE(
           site_isolation::features::kSiteIsolationForPasswordSites)},
@@ -31,7 +31,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -1415,7 +1415,7 @@ void ChromeContentBrowserClient::RegisterLocalStatePrefs(
+@@ -1425,7 +1425,7 @@ void ChromeContentBrowserClient::RegisterLocalStatePrefs(
    registry->RegisterFilePathPref(prefs::kDiskCacheDir, base::FilePath());
    registry->RegisterIntegerPref(prefs::kDiskCacheSize, 0);
    registry->RegisterStringPref(prefs::kIsolateOrigins, std::string());
@@ -40,7 +40,7 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
    registry->RegisterBooleanPref(prefs::kTabFreezingEnabled, true);
    registry->RegisterIntegerPref(prefs::kSCTAuditingHashdanceReportCount, 0);
  }
-@@ -1429,7 +1429,7 @@ void ChromeContentBrowserClient::RegisterProfilePrefs(
+@@ -1439,7 +1439,7 @@ void ChromeContentBrowserClient::RegisterProfilePrefs(
    // user policy in addition to the same named ones in Local State (which are
    // used for mapping the command-line flags).
    registry->RegisterStringPref(prefs::kIsolateOrigins, std::string());
@@ -71,14 +71,14 @@ diff --git a/components/site_isolation/site_isolation_policy.cc b/components/sit
 diff --git a/content/public/common/content_features.cc b/content/public/common/content_features.cc
 --- a/content/public/common/content_features.cc
 +++ b/content/public/common/content_features.cc
-@@ -1000,7 +1000,7 @@ const base::Feature kStopVideoCaptureOnScreenLock{
- // Controls whether site isolation should use origins instead of scheme and
+@@ -1113,7 +1113,7 @@ BASE_FEATURE(kStopVideoCaptureOnScreenLock,
  // eTLD+1.
- const base::Feature kStrictOriginIsolation{"StrictOriginIsolation",
--                                           base::FEATURE_DISABLED_BY_DEFAULT};
-+                                           base::FEATURE_ENABLED_BY_DEFAULT};
+ BASE_FEATURE(kStrictOriginIsolation,
+              "StrictOriginIsolation",
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
  
- // Enables subresource loading with Web Bundles.
- const base::Feature kSubresourceWebBundles{"SubresourceWebBundles",
+ // Disallows window.{alert, prompt, confirm} if triggered inside a subframe that
+ // is not same origin with the main frame.
 --
 2.25.1

--- a/build/patches/Enable-native-Android-autofill.patch
+++ b/build/patches/Enable-native-Android-autofill.patch
@@ -55,14 +55,14 @@ diff --git a/android_webview/browser/aw_contents.cc b/android_webview/browser/aw
 diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
 --- a/chrome/android/BUILD.gn
 +++ b/chrome/android/BUILD.gn
-@@ -461,6 +461,7 @@ android_library("chrome_java") {
-     "//components/autofill_assistant/android:public_dependencies_java",
-     "//components/autofill_assistant/android:public_java",
-     "//components/autofill_assistant/browser:proto_java",
-+    "//components/android_autofill/browser:java",
-     "//components/background_task_scheduler:background_task_scheduler_java",
-     "//components/background_task_scheduler:background_task_scheduler_task_ids_java",
-     "//components/bookmarks/common/android:bookmarks_java",
+@@ -505,6 +505,7 @@ if (current_toolchain == default_toolchain) {
+       "//components/autofill_assistant/android:public_dependencies_java",
+       "//components/autofill_assistant/android:public_java",
+       "//components/autofill_assistant/browser:proto_java",
++      "//components/android_autofill/browser:java",
+       "//components/background_task_scheduler:background_task_scheduler_java",
+       "//components/background_task_scheduler:background_task_scheduler_task_ids_java",
+       "//components/bookmarks/common/android:bookmarks_java",
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java b/chrome/android/java/src/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
@@ -105,18 +105,18 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/password_manage
  
 +    private ChromeSwitchPreference mEnableAndroidAutofillSwitch;
 +    private ChromeSwitchPreference mEnableAndroidAutofillIncognitoSwitch;
+     private @Nullable PasswordCheck mPasswordCheck;
      private @ManagePasswordsReferrer int mManagePasswordsReferrer;
  
-     /**
-@@ -284,6 +297,7 @@ public class PasswordSettings extends PreferenceFragmentCompat
+@@ -286,6 +299,7 @@ public class PasswordSettings extends PreferenceFragmentCompat
          }
  
          createSavePasswordsSwitch();
 +        createEnableAndroidAutofillSwitch();
          createAutoSignInCheckbox();
- 
-         if (mTrustedVaultBannerState == TrustedVaultBannerState.OPTED_IN) {
-@@ -518,6 +532,71 @@ public class PasswordSettings extends PreferenceFragmentCompat
+         if (mPasswordCheck != null) {
+             createCheckPasswords();
+@@ -527,6 +541,71 @@ public class PasswordSettings extends PreferenceFragmentCompat
                  getPrefService().getBoolean(Pref.CREDENTIALS_ENABLE_SERVICE));
      }
  
@@ -286,9 +286,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabImpl.jav
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabViewAndroidDelegate.java b/chrome/android/java/src/org/chromium/chrome/browser/tab/TabViewAndroidDelegate.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabViewAndroidDelegate.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tab/TabViewAndroidDelegate.java
-@@ -32,6 +32,10 @@ import org.chromium.ui.dragdrop.DragAndDropBrowserDelegate;
- import org.chromium.ui.dragdrop.DragStateTracker;
- import org.chromium.ui.dragdrop.DropDataContentProvider;
+@@ -32,6 +32,10 @@ import org.chromium.ui.dragdrop.DragStateTracker;
+ import org.chromium.ui.dragdrop.DropDataProviderImpl;
+ import org.chromium.ui.dragdrop.DropDataProviderUtils;
  
 +import android.util.SparseArray;
 +import android.view.autofill.AutofillValue;
@@ -297,7 +297,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabViewAndr
  /**
   * Implementation of the abstract class {@link ViewAndroidDelegate} for Chrome.
   */
-@@ -214,4 +218,14 @@ public class TabViewAndroidDelegate extends ViewAndroidDelegate {
+@@ -216,4 +220,14 @@ public class TabViewAndroidDelegate extends ViewAndroidDelegate {
              return intent;
          }
      }
@@ -315,7 +315,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabViewAndr
 diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -2478,6 +2478,13 @@ static_library("browser") {
+@@ -2494,6 +2494,13 @@ static_library("browser") {
      deps += [ "//chrome/browser/error_reporting" ]
    }
  
@@ -394,7 +394,7 @@ diff --git a/chrome/browser/android/tab_web_contents_delegate_android.cc b/chrom
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -601,6 +601,12 @@ CHAR_LIMIT guidelines:
+@@ -604,6 +604,12 @@ CHAR_LIMIT guidelines:
        <message name="IDS_PASSWORD_SETTINGS_SAVE_PASSWORDS" desc="Title for the checkbox toggling whether passwords are saved or not. [CHAR_LIMIT=32]">
          Save passwords
        </message>
@@ -410,7 +410,7 @@ diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chro
 diff --git a/chrome/browser/ui/tab_helpers.cc b/chrome/browser/ui/tab_helpers.cc
 --- a/chrome/browser/ui/tab_helpers.cc
 +++ b/chrome/browser/ui/tab_helpers.cc
-@@ -172,6 +172,9 @@
+@@ -168,6 +168,9 @@
  #include "chrome/browser/ui/javascript_dialogs/javascript_tab_modal_dialog_manager_delegate_android.h"
  #include "chrome/browser/video_tutorials/video_tutorial_tab_helper.h"
  #include "content/public/common/content_features.h"
@@ -420,7 +420,7 @@ diff --git a/chrome/browser/ui/tab_helpers.cc b/chrome/browser/ui/tab_helpers.cc
  #else
  #include "chrome/browser/accuracy_tips/accuracy_service_factory.h"
  #include "chrome/browser/banners/app_banner_manager_desktop.h"
-@@ -334,7 +337,8 @@ void TabHelpers::AttachTabHelpers(WebContents* web_contents) {
+@@ -330,7 +333,8 @@ void TabHelpers::AttachTabHelpers(WebContents* web_contents) {
        base::BindRepeating(
            &autofill::BrowserDriverInitHook,
            autofill::ChromeAutofillClient::FromWebContents(web_contents),
@@ -668,7 +668,7 @@ diff --git a/components/autofill/content/browser/content_autofill_driver_factory
 diff --git a/components/autofill/content/renderer/password_autofill_agent.cc b/components/autofill/content/renderer/password_autofill_agent.cc
 --- a/components/autofill/content/renderer/password_autofill_agent.cc
 +++ b/components/autofill/content/renderer/password_autofill_agent.cc
-@@ -793,7 +793,10 @@ void PasswordAutofillAgent::UpdateStateForTextChange(
+@@ -799,7 +799,10 @@ void PasswordAutofillAgent::UpdateStateForTextChange(
  
  void PasswordAutofillAgent::TrackAutofilledElement(
      const blink::WebFormControlElement& element) {

--- a/build/patches/Enable-share-intent.patch
+++ b/build/patches/Enable-share-intent.patch
@@ -19,18 +19,18 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  chrome/browser/about_flags.cc                 |   4 +
  chrome/browser/flag_descriptions.cc           |   5 +
  chrome/browser/flag_descriptions.h            |   3 +
- .../flags/android/chrome_feature_list.cc      |   4 +
+ .../flags/android/chrome_feature_list.cc      |   5 +
  .../flags/android/chrome_feature_list.h       |   1 +
  .../browser/flags/ChromeFeatureList.java      |   1 +
  .../strings/android_chrome_strings.grd        |  13 ++
- 13 files changed, 255 insertions(+)
+ 13 files changed, 256 insertions(+)
  create mode 100644 chrome/android/java/res/layout/sharing_intent_content.xml
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/sharing/shared_intent/SharedIntentShareActivity.java
 
 diff --git a/chrome/android/chrome_java_resources.gni b/chrome/android/chrome_java_resources.gni
 --- a/chrome/android/chrome_java_resources.gni
 +++ b/chrome/android/chrome_java_resources.gni
-@@ -592,6 +592,7 @@ chrome_java_resources = [
+@@ -590,6 +590,7 @@ chrome_java_resources = [
    "java/res/layout/signin_activity.xml",
    "java/res/layout/status_indicator_container.xml",
    "java/res/layout/suggestions_tile_view_condensed.xml",
@@ -41,7 +41,7 @@ diff --git a/chrome/android/chrome_java_resources.gni b/chrome/android/chrome_ja
 diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java_sources.gni
 --- a/chrome/android/chrome_java_sources.gni
 +++ b/chrome/android/chrome_java_sources.gni
-@@ -966,6 +966,7 @@ chrome_java_sources = [
+@@ -971,6 +971,7 @@ chrome_java_sources = [
    "java/src/org/chromium/chrome/browser/sharing/click_to_call/ClickToCallUma.java",
    "java/src/org/chromium/chrome/browser/sharing/shared_clipboard/SharedClipboardMessageHandler.java",
    "java/src/org/chromium/chrome/browser/sharing/sms_fetcher/SmsFetcherMessageHandler.java",
@@ -52,7 +52,7 @@ diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java
 diff --git a/chrome/android/java/AndroidManifest.xml b/chrome/android/java/AndroidManifest.xml
 --- a/chrome/android/java/AndroidManifest.xml
 +++ b/chrome/android/java/AndroidManifest.xml
-@@ -741,6 +741,24 @@ by a child template that "extends" this file.
+@@ -753,6 +753,24 @@ by a child template that "extends" this file.
              android:process=":browser_restart_process">
          </activity>
  
@@ -311,7 +311,7 @@ new file mode 100644
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -6572,6 +6572,10 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -6788,6 +6788,10 @@ const FeatureEntry kFeatureEntries[] = {
  #endif  // BUILDFLAG(IS_CHROMEOS)
  
  #if BUILDFLAG(IS_ANDROID)
@@ -325,7 +325,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
-@@ -2661,6 +2661,11 @@ const char kIsolateOriginsDescription[] =
+@@ -2783,6 +2783,11 @@ const char kIsolateOriginsDescription[] =
      "Requires dedicated processes for an additional set of origins, "
      "specified as a comma-separated list.";
  
@@ -340,7 +340,7 @@ diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descripti
 diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
 --- a/chrome/browser/flag_descriptions.h
 +++ b/chrome/browser/flag_descriptions.h
-@@ -1504,6 +1504,9 @@ extern const char kIsolateOriginsDescription[];
+@@ -1573,6 +1573,9 @@ extern const char kIsolateOriginsDescription[];
  
  extern const char kIsolationByDefaultName[];
  extern const char kIsolationByDefaultDescription[];
@@ -353,7 +353,7 @@ diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptio
 diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
 --- a/chrome/browser/flags/android/chrome_feature_list.cc
 +++ b/chrome/browser/flags/android/chrome_feature_list.cc
-@@ -273,6 +273,7 @@ const base::Feature* const kFeaturesExposedToJava[] = {
+@@ -280,6 +280,7 @@ const base::Feature* const kFeaturesExposedToJava[] = {
      &kRelatedSearchesAlternateUx,
      &kRelatedSearchesInBar,
      &kRelatedSearchesSimplifiedUx,
@@ -361,31 +361,32 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browse
      &kRelatedSearchesUi,
      &kRequestDesktopSiteDefaults,
      &kRequestDesktopSiteDefaultsControl,
-@@ -724,6 +725,9 @@ const base::Feature kNewInstanceFromDraggedLink{
- const base::Feature kNewTabPageTilesTitleWrapAround{
-     "NewTabPageTilesTitleWrapAround", base::FEATURE_DISABLED_BY_DEFAULT};
+@@ -847,6 +848,10 @@ BASE_FEATURE(kNewTabPageTilesTitleWrapAround,
+              "NewTabPageTilesTitleWrapAround",
+              base::FEATURE_DISABLED_BY_DEFAULT);
  
-+const base::Feature kSharedIntentUI{
-+    "SharedIntentUI", base::FEATURE_ENABLED_BY_DEFAULT};
++BASE_FEATURE(kSharedIntentUI,
++             "SharedIntentUI",
++             base::FEATURE_ENABLED_BY_DEFAULT);
 +
- const base::Feature kNewWindowAppMenu{"NewWindowAppMenu",
-                                       base::FEATURE_ENABLED_BY_DEFAULT};
- 
+ BASE_FEATURE(kNewWindowAppMenu,
+              "NewWindowAppMenu",
+              base::FEATURE_ENABLED_BY_DEFAULT);
 diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser/flags/android/chrome_feature_list.h
 --- a/chrome/browser/flags/android/chrome_feature_list.h
 +++ b/chrome/browser/flags/android/chrome_feature_list.h
-@@ -139,6 +139,7 @@ extern const base::Feature kRequestDesktopSiteDefaultsDowngrade;
- extern const base::Feature kSearchEnginePromoExistingDevice;
- extern const base::Feature kSearchEnginePromoExistingDeviceV2;
- extern const base::Feature kSearchEnginePromoNewDevice;
-+extern const base::Feature kSharedIntentUI;
- extern const base::Feature kSearchReadyOmniboxFeature;
- extern const base::Feature kSearchEnginePromoNewDeviceV2;
- extern const base::Feature kShareButtonInTopToolbar;
+@@ -114,6 +114,7 @@ BASE_DECLARE_FEATURE(kLensOnQuickActionSearchWidget);
+ BASE_DECLARE_FEATURE(kLocationBarModelOptimizations);
+ BASE_DECLARE_FEATURE(kNewInstanceFromDraggedLink);
+ BASE_DECLARE_FEATURE(kNewTabPageTilesTitleWrapAround);
++BASE_DECLARE_FEATURE(kSharedIntentUI);
+ BASE_DECLARE_FEATURE(kNewWindowAppMenu);
+ BASE_DECLARE_FEATURE(kNotificationPermissionVariant);
+ BASE_DECLARE_FEATURE(kOmahaMinSdkVersionAndroid);
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
-@@ -506,6 +506,7 @@ public abstract class ChromeFeatureList {
+@@ -508,6 +508,7 @@ public abstract class ChromeFeatureList {
      public static final String QUIET_NOTIFICATION_PROMPTS = "QuietNotificationPrompts";
      public static final String REACHED_CODE_PROFILER = "ReachedCodeProfiler";
      public static final String READ_LATER = "ReadLater";
@@ -396,7 +397,7 @@ diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/f
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -4864,6 +4864,19 @@ To change this setting, <ph name="BEGIN_LINK">&lt;resetlink&gt;</ph>reset sync<p
+@@ -4837,6 +4837,19 @@ To change this setting, <ph name="BEGIN_LINK">&lt;resetlink&gt;</ph>reset sync<p
          Copied to your clipboard
        </message>
  

--- a/build/patches/Experimental-user-scripts-support.patch
+++ b/build/patches/Experimental-user-scripts-support.patch
@@ -27,7 +27,7 @@ Requires patch: Adds-support-for-writing-URIs.patch
 Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- chrome/android/BUILD.gn                       |   5 +
+ chrome/android/BUILD.gn                       |   4 +
  .../android/java/res/xml/main_preferences.xml |   5 +
  .../browser/download/DownloadUtils.java       |   6 +
  .../init/ProcessInitializationHandler.java    |   3 +
@@ -136,7 +136,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../renderer/web_ui_injection_host.h          |  27 +
  .../strings/userscripts_strings.grdp          |  54 ++
  tools/gritsettings/resource_ids.spec          |   6 +
- 109 files changed, 9450 insertions(+), 2 deletions(-)
+ 109 files changed, 9449 insertions(+), 2 deletions(-)
  create mode 100644 components/user_scripts/README.md
  create mode 100755 components/user_scripts/android/BUILD.gn
  create mode 100644 components/user_scripts/android/java/res/layout/accept_script_item.xml
@@ -226,25 +226,24 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
 --- a/chrome/android/BUILD.gn
 +++ b/chrome/android/BUILD.gn
-@@ -276,6 +276,10 @@ android_resources("chrome_app_java_resources") {
-     "//third_party/androidx:androidx_gridlayout_gridlayout_java",
-     "//third_party/androidx:androidx_preference_preference_java",
-   ]
-+
-+  # this need to be into android_resources("chrome_app_java_resources") section because
-+  # android:java_resources are packed *_percent.pak and placed in the executable folder
-+  deps += [ "//components/user_scripts/android:java_resources" ]
- }
+@@ -303,6 +303,9 @@ if (current_toolchain == default_toolchain) {
+       "//third_party/androidx:androidx_gridlayout_gridlayout_java",
+       "//third_party/androidx:androidx_preference_preference_java",
+     ]
++    # this need to be into android_resources("chrome_app_java_resources") section because
++    # android:java_resources are packed *_percent.pak and placed in the executable folder
++    deps += [ "//components/user_scripts/android:java_resources" ]
+   }
  
- if (enable_vr) {
-@@ -581,6 +585,7 @@ android_library("chrome_java") {
-     "//components/ukm/android:java",
-     "//components/url_formatter/android:url_formatter_java",
-     "//components/user_prefs/android:java",
-+    "//components/user_scripts/android:java",
-     "//components/variations:variations_java",
-     "//components/variations/android:variations_java",
-     "//components/version_info/android:version_constants_java",
+   if (enable_vr) {
+@@ -609,6 +612,7 @@ if (current_toolchain == default_toolchain) {
+       "//components/ukm/android:java",
+       "//components/url_formatter/android:url_formatter_java",
+       "//components/user_prefs/android:java",
++      "//components/user_scripts/android:java",
+       "//components/variations:variations_java",
+       "//components/variations/android:variations_java",
+       "//components/version_info/android:version_constants_java",
 diff --git a/chrome/android/java/res/xml/main_preferences.xml b/chrome/android/java/res/xml/main_preferences.xml
 --- a/chrome/android/java/res/xml/main_preferences.xml
 +++ b/chrome/android/java/res/xml/main_preferences.xml
@@ -323,7 +322,7 @@ diff --git a/chrome/android/java_sources.gni b/chrome/android/java_sources.gni
 diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -3488,6 +3488,11 @@ static_library("browser") {
+@@ -3505,6 +3505,11 @@ static_library("browser") {
        ]
        deps += [ "//chrome/android/modules/dev_ui/provider:native" ]
      }
@@ -338,7 +337,7 @@ diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -155,6 +155,7 @@
+@@ -156,6 +156,7 @@
  #include "components/translate/core/browser/translate_ranker_impl.h"
  #include "components/translate/core/common/translate_util.h"
  #include "components/ui_devtools/switches.h"
@@ -346,7 +345,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
  #include "components/version_info/version_info.h"
  #include "components/viz/common/features.h"
  #include "components/viz/common/switches.h"
-@@ -7534,6 +7535,10 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -7754,6 +7755,10 @@ const FeatureEntry kFeatureEntries[] = {
           chromeos::features::kClipboardHistoryNudgeSessionReset)},
  #endif  // BUILDFLAG(IS_CHROMEOS_ASH)
  
@@ -360,7 +359,7 @@ diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -5049,7 +5049,8 @@ ChromeContentBrowserClient::CreateURLLoaderThrottles(
+@@ -5085,7 +5085,8 @@ ChromeContentBrowserClient::CreateURLLoaderThrottles(
    chrome::mojom::DynamicParams dynamic_params = {
        profile->GetPrefs()->GetBoolean(prefs::kForceGoogleSafeSearch),
        profile->GetPrefs()->GetInteger(prefs::kForceYouTubeRestrict),
@@ -373,7 +372,7 @@ diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/ch
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
-@@ -6475,6 +6475,11 @@ const char kFollowingFeedSidepanelDescription[] =
+@@ -6692,6 +6692,11 @@ const char kFollowingFeedSidepanelDescription[] =
  #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) ||
          // BUILDFLAG(IS_FUCHSIA) || BUILDFLAG(IS_CHROMEOS)
  
@@ -388,7 +387,7 @@ diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descripti
 diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
 --- a/chrome/browser/flag_descriptions.h
 +++ b/chrome/browser/flag_descriptions.h
-@@ -3717,6 +3717,9 @@ extern const char kQuickCommandsDescription[];
+@@ -3835,6 +3835,9 @@ extern const char kQuickCommandsDescription[];
  #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) ||
          // defined (OS_FUCHSIA)
  
@@ -401,7 +400,7 @@ diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptio
 diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browser_prefs.cc
 --- a/chrome/browser/prefs/browser_prefs.cc
 +++ b/chrome/browser/prefs/browser_prefs.cc
-@@ -246,6 +246,7 @@
+@@ -251,6 +251,7 @@
  #include "components/ntp_tiles/popular_sites_impl.h"
  #include "components/permissions/contexts/geolocation_permission_context_android.h"
  #include "components/query_tiles/tile_service_prefs.h"
@@ -409,7 +408,7 @@ diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browse
  #else  // BUILDFLAG(IS_ANDROID)
  #include "chrome/browser/cart/cart_service.h"
  #include "chrome/browser/device_api/device_service_impl.h"
-@@ -1350,6 +1351,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
+@@ -1323,6 +1324,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
    translate::TranslatePrefs::RegisterProfilePrefs(registry);
    omnibox::RegisterProfilePrefs(registry);
    ZeroSuggestProvider::RegisterProfilePrefs(registry);
@@ -431,7 +430,7 @@ diff --git a/chrome/browser/profiles/BUILD.gn b/chrome/browser/profiles/BUILD.gn
 diff --git a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc b/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
 --- a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
 +++ b/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
-@@ -260,6 +260,8 @@
+@@ -261,6 +261,8 @@
  #include "chrome/browser/enterprise/idle/idle_service_factory.h"
  #endif
  
@@ -440,7 +439,7 @@ diff --git a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
  namespace chrome {
  
  void AddProfilesExtraParts(ChromeBrowserMainParts* main_parts) {
-@@ -618,6 +620,7 @@ void ChromeBrowserMainExtraPartsProfiles::
+@@ -620,6 +622,7 @@ void ChromeBrowserMainExtraPartsProfiles::
  #endif
    WebDataServiceFactory::GetInstance();
    webrtc_event_logging::WebRtcEventLogManagerKeyedServiceFactory::GetInstance();
@@ -451,7 +450,7 @@ diff --git a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
 diff --git a/chrome/browser/profiles/profile_manager.cc b/chrome/browser/profiles/profile_manager.cc
 --- a/chrome/browser/profiles/profile_manager.cc
 +++ b/chrome/browser/profiles/profile_manager.cc
-@@ -115,6 +115,8 @@
+@@ -116,6 +116,8 @@
  #include "extensions/common/manifest.h"
  #endif
  
@@ -460,7 +459,7 @@ diff --git a/chrome/browser/profiles/profile_manager.cc b/chrome/browser/profile
  #if BUILDFLAG(ENABLE_SESSION_SERVICE)
  #include "chrome/browser/sessions/app_session_service_factory.h"
  #include "chrome/browser/sessions/session_service_factory.h"
-@@ -1696,6 +1698,13 @@ void ProfileManager::DoFinalInitForServices(Profile* profile,
+@@ -1705,6 +1707,13 @@ void ProfileManager::DoFinalInitForServices(Profile* profile,
  #endif
  
  #endif
@@ -527,7 +526,7 @@ diff --git a/chrome/browser/profiles/renderer_updater.h b/chrome/browser/profile
 diff --git a/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc b/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
 --- a/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
 +++ b/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
-@@ -92,6 +92,7 @@
+@@ -94,6 +94,7 @@
  #include "components/security_interstitials/content/urls.h"
  #include "components/signin/public/base/signin_buildflags.h"
  #include "components/site_engagement/content/site_engagement_service.h"
@@ -535,7 +534,7 @@ diff --git a/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc b/chrom
  #include "content/public/browser/web_contents.h"
  #include "content/public/browser/web_ui.h"
  #include "content/public/common/content_client.h"
-@@ -821,6 +822,8 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
+@@ -834,6 +835,8 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
      return &NewWebUI<UserActionsUI>;
    if (url.host_piece() == chrome::kChromeUIVersionHost)
      return &NewWebUI<VersionUI>;
@@ -555,7 +554,7 @@ diff --git a/chrome/chrome_paks.gni b/chrome/chrome_paks.gni
        "$root_gen_dir/ui/resources/webui_generated_resources.pak",
      ]
      deps = [
-@@ -128,6 +129,7 @@ template("chrome_extra_paks") {
+@@ -129,6 +130,7 @@ template("chrome_extra_paks") {
        "//third_party/blink/public:devtools_inspector_resources",
        "//third_party/blink/public:resources",
        "//ui/resources",
@@ -611,7 +610,7 @@ diff --git a/chrome/renderer/chrome_content_renderer_client.cc b/chrome/renderer
  #if BUILDFLAG(ENABLE_SPELLCHECK)
    if (!spellcheck_)
      InitSpellCheck();
-@@ -576,6 +585,13 @@ void ChromeContentRendererClient::RenderFrameCreated(
+@@ -587,6 +596,13 @@ void ChromeContentRendererClient::RenderFrameCreated(
        render_frame, registry);
  #endif
  
@@ -625,7 +624,7 @@ diff --git a/chrome/renderer/chrome_content_renderer_client.cc b/chrome/renderer
  #if BUILDFLAG(ENABLE_PPAPI)
    new PepperHelper(render_frame);
  #endif
-@@ -1545,7 +1561,14 @@ void ChromeContentRendererClient::RunScriptsAtDocumentStart(
+@@ -1556,7 +1572,14 @@ void ChromeContentRendererClient::RunScriptsAtDocumentStart(
    ChromeExtensionsRendererClient::GetInstance()->RunScriptsAtDocumentStart(
        render_frame);
    // |render_frame| might be dead by now.
@@ -640,7 +639,7 @@ diff --git a/chrome/renderer/chrome_content_renderer_client.cc b/chrome/renderer
  }
  
  void ChromeContentRendererClient::RunScriptsAtDocumentEnd(
-@@ -1554,7 +1577,14 @@ void ChromeContentRendererClient::RunScriptsAtDocumentEnd(
+@@ -1565,7 +1588,14 @@ void ChromeContentRendererClient::RunScriptsAtDocumentEnd(
    ChromeExtensionsRendererClient::GetInstance()->RunScriptsAtDocumentEnd(
        render_frame);
    // |render_frame| might be dead by now.
@@ -655,7 +654,7 @@ diff --git a/chrome/renderer/chrome_content_renderer_client.cc b/chrome/renderer
  }
  
  void ChromeContentRendererClient::RunScriptsAtDocumentIdle(
-@@ -1563,7 +1593,14 @@ void ChromeContentRendererClient::RunScriptsAtDocumentIdle(
+@@ -1574,7 +1604,14 @@ void ChromeContentRendererClient::RunScriptsAtDocumentIdle(
    ChromeExtensionsRendererClient::GetInstance()->RunScriptsAtDocumentIdle(
        render_frame);
    // |render_frame| might be dead by now.
@@ -673,7 +672,7 @@ diff --git a/chrome/renderer/chrome_content_renderer_client.cc b/chrome/renderer
 diff --git a/chrome/renderer/chrome_render_thread_observer.cc b/chrome/renderer/chrome_render_thread_observer.cc
 --- a/chrome/renderer/chrome_render_thread_observer.cc
 +++ b/chrome/renderer/chrome_render_thread_observer.cc
-@@ -55,6 +55,8 @@
+@@ -57,6 +57,8 @@
  #include "third_party/blink/public/web/web_security_policy.h"
  #include "third_party/blink/public/web/web_view.h"
  
@@ -682,7 +681,7 @@ diff --git a/chrome/renderer/chrome_render_thread_observer.cc b/chrome/renderer/
  #if BUILDFLAG(ENABLE_EXTENSIONS)
  #include "extensions/renderer/localization_peer.h"
  #endif
-@@ -253,6 +255,7 @@ void ChromeRenderThreadObserver::SetInitialConfiguration(
+@@ -259,6 +261,7 @@ void ChromeRenderThreadObserver::SetInitialConfiguration(
  void ChromeRenderThreadObserver::SetConfiguration(
      chrome::mojom::DynamicParamsPtr params) {
    *GetDynamicConfigParams() = std::move(*params);
@@ -699,8 +698,8 @@ diff --git a/components/components_strings.grd b/components/components_strings.g
        <part file="webapps_strings.grdp" />
 +      <part file="user_scripts/strings/userscripts_strings.grdp" />
  
-       <part file="browser_ui/strings/android/webgl.grdp" />
-       <part file="browser_ui/strings/android/webrtc.grdp" />
+       <if expr="not is_ios">
+         <part file="history_clusters_strings.grdp" />
 diff --git a/components/user_scripts/README.md b/components/user_scripts/README.md
 new file mode 100644
 --- /dev/null
@@ -2608,10 +2607,9 @@ new file mode 100644
 +js_library("view_script_source") {
 +  deps = [
 +    "//ui/webui/resources/js:cr.m",
-+    "//ui/webui/resources/js:util.m",
++    "//ui/webui/resources/js:util",
 +  ]
 +}
-\ No newline at end of file
 diff --git a/components/user_scripts/browser/resources/user-script-ui/user-scripts-ui.html b/components/user_scripts/browser/resources/user-script-ui/user-scripts-ui.html
 new file mode 100644
 --- /dev/null
@@ -2621,7 +2619,7 @@ new file mode 100644
 +<html lang="en">
 +<head>
 +  <meta charset="utf-8">
-+  <title>Local State Debug Page</title>
++  <title>Userscript View Source</title>
 +  <link rel="stylesheet" href="chrome://resources/css/text_defaults.css">
 +  <script type="module" src="user-scripts-ui.js"></script>
 +</head>
@@ -2631,14 +2629,13 @@ new file mode 100644
 +  </pre>
 +</body>
 +</html>
-\ No newline at end of file
 diff --git a/components/user_scripts/browser/resources/user-script-ui/user-scripts-ui.js b/components/user_scripts/browser/resources/user-script-ui/user-scripts-ui.js
 new file mode 100644
 --- /dev/null
 +++ b/components/user_scripts/browser/resources/user-script-ui/user-scripts-ui.js
 @@ -0,0 +1,9 @@
 +import {sendWithPromise} from 'chrome://resources/js/cr.m.js';
-+import {$} from 'chrome://resources/js/util.m.js';
++import {$} from 'chrome://resources/js/util.js';
 +
 +document.addEventListener('DOMContentLoaded', function() {
 +  const urlParams = new URLSearchParams(window.location.search);
@@ -2646,7 +2643,6 @@ new file mode 100644
 +    $('content').textContent = textContent[0].content;
 +  });
 +});
-\ No newline at end of file
 diff --git a/components/user_scripts/browser/ui/user_scripts_ui.cc b/components/user_scripts/browser/ui/user_scripts_ui.cc
 new file mode 100644
 --- /dev/null
@@ -5072,19 +5068,19 @@ new file mode 100755
 +      // Not IPv6 (either IPv4 or just a normal address).
 +      port_separator_pos = host_and_port.find(':');
 +    } else {  // IPv6.
-+      size_t host_end_pos = host_and_port.find(']');
-+      if (host_end_pos == base::StringPiece::npos)
++      size_t ipv6_host_end_pos = host_and_port.find(']');
++      if (ipv6_host_end_pos == base::StringPiece::npos)
 +        return ParseResult::kInvalidHost;
-+      if (host_end_pos == 1)
++      if (ipv6_host_end_pos == 1)
 +        return ParseResult::kEmptyHost;
 +
-+      if (host_end_pos < host_and_port.length() - 1) {
++      if (ipv6_host_end_pos < host_and_port.length() - 1) {
 +        // The host isn't the only component. Check for a port. This would
 +        // require a ':' to follow the closing ']' from the host.
-+        if (host_and_port[host_end_pos + 1] != ':')
++        if (host_and_port[ipv6_host_end_pos + 1] != ':')
 +          return ParseResult::kInvalidHost;
 +
-+        port_separator_pos = host_end_pos + 1;
++        port_separator_pos = ipv6_host_end_pos + 1;
 +      }
 +    }
 +
@@ -10471,7 +10467,7 @@ new file mode 100755
 diff --git a/tools/gritsettings/resource_ids.spec b/tools/gritsettings/resource_ids.spec
 --- a/tools/gritsettings/resource_ids.spec
 +++ b/tools/gritsettings/resource_ids.spec
-@@ -732,6 +732,12 @@
+@@ -738,6 +738,12 @@
    "components/autofill/core/browser/autofill_address_rewriter_resources.grd":{
      "includes": [3720]
    },

--- a/build/patches/History-number-of-days-privacy-setting.patch
+++ b/build/patches/History-number-of-days-privacy-setting.patch
@@ -162,7 +162,7 @@ diff --git a/chrome/browser/history/history_service_factory.cc b/chrome/browser/
 diff --git a/chrome/browser/preferences/BUILD.gn b/chrome/browser/preferences/BUILD.gn
 --- a/chrome/browser/preferences/BUILD.gn
 +++ b/chrome/browser/preferences/BUILD.gn
-@@ -45,6 +45,7 @@ java_cpp_strings("java_pref_names_srcjar") {
+@@ -46,6 +46,7 @@ java_cpp_strings("java_pref_names_srcjar") {
      "//components/safe_browsing/core/common/safe_browsing_prefs.cc",
      "//components/signin/public/base/signin_pref_names.cc",
      "//components/translate/core/browser/translate_pref_names.cc",
@@ -173,7 +173,7 @@ diff --git a/chrome/browser/preferences/BUILD.gn b/chrome/browser/preferences/BU
 diff --git a/chrome/browser/profiles/profile_impl.cc b/chrome/browser/profiles/profile_impl.cc
 --- a/chrome/browser/profiles/profile_impl.cc
 +++ b/chrome/browser/profiles/profile_impl.cc
-@@ -373,6 +373,7 @@ std::unique_ptr<Profile> Profile::CreateProfile(const base::FilePath& path,
+@@ -365,6 +365,7 @@ std::unique_ptr<Profile> Profile::CreateProfile(const base::FilePath& path,
  void ProfileImpl::RegisterProfilePrefs(
      user_prefs::PrefRegistrySyncable* registry) {
    registry->RegisterBooleanPref(prefs::kSavingBrowserHistoryDisabled, false);
@@ -184,7 +184,7 @@ diff --git a/chrome/browser/profiles/profile_impl.cc b/chrome/browser/profiles/p
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -1136,6 +1136,18 @@ Your Google account may have other forms of browsing history like searches and a
+@@ -1139,6 +1139,18 @@ Your Google account may have other forms of browsing history like searches and a
        <message name="IDS_CLEAR_HISTORY_TITLE" desc="Title for Clear History in Clear Browsing Data dialog">
          Browsing history
        </message>
@@ -356,7 +356,7 @@ diff --git a/components/history/core/browser/expire_history_backend.h b/componen
 diff --git a/components/history/core/browser/history_backend.cc b/components/history/core/browser/history_backend.cc
 --- a/components/history/core/browser/history_backend.cc
 +++ b/components/history/core/browser/history_backend.cc
-@@ -156,7 +156,7 @@ const int kMaxRedirectCount = 32;
+@@ -158,7 +158,7 @@ const int kMaxRedirectCount = 32;
  
  // The number of days old a history entry can be before it is considered "old"
  // and is deleted.
@@ -365,7 +365,7 @@ diff --git a/components/history/core/browser/history_backend.cc b/components/his
  
  // The maximum number of days for which domain visit metrics are computed
  // each time HistoryBackend::GetDomainDiversity() is called.
-@@ -1088,6 +1088,19 @@ void HistoryBackend::InitImpl(
+@@ -1090,6 +1090,19 @@ void HistoryBackend::InitImpl(
    LOCAL_HISTOGRAM_TIMES("History.InitTime", TimeTicks::Now() - beginning_time);
  }
  
@@ -410,7 +410,7 @@ diff --git a/components/history/core/browser/history_service.cc b/components/his
  #include "components/history/core/browser/download_row.h"
  #include "components/history/core/browser/history_backend.h"
  #include "components/history/core/browser/history_backend_client.h"
-@@ -1105,6 +1108,9 @@ void HistoryService::Cleanup() {
+@@ -1126,6 +1129,9 @@ void HistoryService::Cleanup() {
      return;
    }
  
@@ -420,7 +420,7 @@ diff --git a/components/history/core/browser/history_service.cc b/components/his
    NotifyHistoryServiceBeingDeleted();
  
    weak_ptr_factory_.InvalidateWeakPtrs();
-@@ -1169,6 +1175,33 @@ bool HistoryService::Init(
+@@ -1190,6 +1196,33 @@ bool HistoryService::Init(
    return true;
  }
  
@@ -475,7 +475,7 @@ diff --git a/components/history/core/browser/history_service.h b/components/hist
    // Triggers the backend to load if it hasn't already, and then returns whether
    // it's finished loading.
    // Note: Virtual needed for mocking.
-@@ -1013,6 +1017,10 @@ class HistoryService : public KeyedService {
+@@ -1024,6 +1028,10 @@ class HistoryService : public KeyedService {
  
    base::OnceClosure origin_queried_closure_for_testing_;
  

--- a/build/patches/JIT-site-settings.patch
+++ b/build/patches/JIT-site-settings.patch
@@ -55,10 +55,10 @@ diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/b
      "java/res/drawable-mdpi/permission_background_sync.png",
      "java/res/drawable-mdpi/permission_javascript.png",
 +    "java/res/drawable-mdpi/permission_javascript_jit.png",
-     "java/res/drawable-hdpi/settings_autoplay.png",
-     "java/res/drawable-xhdpi/settings_autoplay.png",
-     "java/res/drawable-xxhdpi/settings_autoplay.png",
-@@ -183,6 +185,7 @@ android_resources("java_resources") {
+     "java/res/drawable-mdpi/permission_popups.png",
+     "java/res/drawable-mdpi/permission_protected_media.png",
+     "java/res/drawable-mdpi/settings_sensors.png",
+@@ -178,6 +180,7 @@ android_resources("java_resources") {
      "java/res/drawable-xhdpi/ic_volume_up_grey600_24dp.png",
      "java/res/drawable-xhdpi/permission_background_sync.png",
      "java/res/drawable-xhdpi/permission_javascript.png",
@@ -66,7 +66,7 @@ diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/b
      "java/res/drawable-xhdpi/permission_popups.png",
      "java/res/drawable-xhdpi/permission_protected_media.png",
      "java/res/drawable-xhdpi/settings_sensors.png",
-@@ -190,6 +193,7 @@ android_resources("java_resources") {
+@@ -185,6 +188,7 @@ android_resources("java_resources") {
      "java/res/drawable-xxhdpi/ic_volume_up_grey600_24dp.png",
      "java/res/drawable-xxhdpi/permission_background_sync.png",
      "java/res/drawable-xxhdpi/permission_javascript.png",
@@ -74,7 +74,7 @@ diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/b
      "java/res/drawable-xxhdpi/permission_popups.png",
      "java/res/drawable-xxhdpi/permission_protected_media.png",
      "java/res/drawable-xxhdpi/settings_sensors.png",
-@@ -197,6 +201,7 @@ android_resources("java_resources") {
+@@ -192,6 +196,7 @@ android_resources("java_resources") {
      "java/res/drawable-xxxhdpi/ic_volume_up_grey600_24dp.png",
      "java/res/drawable-xxxhdpi/permission_background_sync.png",
      "java/res/drawable-xxxhdpi/permission_javascript.png",
@@ -247,8 +247,8 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
              case ContentSettingsType.POPUPS:
                  return "popup_permission_list";
              case ContentSettingsType.SOUND:
-@@ -514,6 +516,8 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
-                 setUpJavascriptPreference(preference);
+@@ -516,6 +518,8 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
+                 setUpCookiesPreference(preference);
              } else if (type == ContentSettingsType.GEOLOCATION) {
                  setUpLocationPreference(preference);
 +            } else if (type == ContentSettingsType.JAVASCRIPT_JIT) {
@@ -256,9 +256,9 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
              } else if (type == ContentSettingsType.NOTIFICATIONS) {
                  setUpNotificationsPreference(preference, mSite.isEmbargoed(type));
              } else if (type == ContentSettingsType.REQUEST_DESKTOP_SITE) {
-@@ -1060,6 +1064,23 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
+@@ -1072,6 +1076,23 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
          setupContentSettingsPreference(preference, currentValue, false /* isEmbargoed */);
-     }
+      }
  
 +    private void setUpJavascriptJitPreference(Preference preference) {
 +        BrowserContextHandle browserContextHandle =
@@ -337,7 +337,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
-@@ -230,6 +230,13 @@ public final class Website implements WebsiteEntry {
+@@ -235,6 +235,13 @@ public final class Website implements WebsiteEntry {
              } else {
                  RecordUserAction.record("JavascriptContentSetting.DisableBy.SiteSettings");
              }

--- a/build/patches/Keep-empty-tabs-between-sessions.patch
+++ b/build/patches/Keep-empty-tabs-between-sessions.patch
@@ -12,7 +12,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPersistentStore.java
-@@ -806,14 +806,6 @@ public class TabPersistentStore {
+@@ -816,14 +816,6 @@ public class TabPersistentStore {
                  mTabsToMigrate.add(tab);
              }
          } else {
@@ -30,7 +30,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabPer
 diff --git a/chrome/browser/tab/java/src/org/chromium/chrome/browser/tab/state/CriticalPersistedTabData.java b/chrome/browser/tab/java/src/org/chromium/chrome/browser/tab/state/CriticalPersistedTabData.java
 --- a/chrome/browser/tab/java/src/org/chromium/chrome/browser/tab/state/CriticalPersistedTabData.java
 +++ b/chrome/browser/tab/java/src/org/chromium/chrome/browser/tab/state/CriticalPersistedTabData.java
-@@ -598,9 +598,6 @@ public class CriticalPersistedTabData extends PersistedTabData {
+@@ -602,9 +602,6 @@ public class CriticalPersistedTabData extends PersistedTabData {
          if (getUrl() == null || getUrl().isEmpty()) {
              return false;
          }

--- a/build/patches/Logcat-crash-reports-UI.patch
+++ b/build/patches/Logcat-crash-reports-UI.patch
@@ -140,7 +140,7 @@ diff --git a/chrome/browser/crash_upload_list/crash_upload_list_android.h b/chro
 diff --git a/chrome/browser/net/chrome_network_delegate.cc b/chrome/browser/net/chrome_network_delegate.cc
 --- a/chrome/browser/net/chrome_network_delegate.cc
 +++ b/chrome/browser/net/chrome_network_delegate.cc
-@@ -131,6 +131,13 @@ bool IsAccessAllowedAndroid(const base::FilePath& path) {
+@@ -133,6 +133,13 @@ bool IsAccessAllowedAndroid(const base::FilePath& path) {
    if (external_storage_path.IsParent(path))
      return true;
  
@@ -157,7 +157,7 @@ diff --git a/chrome/browser/net/chrome_network_delegate.cc b/chrome/browser/net/
 diff --git a/chrome/browser/ui/BUILD.gn b/chrome/browser/ui/BUILD.gn
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -633,6 +633,7 @@ static_library("ui") {
+@@ -639,6 +639,7 @@ static_library("ui") {
      "//third_party/re2",
      "//third_party/webrtc_overrides:webrtc_component",
      "//third_party/zlib",
@@ -279,7 +279,7 @@ diff --git a/chrome/browser/ui/webui/crashes_ui.cc b/chrome/browser/ui/webui/cra
  
    bool system_crash_reporter = false;
  #if BUILDFLAG(IS_CHROMEOS)
-@@ -234,14 +277,112 @@ void CrashesDOMHandler::UpdateUI() {
+@@ -226,14 +269,112 @@ void CrashesDOMHandler::UpdateUI() {
  
  void CrashesDOMHandler::HandleRequestSingleCrashUpload(
      const base::Value::List& args) {
@@ -398,7 +398,7 @@ diff --git a/chrome/browser/ui/webui/crashes_ui.cc b/chrome/browser/ui/webui/cra
  }
  
  }  // namespace
-@@ -253,7 +394,8 @@ void CrashesDOMHandler::HandleRequestSingleCrashUpload(
+@@ -245,7 +386,8 @@ void CrashesDOMHandler::HandleRequestSingleCrashUpload(
  ///////////////////////////////////////////////////////////////////////////////
  
  CrashesUI::CrashesUI(content::WebUI* web_ui) : WebUIController(web_ui) {

--- a/build/patches/Move-navigation-bar-to-bottom.patch
+++ b/build/patches/Move-navigation-bar-to-bottom.patch
@@ -12,7 +12,7 @@ Support for tablet mode is also included.
 Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- cc/base/features.cc                           |  3 ++
+ cc/base/features.cc                           |  4 ++
  cc/base/features.h                            |  1 +
  cc/input/browser_controls_offset_manager.cc   |  6 +++
  cc/trees/layer_tree_host_impl.cc              |  3 ++
@@ -44,7 +44,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../modaldialog/ChromeTabModalPresenter.java  |  2 +-
  .../chrome/browser/ntp/NewTabPage.java        | 13 +++--
  .../chrome/browser/ntp/RecentTabsPage.java    | 22 ++++++--
- .../browser/searchwidget/SearchActivity.java  | 12 ++++-
+ .../browser/searchwidget/SearchActivity.java  | 13 ++++-
  .../browser/settings/SettingsActivity.java    |  5 ++
  .../StatusIndicatorCoordinator.java           | 10 ++++
  .../StatusIndicatorSceneLayer.java            |  7 ++-
@@ -65,9 +65,9 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../ui/appmenu/AppMenuHandlerImpl.java        | 11 ++++
  .../omnibox/LocationBarCoordinator.java       |  9 +++-
  .../browser/omnibox/UrlBarCoordinator.java    | 11 +++-
- .../suggestions/AutocompleteCoordinator.java  | 16 +++++-
+ .../suggestions/AutocompleteCoordinator.java  | 18 ++++++-
  .../suggestions/AutocompleteMediator.java     |  7 ++-
- .../OmniboxSuggestionsDropdown.java           | 23 +++++++-
+ .../OmniboxSuggestionsDropdown.java           | 22 +++++++-
  .../OmniboxSuggestionsDropdownEmbedder.java   |  4 ++
  .../strings/android_chrome_strings.grd        |  6 +++
  chrome/browser/ui/android/toolbar/BUILD.gn    |  1 +
@@ -86,29 +86,30 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../accessibility/AccessibilitySettings.java  | 16 ++++++
  .../AccessibilitySettingsDelegate.java        |  6 +++
  .../render_widget_host_view_android.cc        |  3 ++
- 74 files changed, 782 insertions(+), 56 deletions(-)
+ 74 files changed, 784 insertions(+), 57 deletions(-)
 
 diff --git a/cc/base/features.cc b/cc/base/features.cc
 --- a/cc/base/features.cc
 +++ b/cc/base/features.cc
-@@ -35,6 +35,9 @@ const base::Feature kSynchronizedScrolling = {
-     base::FEATURE_ENABLED_BY_DEFAULT};
- #endif
+@@ -40,6 +40,10 @@ BASE_FEATURE(kAvoidRasterDuringElasticOverscroll,
+              "AvoidRasterDuringElasticOverscroll",
+              base::FEATURE_DISABLED_BY_DEFAULT);
  
-+const base::Feature kMoveTopToolbarToBottom = {
-+    "MoveTopToolbarToBottom", base::FEATURE_DISABLED_BY_DEFAULT};
++BASE_FEATURE(kMoveTopToolbarToBottom,
++             "MoveTopToolbarToBottom",
++             base::FEATURE_DISABLED_BY_DEFAULT);
 +
- const base::Feature kRemoveMobileViewportDoubleTap{
-     "RemoveMobileViewportDoubleTap", base::FEATURE_ENABLED_BY_DEFAULT};
- 
+ BASE_FEATURE(kRemoveMobileViewportDoubleTap,
+              "RemoveMobileViewportDoubleTap",
+              base::FEATURE_ENABLED_BY_DEFAULT);
 diff --git a/cc/base/features.h b/cc/base/features.h
 --- a/cc/base/features.h
 +++ b/cc/base/features.h
-@@ -14,6 +14,7 @@ namespace features {
- CC_BASE_EXPORT extern const base::Feature kAnimatedImageResume;
- CC_BASE_EXPORT extern bool IsImpulseScrollAnimationEnabled();
- CC_BASE_EXPORT extern const base::Feature kSynchronizedScrolling;
-+CC_BASE_EXPORT extern const base::Feature kMoveTopToolbarToBottom;
+@@ -20,6 +20,7 @@ CC_BASE_EXPORT BASE_DECLARE_FEATURE(kSynchronizedScrolling);
+ // that resets the scale at the end. When enabled, this aovids recomputing
+ // raster scale during elastic overscroll.
+ CC_BASE_EXPORT BASE_DECLARE_FEATURE(kAvoidRasterDuringElasticOverscroll);
++CC_BASE_EXPORT BASE_DECLARE_FEATURE(kMoveTopToolbarToBottom);
  
  // When enabled, the double tap to zoom will be disabled when the viewport
  // meta tag is properly set for mobile using content=width=device-width
@@ -138,7 +139,7 @@ diff --git a/cc/input/browser_controls_offset_manager.cc b/cc/input/browser_cont
 diff --git a/cc/trees/layer_tree_host_impl.cc b/cc/trees/layer_tree_host_impl.cc
 --- a/cc/trees/layer_tree_host_impl.cc
 +++ b/cc/trees/layer_tree_host_impl.cc
-@@ -4229,6 +4229,9 @@ bool LayerTreeHostImpl::AnimateBrowserControls(base::TimeTicks time) {
+@@ -4253,6 +4253,9 @@ bool LayerTreeHostImpl::AnimateBrowserControls(base::TimeTicks time) {
    if (scroll_delta.IsZero())
      return false;
  
@@ -151,7 +152,7 @@ diff --git a/cc/trees/layer_tree_host_impl.cc b/cc/trees/layer_tree_host_impl.cc
 diff --git a/chrome/android/features/start_surface/java/src/org/chromium/chrome/features/start_surface/StartSurfaceMediator.java b/chrome/android/features/start_surface/java/src/org/chromium/chrome/features/start_surface/StartSurfaceMediator.java
 --- a/chrome/android/features/start_surface/java/src/org/chromium/chrome/features/start_surface/StartSurfaceMediator.java
 +++ b/chrome/android/features/start_surface/java/src/org/chromium/chrome/features/start_surface/StartSurfaceMediator.java
-@@ -78,6 +78,9 @@ import org.chromium.components.prefs.PrefService;
+@@ -85,6 +85,9 @@ import org.chromium.content_public.browser.LoadUrlParams;
  import org.chromium.ui.modelutil.PropertyModel;
  import org.chromium.ui.util.ColorUtils;
  
@@ -160,8 +161,8 @@ diff --git a/chrome/android/features/start_surface/java/src/org/chromium/chrome/
 +
  /** The mediator implements the logic to interact with the surfaces and caller. */
  class StartSurfaceMediator implements TabSwitcher.TabSwitcherViewObserver, View.OnClickListener,
-                                       StartSurface.OnTabSelectingListener, BackPressHandler {
-@@ -1028,6 +1031,8 @@ class StartSurfaceMediator implements TabSwitcher.TabSwitcherViewObserver, View.
+                                       StartSurface.OnTabSelectingListener, BackPressHandler,
+@@ -1095,6 +1098,8 @@ class StartSurfaceMediator implements TabSwitcher.TabSwitcherViewObserver, View.
      }
  
      private void setTopMargin(int topMargin) {
@@ -392,7 +393,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
 diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListContainerViewBinder.java b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListContainerViewBinder.java
 --- a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListContainerViewBinder.java
 +++ b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListContainerViewBinder.java
-@@ -22,6 +22,8 @@ import androidx.recyclerview.widget.LinearLayoutManager;
+@@ -21,6 +21,8 @@ import androidx.recyclerview.widget.LinearLayoutManager;
  import org.chromium.components.browser_ui.styles.ChromeColors;
  import org.chromium.ui.modelutil.PropertyKey;
  import org.chromium.ui.modelutil.PropertyModel;
@@ -401,7 +402,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
  
  /**
   * ViewBinder for TabListRecyclerView.
-@@ -58,6 +60,8 @@ class TabListContainerViewBinder {
+@@ -57,6 +59,8 @@ class TabListContainerViewBinder {
              params.topMargin = newTopMargin;
              view.requestLayout();
          } else if (BOTTOM_CONTROLS_HEIGHT == propertyKey) {
@@ -453,7 +454,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
      /**
       * Field trial parameter for downsampling scaling factor.
       */
-@@ -194,6 +197,7 @@ class TabListRecyclerView
+@@ -192,6 +195,7 @@ class TabListRecyclerView
                  ? FINAL_FADE_IN_DURATION_MS
                  : BASE_ANIMATION_DURATION_MS;
  
@@ -461,7 +462,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
          setAlpha(0);
          setVisibility(View.VISIBLE);
          mFadeInAnimator = ObjectAnimator.ofFloat(this, View.ALPHA, 1);
-@@ -227,6 +231,11 @@ class TabListRecyclerView
+@@ -225,6 +229,11 @@ class TabListRecyclerView
      }
  
      void setShadowVisibility(boolean shouldShowShadow) {
@@ -473,7 +474,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
          if (mShadowImageView == null) {
              Context context = getContext();
              mShadowImageView = new ImageView(context);
-@@ -239,7 +248,10 @@ class TabListRecyclerView
+@@ -237,7 +246,10 @@ class TabListRecyclerView
              if (getParent() instanceof FrameLayout) {
                  // Add shadow for grid tab switcher.
                  FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
@@ -485,7 +486,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
                  mShadowImageView.setLayoutParams(params);
                  mShadowImageView.setTranslationY(mShadowTopOffset);
                  FrameLayout parent = (FrameLayout) getParent();
-@@ -266,6 +278,10 @@ class TabListRecyclerView
+@@ -264,6 +276,10 @@ class TabListRecyclerView
  
      void setShadowTopOffset(int shadowTopOffset) {
          mShadowTopOffset = shadowTopOffset;
@@ -496,7 +497,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
  
          if (mShadowImageView != null && getParent() instanceof FrameLayout) {
              // Since the shadow has no functionality, other than just existing visually, we can use
-@@ -445,6 +461,7 @@ class TabListRecyclerView
+@@ -443,6 +459,7 @@ class TabListRecyclerView
                  mListener.finishedHiding();
              }
          });
@@ -507,15 +508,15 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
 diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java
 --- a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java
 +++ b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java
-@@ -40,6 +40,7 @@ import org.chromium.chrome.browser.browser_controls.BrowserControlsStateProvider
- import org.chromium.chrome.browser.compositor.layouts.LayoutManagerImpl;
- import org.chromium.chrome.browser.compositor.layouts.content.TabContentManager;
+@@ -43,6 +43,7 @@ import org.chromium.chrome.browser.compositor.layouts.content.TabContentManager;
  import org.chromium.chrome.browser.flags.ChromeFeatureList;
+ import org.chromium.chrome.browser.incognito.reauth.IncognitoReauthController;
+ import org.chromium.chrome.browser.incognito.reauth.IncognitoReauthManager;
 +import org.chromium.chrome.browser.flags.CachedFeatureFlags;
  import org.chromium.chrome.browser.multiwindow.MultiWindowModeStateDispatcher;
  import org.chromium.chrome.browser.preferences.ChromePreferenceKeys;
  import org.chromium.chrome.browser.preferences.SharedPreferencesManager;
-@@ -414,11 +415,22 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
+@@ -457,11 +458,22 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
              updateTopControlsProperties();
              mContainerViewModel.set(
                      BOTTOM_CONTROLS_HEIGHT, browserControlsStateProvider.getBottomControlsHeight());
@@ -538,7 +539,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
          }
  
          mContainerView = containerView;
-@@ -535,6 +547,10 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
+@@ -588,6 +600,10 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
          final int contentOffset = mBrowserControlsStateProvider.getContentOffset();
  
          mContainerViewModel.set(TOP_MARGIN, contentOffset);
@@ -628,7 +629,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/accessibility/s
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
-@@ -243,6 +243,9 @@ import java.util.ArrayList;
+@@ -244,6 +244,9 @@ import java.util.ArrayList;
  import java.util.List;
  import java.util.function.Consumer;
  
@@ -638,7 +639,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActiv
  /**
   * A {@link AsyncInitializationActivity} that builds and manages a {@link CompositorViewHolder}
   * and associated classes.
-@@ -747,6 +750,16 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
+@@ -748,6 +751,16 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
                  int toolbarLayoutId = getToolbarLayoutId();
                  if (toolbarLayoutId != ActivityUtils.NO_RESOURCE_ID && controlContainer != null) {
                      controlContainer.initWithToolbar(toolbarLayoutId);
@@ -658,19 +659,19 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActiv
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java b/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
-@@ -107,6 +107,7 @@ public class ChromeCachedFlags {
+@@ -111,6 +111,7 @@ public class ChromeCachedFlags {
                  add(ChromeFeatureList.sInstanceSwitcher);
                  add(ChromeFeatureList.sInstantStart);
                  add(ChromeFeatureList.sInterestFeedV2);
 +                add(ChromeFeatureList.sMoveTopToolbarToBottom);
                  add(ChromeFeatureList.sNewWindowAppMenu);
                  add(ChromeFeatureList.sOmniboxModernizeVisualUpdate);
-                 add(ChromeFeatureList.sOptimizationGuidePushNotifications);
+                 add(ChromeFeatureList.sOmniboxRemoveExcessiveRecycledViewClearCalls);
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/CompositorViewHolder.java b/chrome/android/java/src/org/chromium/chrome/browser/compositor/CompositorViewHolder.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/compositor/CompositorViewHolder.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/compositor/CompositorViewHolder.java
-@@ -79,6 +79,8 @@ import org.chromium.ui.base.EventOffsetHandler;
- import org.chromium.ui.base.WindowAndroid;
+@@ -83,6 +83,8 @@ import org.chromium.ui.base.WindowAndroid;
+ import org.chromium.ui.mojom.VirtualKeyboardMode;
  import org.chromium.ui.resources.ResourceManager;
  import org.chromium.ui.resources.dynamics.DynamicResourceLoader;
 +import org.chromium.chrome.browser.flags.ChromeFeatureList;
@@ -678,7 +679,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/Comp
  
  import java.util.ArrayList;
  import java.util.HashSet;
-@@ -298,6 +300,10 @@ public class CompositorViewHolder extends FrameLayout
+@@ -316,6 +318,10 @@ public class CompositorViewHolder extends FrameLayout
                          WebContents webContents = mTabVisible.getWebContents();
                          if (webContents == null) return;
                          EventForwarder forwarder = webContents.getEventForwarder();
@@ -765,7 +766,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/layo
  
  import java.util.concurrent.Callable;
  
-@@ -84,7 +85,8 @@ public class LayoutManagerChromeTablet extends LayoutManagerChrome {
+@@ -87,7 +88,8 @@ public class LayoutManagerChromeTablet extends LayoutManagerChrome {
          mStartSurfaceSupplier = startSurfaceSupplier;
          mTabSwitcherSupplier = tabSwitcherSupplier;
          mTabStripLayoutHelperManager = new StripLayoutHelperManager(host.getContext(), this,
@@ -817,7 +818,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/layo
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelper.java b/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelper.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelper.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelper.java
-@@ -376,7 +376,7 @@ public class StripLayoutHelper implements StripLayoutTab.StripLayoutTabDelegate
+@@ -375,7 +375,7 @@ public class StripLayoutHelper implements StripLayoutTab.StripLayoutTabDelegate
          // position 0 is on the left. Account for that in the offset calculation.
          boolean isRtl = LocalizationUtils.isLayoutRtl();
          boolean useUnadjustedScrollOffset = isRtl != isLeft;
@@ -1066,7 +1067,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/findinpage/Find
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/BrowserControlsManager.java b/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/BrowserControlsManager.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/BrowserControlsManager.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/BrowserControlsManager.java
-@@ -49,6 +49,9 @@ import org.chromium.ui.vr.VrModeObserver;
+@@ -51,6 +51,9 @@ import org.chromium.ui.vr.VrModeObserver;
  import java.lang.annotation.Retention;
  import java.lang.annotation.RetentionPolicy;
  
@@ -1076,7 +1077,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/Brow
  /**
   * A class that manages browser control visibility and positioning.
   */
-@@ -367,6 +370,14 @@ public class BrowserControlsManager
+@@ -396,6 +399,14 @@ public class BrowserControlsManager
          return mTopControlContainerHeight;
      }
  
@@ -1091,7 +1092,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/Brow
      @Override
      public int getTopControlsMinHeight() {
          return mTopControlsMinHeight;
-@@ -433,6 +444,8 @@ public class BrowserControlsManager
+@@ -462,6 +473,8 @@ public class BrowserControlsManager
  
      @Override
      public float getTopVisibleContentOffset() {
@@ -1263,7 +1264,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsP
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java
-@@ -71,6 +71,11 @@ import org.chromium.ui.base.WindowDelegate;
+@@ -76,6 +76,11 @@ import org.chromium.ui.base.WindowDelegate;
  import org.chromium.ui.modaldialog.ModalDialogManager;
  import org.chromium.url.GURL;
  
@@ -1275,24 +1276,25 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/Se
  import java.lang.ref.WeakReference;
  
  /** Queries the user's default search engine and shows autocomplete suggestions. */
-@@ -182,6 +187,11 @@ public class SearchActivity extends AsyncInitializationActivity
+@@ -189,6 +194,12 @@ public class SearchActivity extends AsyncInitializationActivity
          mSearchBox = (SearchActivityLocationBarLayout) mContentView.findViewById(
                  R.id.search_location_bar);
-         View anchorView = mContentView.findViewById(R.id.toolbar);
+         mAnchorView = mContentView.findViewById(R.id.toolbar);
 +        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
 +            CoordinatorLayout.LayoutParams layoutParams = (CoordinatorLayout.LayoutParams)
-+                anchorView.getLayoutParams();
++                mAnchorView.getLayoutParams();
 +            layoutParams.gravity = Gravity.START | Gravity.BOTTOM;
++            mAnchorView.setLayoutParams(layoutParams);
 +        }
+         updateAnchorViewLayout();
+ 
          OverrideUrlLoadingDelegate overrideUrlLoadingDelegate =
-                 (String url, @PageTransition int transition, String postDataType, byte[] postData,
-                         boolean incognito) -> {
-@@ -195,7 +205,7 @@ public class SearchActivity extends AsyncInitializationActivity
+@@ -204,7 +215,7 @@ public class SearchActivity extends AsyncInitializationActivity
              getOnBackPressedDispatcher().addCallback(this, backPressManager.getCallback());
          }
          // clang-format off
--        mLocationBarCoordinator = new LocationBarCoordinator(mSearchBox, anchorView,
-+        mLocationBarCoordinator = new LocationBarCoordinator(mSearchBox, anchorView, anchorView,
+-        mLocationBarCoordinator = new LocationBarCoordinator(mSearchBox, mAnchorView,
++        mLocationBarCoordinator = new LocationBarCoordinator(mSearchBox, mAnchorView, mAnchorView,
                  mProfileSupplier, PrivacyPreferencesManagerImpl.getInstance(),
                  mSearchBoxDataProvider, null, new WindowDelegate(getWindow()), getWindowAndroid(),
                  /*activityTabSupplier=*/() -> null, getModalDialogManagerSupplier(),
@@ -1365,7 +1367,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/status_indicato
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
-@@ -176,6 +176,9 @@ import org.chromium.url.GURL;
+@@ -178,6 +178,9 @@ import org.chromium.url.GURL;
  
  import java.util.List;
  
@@ -1375,7 +1377,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
  /**
   * Contains logic for managing the toolbar visual component.  This class manages the interactions
   * with the rest of the application to ensure the toolbar is always visually up to date.
-@@ -665,7 +668,7 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+@@ -670,7 +673,7 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
                      mEphemeralTabCoordinatorSupplier);
              // clang-format off
              LocationBarCoordinator locationBarCoordinator = new LocationBarCoordinator(
@@ -1384,7 +1386,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
                      PrivacyPreferencesManagerImpl.getInstance(), mLocationBarModel,
                      mActionModeController.getActionModeCallback(),
                      new WindowDelegate(mActivity.getWindow()), windowAndroid, mActivityTabProvider,
-@@ -915,11 +918,13 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+@@ -927,11 +930,13 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
                  // the height won't be measured by the background image.
                  if (mControlContainer.getBackground() == null) {
                      setControlContainerTopMargin(getToolbarExtraYOffset());
@@ -1398,7 +1400,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
                              mControlContainer.removeOnLayoutChangeListener(mLayoutChangeListener);
                              mLayoutChangeListener = null;
                          }
-@@ -1286,13 +1291,25 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+@@ -1311,13 +1316,25 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
          return mLocationBar.getOmniboxStub().isUrlBarFocused();
      }
  
@@ -1426,7 +1428,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
                  mScrimCoordinator, mOmniboxFocusStateSupplier, mBottomSheetController,
                  mActivityLifecycleDispatcher, mIsWarmOnResumeSupplier, mTabModelSelector,
                  mTabContentManager, mCompositorViewHolder,
-@@ -1301,8 +1318,9 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+@@ -1326,8 +1343,9 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
          mBottomControlsCoordinatorSupplier.set(new BottomControlsCoordinator(mActivity,
                  mWindowAndroid, mLayoutManager, mCompositorViewHolder.getResourceManager(),
                  mBrowserControlsSizer, mFullscreenManager,
@@ -1438,7 +1440,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
      }
  
      /**
-@@ -2073,6 +2091,15 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+@@ -2091,6 +2109,15 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
      private void setControlContainerTopMargin(int margin) {
          final ViewGroup.MarginLayoutParams layoutParams =
                  ((ViewGroup.MarginLayoutParams) mControlContainer.getLayoutParams());
@@ -1507,7 +1509,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/system/Statu
  import org.chromium.base.ApiCompatibilityUtils;
  import org.chromium.base.CallbackController;
  import org.chromium.base.supplier.ObservableSupplier;
-@@ -347,6 +350,12 @@ public class StatusBarColorController
+@@ -370,6 +373,12 @@ public class StatusBarColorController
          boolean needsDarkStatusBarIcons = !ColorUtils.shouldUseLightForegroundOnBackground(color);
          ApiCompatibilityUtils.setStatusBarIconColor(root, needsDarkStatusBarIcons);
          ApiCompatibilityUtils.setStatusBarColor(mWindow, color);
@@ -1523,7 +1525,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/system/Statu
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -7202,6 +7202,11 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -7427,6 +7427,11 @@ const FeatureEntry kFeatureEntries[] = {
       flag_descriptions::kWindowsScrollingPersonalityDescription, kOsAll,
       FEATURE_VALUE_TYPE(features::kWindowsScrollingPersonality)},
  
@@ -1621,7 +1623,7 @@ diff --git a/chrome/browser/browser_controls/android/java/src/org/chromium/chrom
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
-@@ -1703,6 +1703,10 @@ const char kImprovedKeyboardShortcutsDescription[] =
+@@ -1752,6 +1752,10 @@ const char kImprovedKeyboardShortcutsDescription[] =
      "Ensure keyboard shortcuts work consistently with international keyboard "
      "layouts and deprecate legacy shortcuts.";
  
@@ -1635,7 +1637,7 @@ diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descripti
 diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
 --- a/chrome/browser/flag_descriptions.h
 +++ b/chrome/browser/flag_descriptions.h
-@@ -954,6 +954,9 @@ extern const char kImprovedKeyboardShortcutsDescription[];
+@@ -984,6 +984,9 @@ extern const char kImprovedKeyboardShortcutsDescription[];
  extern const char kCompositorThreadedScrollbarScrollingName[];
  extern const char kCompositorThreadedScrollbarScrollingDescription[];
  
@@ -1688,26 +1690,26 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browse
  #include "base/metrics/field_trial_params.h"
  #include "base/no_destructor.h"
  #include "base/strings/string_piece_forward.h"
-@@ -249,6 +250,7 @@ const base::Feature* const kFeaturesExposedToJava[] = {
+@@ -258,6 +259,7 @@ const base::Feature* const kFeaturesExposedToJava[] = {
      &kKitKatSupported,
      &kLensCameraAssistedSearch,
      &kLensOnQuickActionSearchWidget,
 +    &features::kMoveTopToolbarToBottom,
-     &kMostRecentTabOnBackgroundCloseTab,
      &kNewInstanceFromDraggedLink,
      &kNewTabPageTilesTitleWrapAround,
+     &kNewWindowAppMenu,
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
-@@ -103,6 +103,7 @@ public class CachedFeatureFlags {
-                     .put(ChromeFeatureList.TAB_GROUPS_CONTINUATION_ANDROID, false)
+@@ -107,6 +107,7 @@ public class CachedFeatureFlags {
                      .put(ChromeFeatureList.TAB_GROUPS_FOR_TABLETS, false)
+                     .put(ChromeFeatureList.TAB_SELECTION_EDITOR_V2, false)
                      .put(ChromeFeatureList.TAB_STRIP_IMPROVEMENTS, false)
 +                    .put(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM, false)
                      .put(ChromeFeatureList.TAB_TO_GTS_ANIMATION, true)
                      .put(ChromeFeatureList.TEST_DEFAULT_DISABLED, false)
                      .put(ChromeFeatureList.TEST_DEFAULT_ENABLED, true)
-@@ -208,6 +209,23 @@ public class CachedFeatureFlags {
+@@ -213,6 +214,23 @@ public class CachedFeatureFlags {
          SharedPreferencesManager.getInstance().writeBoolean(preferenceName, isEnabledInNative);
      }
  
@@ -1731,7 +1733,7 @@ diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/f
      /**
       * Forces a feature to be enabled or disabled for testing.
       *
-@@ -527,6 +545,7 @@ public class CachedFeatureFlags {
+@@ -532,6 +550,7 @@ public class CachedFeatureFlags {
  
      @NativeMethods
      interface Natives {
@@ -1742,16 +1744,16 @@ diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/f
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
-@@ -424,6 +424,8 @@ public abstract class ChromeFeatureList {
+@@ -429,6 +429,8 @@ public abstract class ChromeFeatureList {
      public static final String MESSAGES_FOR_ANDROID_SYNC_ERROR = "MessagesForAndroidSyncError";
      public static final String SEARCH_READY_OMNIBOX = "SearchReadyOmnibox";
      public static final String MODAL_PERMISSION_DIALOG_VIEW = "ModalPermissionDialogView";
 +    public static final String MOVE_TOP_TOOLBAR_TO_BOTTOM =
 +            "MoveTopToolbarToBottom";
      public static final String METRICS_SETTINGS_ANDROID = "MetricsSettingsAndroid";
-     public static final String MOST_RECENT_TAB_ON_BACKGROUND_CLOSE_TAB =
-             "MostRecentTabOnBackgroundCloseTab";
-@@ -700,6 +702,8 @@ public abstract class ChromeFeatureList {
+     public static final String NEW_INSTANCE_FROM_DRAGGED_LINK = "NewInstanceFromDraggedLink";
+     public static final String NEW_TAB_PAGE_TILES_TITLE_WRAP_AROUND =
+@@ -713,6 +715,8 @@ public abstract class ChromeFeatureList {
      public static final CachedFlag sInterestFeedV2 = new CachedFlag(INTEREST_FEED_V2, true);
      public static final CachedFlag sLensCameraAssistedSearch =
              new CachedFlag(LENS_CAMERA_ASSISTED_SEARCH, false);
@@ -1859,7 +1861,7 @@ diff --git a/chrome/browser/ui/android/appmenu/internal/java/src/org/chromium/ch
 diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarCoordinator.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarCoordinator.java
 --- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarCoordinator.java
 +++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarCoordinator.java
-@@ -85,6 +85,7 @@ public class LocationBarCoordinator implements LocationBar, NativeInitObserver,
+@@ -88,6 +88,7 @@ public class LocationBarCoordinator implements LocationBar, NativeInitObserver,
      private WindowDelegate mWindowDelegate;
      private WindowAndroid mWindowAndroid;
      private View mAutocompleteAnchorView;
@@ -1867,7 +1869,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
      private LocationBarMediator mLocationBarMediator;
      private View mUrlBar;
      private View mDeleteButton;
-@@ -141,7 +142,7 @@ public class LocationBarCoordinator implements LocationBar, NativeInitObserver,
+@@ -145,7 +146,7 @@ public class LocationBarCoordinator implements LocationBar, NativeInitObserver,
       * @param reportExceptionCallback A {@link Callback} to report exceptions.
       * @param backPressManager The {@link BackPressManager} for intercepting back press.
       */
@@ -1876,15 +1878,15 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
              ObservableSupplier<Profile> profileObservableSupplier,
              PrivacyPreferencesManager privacyPreferencesManager,
              LocationBarDataProvider locationBarDataProvider, ActionMode.Callback actionModeCallback,
-@@ -171,6 +172,7 @@ public class LocationBarCoordinator implements LocationBar, NativeInitObserver,
+@@ -177,6 +178,7 @@ public class LocationBarCoordinator implements LocationBar, NativeInitObserver,
          mActivityLifecycleDispatcher = activityLifecycleDispatcher;
          mActivityLifecycleDispatcher.register(this);
          mAutocompleteAnchorView = autocompleteAnchorView;
 +        mContainerView = containerView;
+         Context context = mLocationBarLayout.getContext();
  
          mUrlBar = mLocationBarLayout.findViewById(R.id.url_bar);
-         // TODO(crbug.com/1151513): Inject LocaleManager instance to LocationBarCoordinator instead
-@@ -381,6 +383,11 @@ public class LocationBarCoordinator implements LocationBar, NativeInitObserver,
+@@ -389,6 +391,11 @@ public class LocationBarCoordinator implements LocationBar, NativeInitObserver,
          return mAutocompleteAnchorView;
      }
  
@@ -1909,7 +1911,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
  /**
   * Coordinates the interactions with the UrlBar text component.
   */
-@@ -217,7 +220,13 @@ public class UrlBarCoordinator implements UrlBarEditingTextStateProvider, UrlFoc
+@@ -231,7 +234,13 @@ public class UrlBarCoordinator implements UrlBarEditingTextStateProvider, UrlFoc
          // to show or hide keyboard anyway. This may happen when we schedule keyboard hide, and
          // receive a second request to hide the keyboard instantly.
          if (showKeyboard) {
@@ -1927,7 +1929,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
 diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteCoordinator.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteCoordinator.java
 --- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteCoordinator.java
 +++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteCoordinator.java
-@@ -57,6 +57,8 @@ import org.chromium.ui.modelutil.LazyConstructionPropertyMcp;
+@@ -61,6 +61,8 @@ import org.chromium.ui.modelutil.LazyConstructionPropertyMcp;
  import org.chromium.ui.modelutil.MVCListAdapter;
  import org.chromium.ui.modelutil.MVCListAdapter.ModelList;
  import org.chromium.ui.modelutil.PropertyModel;
@@ -1936,15 +1938,15 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
  
  import java.util.ArrayList;
  import java.util.List;
-@@ -71,6 +73,7 @@ public class AutocompleteCoordinator implements UrlFocusChangeListener, UrlTextC
-     private final @NonNull AutocompleteMediator mMediator;
-     private final @NonNull Supplier<ModalDialogManager> mModalDialogManagerSupplier;
+@@ -77,6 +79,7 @@ public class AutocompleteCoordinator implements UrlFocusChangeListener, UrlTextC
      private @Nullable OmniboxSuggestionsDropdown mDropdown;
+     private @NonNull ObserverList<OmniboxSuggestionsDropdownScrollListener> mScrollListenerList =
+             new ObserverList<>();
 +    private final @NonNull OmniboxSuggestionsDropdownEmbedder mDropdownEmbedder;
  
      public AutocompleteCoordinator(@NonNull ViewGroup parent,
              @NonNull AutocompleteDelegate delegate,
-@@ -92,6 +95,7 @@ public class AutocompleteCoordinator implements UrlFocusChangeListener, UrlTextC
+@@ -99,6 +102,7 @@ public class AutocompleteCoordinator implements UrlFocusChangeListener, UrlTextC
          PropertyModel listModel = new PropertyModel(SuggestionListProperties.ALL_KEYS);
          ModelList listItems = new ModelList();
  
@@ -1952,16 +1954,16 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
          listModel.set(SuggestionListProperties.EMBEDDER, dropdownEmbedder);
          listModel.set(SuggestionListProperties.VISIBLE, false);
          listModel.set(SuggestionListProperties.SUGGESTION_MODELS, listItems);
-@@ -140,7 +144,7 @@ public class AutocompleteCoordinator implements UrlFocusChangeListener, UrlTextC
+@@ -154,7 +158,7 @@ public class AutocompleteCoordinator implements UrlFocusChangeListener, UrlTextC
              public void inflate() {
                  OmniboxSuggestionsDropdown dropdown;
                  try (StrictModeContext ignored = StrictModeContext.allowDiskReads()) {
--                    dropdown = new OmniboxSuggestionsDropdown(context, locationBarDataProvider);
-+                    dropdown = new OmniboxSuggestionsDropdown(context, locationBarDataProvider, mDropdownEmbedder);
+-                    dropdown = new OmniboxSuggestionsDropdown(context);
++                    dropdown = new OmniboxSuggestionsDropdown(context, mDropdownEmbedder);
                  }
  
                  // Start with visibility GONE to ensure that show() is called.
-@@ -211,6 +215,16 @@ public class AutocompleteCoordinator implements UrlFocusChangeListener, UrlTextC
+@@ -232,6 +236,16 @@ public class AutocompleteCoordinator implements UrlFocusChangeListener, UrlTextC
                  ViewGroup container = (ViewGroup) ((ViewStub) mParent.getRootView().findViewById(
                                                             R.id.omnibox_results_container_stub))
                                                .inflate();
@@ -1978,10 +1980,17 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
  
                  mHolder = new SuggestionListViewHolder(container, dropdown);
                  for (int i = 0; i < mCallbacks.size(); i++) {
+@@ -458,4 +472,4 @@ public class AutocompleteCoordinator implements UrlFocusChangeListener, UrlTextC
+             listener.onSuggestionDropdownOverscrolledToTop();
+         }
+     }
+-}
+\ No newline at end of file
++}
 diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteMediator.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteMediator.java
 --- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteMediator.java
 +++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteMediator.java
-@@ -57,6 +57,9 @@ import org.chromium.ui.modelutil.PropertyModel;
+@@ -58,6 +58,9 @@ import org.chromium.ui.modelutil.PropertyModel;
  import org.chromium.ui.mojom.WindowOpenDisposition;
  import org.chromium.url.GURL;
  
@@ -1991,7 +2000,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
  import java.lang.annotation.Retention;
  import java.lang.annotation.RetentionPolicy;
  import java.util.List;
-@@ -969,7 +972,9 @@ class AutocompleteMediator implements OnSuggestionsReceivedListener,
+@@ -1011,7 +1014,9 @@ class AutocompleteMediator implements OnSuggestionsReceivedListener,
      public void onSuggestionDropdownScroll() {
          if (mDropdownViewInfoListBuilder.hasFullyConcealedElements()) {
              mSuggestionsListScrolled = true;
@@ -2005,7 +2014,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
 diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/OmniboxSuggestionsDropdown.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/OmniboxSuggestionsDropdown.java
 --- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/OmniboxSuggestionsDropdown.java
 +++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/OmniboxSuggestionsDropdown.java
-@@ -43,6 +43,9 @@ import org.chromium.ui.base.ViewUtils;
+@@ -42,6 +42,9 @@ import org.chromium.ui.base.ViewUtils;
  import java.lang.annotation.Retention;
  import java.lang.annotation.RetentionPolicy;
  
@@ -2015,33 +2024,31 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
  /** A widget for showing a list of omnibox suggestions. */
  public class OmniboxSuggestionsDropdown extends RecyclerView {
      private static final long DEFERRED_INITIAL_SHRINKING_LAYOUT_FROM_IME_DURATION_MS = 300;
-@@ -173,7 +176,8 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
+@@ -208,7 +211,8 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
+      * Constructs a new list designed for containing omnibox suggestions.
       * @param context Context used for contained views.
       */
-     public OmniboxSuggestionsDropdown(
--            @NonNull Context context, @NonNull LocationBarDataProvider locationBarDataProvider) {
-+            @NonNull Context context, @NonNull LocationBarDataProvider locationBarDataProvider,
+-    public OmniboxSuggestionsDropdown(@NonNull Context context) {
++    public OmniboxSuggestionsDropdown(@NonNull Context context,
 +            @NonNull OmniboxSuggestionsDropdownEmbedder embedder) {
          super(context, null, android.R.attr.dropDownListViewStyle);
          setFocusable(true);
          setFocusableInTouchMode(true);
-@@ -184,7 +188,7 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
+@@ -218,13 +222,25 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
+         setItemAnimator(null);
  
-         mScrollListener = new SuggestionScrollListener();
-         setOnScrollListener(mScrollListener);
--        setLayoutManager(new LinearLayoutManager(context) {
-+        LinearLayoutManager linearLayoutManager = (new LinearLayoutManager(context) {
-             @Override
-             public int scrollVerticallyBy(
-                     int deltaY, RecyclerView.Recycler recycler, RecyclerView.State state) {
-@@ -204,6 +208,19 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
-                 : 0;
+         mLayoutScrollListener = new SuggestionLayoutScrollListener(context);
+-        setLayoutManager(mLayoutScrollListener);
+ 
+         boolean shouldShowModernizeVisualUpdate =
+                 OmniboxFeatures.shouldShowModernizeVisualUpdate(context);
+         final Resources resources = context.getResources();
          int paddingBottom =
                  resources.getDimensionPixelOffset(R.dimen.omnibox_suggestion_list_padding_bottom);
 +        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
 +            // reverse the layout so that the items are at the bottom (in reverse order)
 +            // and anchored to the bottom edge
-+            linearLayoutManager.setReverseLayout(true);
++            mLayoutScrollListener.setReverseLayout(true);
 +
 +            if (!embedder.isTablet()) {
 +                ViewGroup.MarginLayoutParams embedderParams = (ViewGroup.MarginLayoutParams)
@@ -2050,11 +2057,11 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
 +                                embedderParams.bottomMargin;
 +            }
 +        }
-+        setLayoutManager(linearLayoutManager);
-         ViewCompat.setPaddingRelative(this, paddingSide, 0, paddingSide, paddingBottom);
++        setLayoutManager(mLayoutScrollListener);
+         ViewCompat.setPaddingRelative(this, 0, 0, 0, paddingBottom);
  
          mStandardBgColor = shouldShowModernizeVisualUpdate
-@@ -379,6 +396,8 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
+@@ -442,6 +458,8 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
      }
  
      private int calculateAnchorBottomRelativeToContent() {
@@ -2080,7 +2087,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -1480,6 +1480,12 @@ Your Google account may have other forms of browsing history like searches and a
+@@ -1483,6 +1483,12 @@ Your Google account may have other forms of browsing history like searches and a
        <message name="IDS_FORCE_TABLET_UI_TITLE" desc="Title of the preference that allows the user to update force tablet UI settings.">
          Force Tablet Mode
        </message>
@@ -2096,7 +2103,7 @@ diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chro
 diff --git a/chrome/browser/ui/android/toolbar/BUILD.gn b/chrome/browser/ui/android/toolbar/BUILD.gn
 --- a/chrome/browser/ui/android/toolbar/BUILD.gn
 +++ b/chrome/browser/ui/android/toolbar/BUILD.gn
-@@ -162,6 +162,7 @@ android_library("java") {
+@@ -164,6 +164,7 @@ android_library("java") {
      "//components/user_prefs/android:java",
      "//content/public/android:content_java",
      "//third_party/android_deps:material_design_java",
@@ -2255,15 +2262,15 @@ diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/brow
 diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/bottom/BottomControlsViewBinder.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/bottom/BottomControlsViewBinder.java
 --- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/bottom/BottomControlsViewBinder.java
 +++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/bottom/BottomControlsViewBinder.java
-@@ -39,6 +39,8 @@ class BottomControlsViewBinder {
+@@ -40,6 +40,8 @@ class BottomControlsViewBinder {
                      model.get(BottomControlsProperties.BOTTOM_CONTROLS_CONTAINER_HEIGHT_PX);
          } else if (BottomControlsProperties.Y_OFFSET == propertyKey) {
              view.sceneLayer.setYOffset(model.get(BottomControlsProperties.Y_OFFSET));
 +        } else if (BottomControlsProperties.TOPCONTROLSMINHEIGHT_OFFSET == propertyKey) {
 +            view.sceneLayer.setTopControlsMinHeightOffset(model.get(BottomControlsProperties.TOPCONTROLSMINHEIGHT_OFFSET));
-         } else if (BottomControlsProperties.ANDROID_VIEW_VISIBLE == propertyKey) {
-             view.root.setVisibility(model.get(BottomControlsProperties.ANDROID_VIEW_VISIBLE)
-                             ? View.VISIBLE
+         } else if (BottomControlsProperties.ANDROID_VIEW_VISIBLE == propertyKey
+                 || BottomControlsProperties.COMPOSITED_VIEW_VISIBLE == propertyKey) {
+             final boolean showAndroidView =
 diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/bottom/ScrollingBottomViewSceneLayer.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/bottom/ScrollingBottomViewSceneLayer.java
 --- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/bottom/ScrollingBottomViewSceneLayer.java
 +++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/bottom/ScrollingBottomViewSceneLayer.java
@@ -2320,8 +2327,8 @@ diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/brow
 diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarControlContainer.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarControlContainer.java
 --- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarControlContainer.java
 +++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarControlContainer.java
-@@ -43,6 +43,11 @@ import org.chromium.ui.base.ViewUtils;
- import org.chromium.ui.resources.dynamics.ViewResourceAdapter;
+@@ -48,6 +48,11 @@ import org.chromium.ui.resources.dynamics.ViewResourceAdapter;
+ import org.chromium.ui.util.TokenHolder;
  import org.chromium.ui.widget.OptimizedFrameLayout;
  
 +import android.view.Gravity;
@@ -2332,7 +2339,7 @@ diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/brow
  /**
   * Layout for the browser controls (omnibox, menu, tab strip, etc..).
   */
-@@ -99,6 +104,12 @@ public class ToolbarControlContainer extends OptimizedFrameLayout implements Con
+@@ -104,6 +109,12 @@ public class ToolbarControlContainer extends OptimizedFrameLayout implements Con
      @Override
      public void initWithToolbar(int toolbarLayoutId) {
          try (TraceEvent te = TraceEvent.scoped("ToolbarControlContainer.initWithToolbar")) {
@@ -2530,7 +2537,7 @@ diff --git a/content/browser/renderer_host/render_widget_host_view_android.cc b/
  #include "cc/base/math_util.h"
  #include "cc/layers/layer.h"
  #include "cc/layers/surface_layer.h"
-@@ -474,6 +475,8 @@ void RenderWidgetHostViewAndroid::OnRenderFrameMetadataChangedBeforeActivation(
+@@ -479,6 +480,8 @@ void RenderWidgetHostViewAndroid::OnRenderFrameMetadataChangedBeforeActivation(
    // factor. Thus, |top_content_offset| in CSS pixels is also in DIPs.
    float top_content_offset =
        metadata.top_controls_height * metadata.top_controls_shown_ratio;

--- a/build/patches/Override-Navigator-Language.patch
+++ b/build/patches/Override-Navigator-Language.patch
@@ -16,7 +16,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/AppLocaleUtils.java b/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/AppLocaleUtils.java
 --- a/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/AppLocaleUtils.java
 +++ b/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/AppLocaleUtils.java
-@@ -35,6 +35,10 @@ import java.util.Locale;
+@@ -34,6 +34,10 @@ import java.util.Locale;
  public class AppLocaleUtils {
      private AppLocaleUtils(){};
  
@@ -27,7 +27,7 @@ diff --git a/chrome/browser/language/android/java/src/org/chromium/chrome/browse
      // Value of AppLocale preference when the system language is used.
      public static final String APP_LOCALE_USE_SYSTEM_LANGUAGE = null;
  
-@@ -99,6 +103,22 @@ public class AppLocaleUtils {
+@@ -98,6 +102,22 @@ public class AppLocaleUtils {
          return locale.toLanguageTag();
      }
  
@@ -71,7 +71,7 @@ diff --git a/chrome/browser/language/android/java/src/org/chromium/chrome/browse
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
-@@ -68,6 +68,7 @@
+@@ -69,6 +69,7 @@
  #include "cc/base/switches.h"
  #include "components/discardable_memory/public/mojom/discardable_shared_memory_manager.mojom.h"
  #include "components/discardable_memory/service/discardable_shared_memory_manager.h"
@@ -79,7 +79,7 @@ diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content
  #include "components/metrics/single_sample_metrics.h"
  #include "components/services/storage/privileged/mojom/indexed_db_control.mojom.h"
  #include "components/services/storage/public/cpp/buckets/bucket_id.h"
-@@ -3173,8 +3174,11 @@ void RenderProcessHostImpl::AppendRendererCommandLine(
+@@ -3175,8 +3176,11 @@ void RenderProcessHostImpl::AppendRendererCommandLine(
    PropagateBrowserCommandLineToRenderer(browser_command_line, command_line);
  
    // Pass on the browser locale.

--- a/build/patches/Partition-Blink-memory-cache.patch
+++ b/build/patches/Partition-Blink-memory-cache.patch
@@ -30,7 +30,7 @@ diff --git a/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc b
 @@ -413,7 +413,7 @@ static unsigned AvoidDownloadIfHigherDensityResourceIsInCache(
      KURL url = document->CompleteURL(
          StripLeadingAndTrailingHTMLSpaces(image_candidates[i]->Url()));
-     if (GetMemoryCache()->ResourceForURL(
+     if (MemoryCache::Get()->ResourceForURL(
 -            url, document->Fetcher()->GetCacheIdentifier(url)) ||
 +            url, document->Fetcher()->GetCacheIdentifier(url, document->TopFrameOrigin())) ||
          url.ProtocolIsData())
@@ -39,10 +39,10 @@ diff --git a/third_party/blink/renderer/core/html/parser/html_srcset_parser.cc b
 diff --git a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
 --- a/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
 +++ b/third_party/blink/renderer/core/inspector/inspector_network_agent.cc
-@@ -2216,7 +2216,7 @@ bool InspectorNetworkAgent::FetchResourceContent(Document* document,
+@@ -2252,7 +2252,7 @@ bool InspectorNetworkAgent::FetchResourceContent(Document* document,
    Resource* cached_resource = document->Fetcher()->CachedResource(url);
    if (!cached_resource) {
-     cached_resource = GetMemoryCache()->ResourceForURL(
+     cached_resource = MemoryCache::Get()->ResourceForURL(
 -        url, document->Fetcher()->GetCacheIdentifier(url));
 +        url, document->Fetcher()->GetCacheIdentifier(url, document->TopFrameOrigin()));
    }
@@ -57,7 +57,7 @@ diff --git a/third_party/blink/renderer/core/inspector/inspector_page_agent.cc b
    Resource* cached_resource = document->Fetcher()->CachedResource(url);
 -  if (!cached_resource) {
 +  if (!cached_resource && document->TopFrameOrigin()) {
-     cached_resource = GetMemoryCache()->ResourceForURL(
+     cached_resource = MemoryCache::Get()->ResourceForURL(
 -        url, document->Fetcher()->GetCacheIdentifier(url));
 +        url, document->Fetcher()->GetCacheIdentifier(url,
 +          document->TopFrameOrigin()));
@@ -67,10 +67,10 @@ diff --git a/third_party/blink/renderer/core/inspector/inspector_page_agent.cc b
 diff --git a/third_party/blink/renderer/core/loader/image_loader.cc b/third_party/blink/renderer/core/loader/image_loader.cc
 --- a/third_party/blink/renderer/core/loader/image_loader.cc
 +++ b/third_party/blink/renderer/core/loader/image_loader.cc
-@@ -726,7 +726,8 @@ bool ImageLoader::ShouldLoadImmediately(const KURL& url) const {
+@@ -729,7 +729,8 @@ bool ImageLoader::ShouldLoadImmediately(const KURL& url) const {
    // content when style recalc is over and DOM mutation is allowed again.
    if (!url.IsNull()) {
-     Resource* resource = GetMemoryCache()->ResourceForURL(
+     Resource* resource = MemoryCache::Get()->ResourceForURL(
 -        url, element_->GetDocument().Fetcher()->GetCacheIdentifier(url));
 +        url, element_->GetDocument().Fetcher()->GetCacheIdentifier(url,
 +                element_->GetDocument().TopFrameOrigin()));
@@ -80,16 +80,16 @@ diff --git a/third_party/blink/renderer/core/loader/image_loader.cc b/third_part
 diff --git a/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc b/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc
 --- a/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc
 +++ b/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc
-@@ -197,7 +197,7 @@ void MemoryCache::RemoveInternal(ResourceMap* resource_map,
+@@ -198,7 +198,7 @@ void MemoryCache::RemoveInternal(ResourceMap* resource_map,
  }
  
  bool MemoryCache::Contains(const Resource* resource) const {
 -  if (!resource || resource->Url().IsEmpty())
-+  if (!resource || resource->Url().IsEmpty() || resource->CacheIdentifier().IsEmpty())
++  if (!resource || resource->Url().IsEmpty() || resource->CacheIdentifier().empty())
      return false;
  
    const auto resource_maps_it =
-@@ -213,12 +213,9 @@ bool MemoryCache::Contains(const Resource* resource) const {
+@@ -214,12 +214,9 @@ bool MemoryCache::Contains(const Resource* resource) const {
    return resource == resources_it->value->GetResource();
  }
  
@@ -99,14 +99,14 @@ diff --git a/third_party/blink/renderer/platform/loader/fetch/memory_cache.cc b/
 -
  Resource* MemoryCache::ResourceForURL(const KURL& resource_url,
                                        const String& cache_identifier) const {
-+  if (cache_identifier.IsEmpty()) return nullptr;
++  if (cache_identifier.empty()) return nullptr;
    DCHECK(WTF::IsMainThread());
    if (!resource_url.IsValid() || resource_url.IsNull())
      return nullptr;
 diff --git a/third_party/blink/renderer/platform/loader/fetch/memory_cache.h b/third_party/blink/renderer/platform/loader/fetch/memory_cache.h
 --- a/third_party/blink/renderer/platform/loader/fetch/memory_cache.h
 +++ b/third_party/blink/renderer/platform/loader/fetch/memory_cache.h
-@@ -112,9 +112,7 @@ class PLATFORM_EXPORT MemoryCache final : public GarbageCollected<MemoryCache>,
+@@ -116,9 +116,7 @@ class PLATFORM_EXPORT MemoryCache final : public GarbageCollected<MemoryCache>,
      TypeStatistic other;
    };
  
@@ -116,7 +116,7 @@ diff --git a/third_party/blink/renderer/platform/loader/fetch/memory_cache.h b/t
  
    void Add(Resource*);
    void Remove(Resource*);
-@@ -159,6 +157,8 @@ class PLATFORM_EXPORT MemoryCache final : public GarbageCollected<MemoryCache>,
+@@ -163,6 +161,8 @@ class PLATFORM_EXPORT MemoryCache final : public GarbageCollected<MemoryCache>,
        base::MemoryPressureListener::MemoryPressureLevel) override;
  
   private:
@@ -128,7 +128,7 @@ diff --git a/third_party/blink/renderer/platform/loader/fetch/memory_cache.h b/t
 diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
 --- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
 +++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
-@@ -652,7 +652,8 @@ Resource* ResourceFetcher::CreateResourceForStaticData(
+@@ -657,7 +657,8 @@ Resource* ResourceFetcher::CreateResourceForStaticData(
    if (!archive_ && factory.GetType() == ResourceType::kRaw)
      return nullptr;
  
@@ -138,10 +138,10 @@ diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.c
    // Most off-main-thread resource fetches use Resource::kRaw and don't reach
    // this point, but off-main-thread module fetches might.
    if (IsMainThread()) {
-@@ -1111,7 +1112,9 @@ Resource* ResourceFetcher::RequestResource(FetchParameters& params,
+@@ -1116,7 +1117,9 @@ Resource* ResourceFetcher::RequestResource(FetchParameters& params,
          resource = nullptr;
        } else {
-         resource = GetMemoryCache()->ResourceForURL(
+         resource = MemoryCache::Get()->ResourceForURL(
 -            params.Url(), GetCacheIdentifier(params.Url()));
 +            params.Url(),
 +            GetCacheIdentifier(params.Url(),
@@ -149,7 +149,7 @@ diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.c
        }
        if (resource) {
          policy = DetermineRevalidationPolicy(resource_type, params, *resource,
-@@ -1319,7 +1322,8 @@ Resource* ResourceFetcher::CreateResourceForLoading(
+@@ -1324,7 +1327,8 @@ Resource* ResourceFetcher::CreateResourceForLoading(
      const FetchParameters& params,
      const ResourceFactory& factory) {
    const String cache_identifier =
@@ -159,7 +159,7 @@ diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.c
    if (!base::FeatureList::IsEnabled(
            blink::features::kScopeMemoryCachePerContext)) {
      DCHECK(!IsMainThread() || params.IsStaleRevalidation() ||
-@@ -2207,13 +2211,16 @@ void ResourceFetcher::UpdateAllImageResourcePriorities() {
+@@ -2213,13 +2217,16 @@ void ResourceFetcher::UpdateAllImageResourcePriorities() {
    to_be_removed.clear();
  }
  
@@ -179,7 +179,7 @@ diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.c
  
    // Requests that can be satisfied via `archive_` (i.e. MHTML) or
    // `subresource_web_bundles_` should not participate in the global caching,
-@@ -2225,7 +2232,7 @@ String ResourceFetcher::GetCacheIdentifier(const KURL& url) const {
+@@ -2231,7 +2238,7 @@ String ResourceFetcher::GetCacheIdentifier(const KURL& url) const {
    if (bundle)
      return bundle->GetCacheIdentifier();
  

--- a/build/patches/Partition-blobs-by-top-frame-URL.patch
+++ b/build/patches/Partition-blobs-by-top-frame-URL.patch
@@ -101,7 +101,7 @@ diff --git a/storage/browser/blob/blob_url_store_impl.cc b/storage/browser/blob/
 diff --git a/storage/browser/blob/blob_url_store_impl.h b/storage/browser/blob/blob_url_store_impl.h
 --- a/storage/browser/blob/blob_url_store_impl.h
 +++ b/storage/browser/blob/blob_url_store_impl.h
-@@ -39,14 +39,21 @@ class COMPONENT_EXPORT(STORAGE_BROWSER) BlobURLStoreImpl
+@@ -40,14 +40,21 @@ class COMPONENT_EXPORT(STORAGE_BROWSER) BlobURLStoreImpl
        const absl::optional<net::SchemefulSite>& unsafe_top_level_site,
        RegisterCallback callback) override;
    void Revoke(const GURL& url) override;
@@ -124,7 +124,7 @@ diff --git a/storage/browser/blob/blob_url_store_impl.h b/storage/browser/blob/b
        ResolveForNavigationCallback callback) override;
  
   private:
-@@ -54,6 +61,11 @@ class COMPONENT_EXPORT(STORAGE_BROWSER) BlobURLStoreImpl
+@@ -55,6 +62,11 @@ class COMPONENT_EXPORT(STORAGE_BROWSER) BlobURLStoreImpl
    // Returns false and reports a bad mojo message if not.
    bool BlobUrlIsValid(const GURL& url, const char* method) const;
  
@@ -133,9 +133,9 @@ diff --git a/storage/browser/blob/blob_url_store_impl.h b/storage/browser/blob/b
 +      const base::UnguessableToken& unsafe_agent_cluster_id,
 +      const absl::optional<net::SchemefulSite>& unsafe_top_level_site);
 +
-   const url::Origin origin_;
-   base::WeakPtr<BlobUrlRegistry> registry_;
+   const blink::StorageKey storage_key_;
  
+   base::WeakPtr<BlobUrlRegistry> registry_;
 diff --git a/third_party/blink/public/mojom/blob/blob_url_store.mojom b/third_party/blink/public/mojom/blob/blob_url_store.mojom
 --- a/third_party/blink/public/mojom/blob/blob_url_store.mojom
 +++ b/third_party/blink/public/mojom/blob/blob_url_store.mojom
@@ -197,21 +197,21 @@ diff --git a/third_party/blink/renderer/core/fileapi/public_url_manager.cc b/thi
  }  // namespace
  
  PublicURLManager::PublicURLManager(ExecutionContext* context)
-@@ -176,6 +191,7 @@ void PublicURLManager::Resolve(
+@@ -217,6 +232,7 @@ void PublicURLManager::Resolve(
  
    url_store_->ResolveAsURLLoaderFactory(
        url, std::move(factory_receiver),
 +      GetExecutionContext()->GetAgentClusterID(), GetInsecureTopLevelSite(GetExecutionContext()),
-       WTF::Bind(
-           [](ExecutionContext* execution_context,
-              const absl::optional<base::UnguessableToken>&
-@@ -249,6 +265,7 @@ void PublicURLManager::Resolve(
+       WTF::BindOnce(std::move(metrics_callback),
+                     WrapPersistent(GetExecutionContext())));
+ }
+@@ -258,6 +274,7 @@ void PublicURLManager::Resolve(
  
    url_store_->ResolveForNavigation(
        url, std::move(token_receiver),
 +      GetExecutionContext()->GetAgentClusterID(), GetInsecureTopLevelSite(GetExecutionContext()),
-       WTF::Bind(
-           [](ExecutionContext* execution_context,
-              const absl::optional<base::UnguessableToken>&
+       WTF::BindOnce(std::move(metrics_callback),
+                     WrapPersistent(GetExecutionContext())));
+ }
 --
 2.25.1

--- a/build/patches/Remove-HTTP-referrals-in-cross-origin-navigation.patch
+++ b/build/patches/Remove-HTTP-referrals-in-cross-origin-navigation.patch
@@ -41,8 +41,8 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
      private static final String PREF_DO_NOT_TRACK = "do_not_track";
 +    private static final String PREF_ENABLE_REFERRERS = "enable_referrers";
      private static final String PREF_CLEAR_BROWSING_DATA = "clear_browsing_data";
+     private static final String PREF_PROXY_OPTIONS = "proxy";
      private static final String PREF_PRIVACY_GUIDE = "privacy_guide";
-     private static final String PREF_INCOGNITO_LOCK = "incognito_lock";
 @@ -175,6 +176,9 @@ public class PrivacySettings
          } else if (PREF_CAN_MAKE_PAYMENT.equals(key)) {
              UserPrefs.get(Profile.getLastUsedRegularProfile())
@@ -67,12 +67,12 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -879,6 +879,9 @@ CHAR_LIMIT guidelines:
+@@ -882,6 +882,9 @@ CHAR_LIMIT guidelines:
  
  For example, some websites may respond to this request by showing you ads that aren’t based on other websites you’ve visited. Many websites will still collect and use your browsing data — for example to improve security, to provide content, ads and recommendations, and to generate reporting statistics.
        </message>
 +      <message name="IDS_ENABLE_REFERRERS_TITLE" desc="Title for 'Enable referrers' preference">
-+        Enable HTTP Referer header
++        Enable HTTP Referrer header
 +      </message>
        <message name="IDS_CAN_MAKE_PAYMENT_TITLE" desc="Title for preference to allow websites to know whether you have payment methods available through PaymentRequest.CanMakePayment interface">
          Access payment methods
@@ -80,7 +80,7 @@ diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chro
 diff --git a/content/browser/renderer_host/navigation_request.cc b/content/browser/renderer_host/navigation_request.cc
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
-@@ -446,6 +446,13 @@ void AddAdditionalRequestHeaders(
+@@ -431,6 +431,13 @@ void AddAdditionalRequestHeaders(
          blink::mojom::Referrer(GURL(), network::mojom::ReferrerPolicy::kNever);
    }
  

--- a/build/patches/Remove-navigator.connection-info.patch
+++ b/build/patches/Remove-navigator.connection-info.patch
@@ -8,10 +8,11 @@ and disable observers
 Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- .../renderer/modules/netinfo/network_information.cc   |  5 ++++-
- .../platform/network/network_state_notifier.cc        | 11 +++++++++++
- .../platform/network/network_state_notifier.h         |  2 +-
- 3 files changed, 16 insertions(+), 2 deletions(-)
+ .../renderer/modules/netinfo/network_information.cc |  7 ++++++-
+ .../renderer/modules/netinfo/network_information.h  |  1 +
+ .../platform/network/network_state_notifier.cc      | 13 +++++++++++++
+ .../platform/network/network_state_notifier.h       |  2 +-
+ 4 files changed, 21 insertions(+), 2 deletions(-)
 
 diff --git a/third_party/blink/renderer/modules/netinfo/network_information.cc b/third_party/blink/renderer/modules/netinfo/network_information.cc
 --- a/third_party/blink/renderer/modules/netinfo/network_information.cc
@@ -21,7 +22,7 @@ diff --git a/third_party/blink/renderer/modules/netinfo/network_information.cc b
  
  bool NetworkInformation::IsObserving() const {
 -  return !!connection_observer_handle_;
-+  return false;
++  return !!connection_observer_handle_ || is_fake_observing_;
  }
  
  String NetworkInformation::type() const {
@@ -33,27 +34,40 @@ diff --git a/third_party/blink/renderer/modules/netinfo/network_information.cc b
    DCHECK(GetExecutionContext()->IsContextThread());
  
    const String host = Host();
-@@ -242,6 +243,7 @@ void NetworkInformation::ContextDestroyed() {
+@@ -242,6 +243,8 @@ void NetworkInformation::ContextDestroyed() {
  }
  
  void NetworkInformation::StartObserving() {
++  is_fake_observing_ = true;
 +  if ((true)) return;
    if (!IsObserving() && !context_stopped_) {
      type_ = GetNetworkStateNotifier().ConnectionType();
      DCHECK(!connection_observer_handle_);
-@@ -252,6 +254,7 @@ void NetworkInformation::StartObserving() {
+@@ -252,6 +255,8 @@ void NetworkInformation::StartObserving() {
  }
  
  void NetworkInformation::StopObserving() {
++  is_fake_observing_ = false;
 +  if ((true)) return;
    if (IsObserving()) {
      DCHECK(connection_observer_handle_);
      connection_observer_handle_ = nullptr;
+diff --git a/third_party/blink/renderer/modules/netinfo/network_information.h b/third_party/blink/renderer/modules/netinfo/network_information.h
+--- a/third_party/blink/renderer/modules/netinfo/network_information.h
++++ b/third_party/blink/renderer/modules/netinfo/network_information.h
+@@ -118,6 +118,7 @@ class NetworkInformation final
+ 
+   std::unique_ptr<NetworkStateNotifier::NetworkStateObserverHandle>
+       connection_observer_handle_;
++  bool is_fake_observing_ = false;
+ };
+ 
+ }  // namespace blink
 diff --git a/third_party/blink/renderer/platform/network/network_state_notifier.cc b/third_party/blink/renderer/platform/network/network_state_notifier.cc
 --- a/third_party/blink/renderer/platform/network/network_state_notifier.cc
 +++ b/third_party/blink/renderer/platform/network/network_state_notifier.cc
-@@ -99,6 +99,17 @@ NetworkStateNotifier::ScopedNotifier::~ScopedNotifier() {
-   }
+@@ -522,6 +522,19 @@ NetworkStateNotifier::GetWebHoldbackDownlinkThroughputMbps() const {
+   return absl::nullopt;
  }
  
 +NetworkStateNotifier::NetworkStateNotifier() : has_override_(false) {
@@ -64,12 +78,14 @@ diff --git a/third_party/blink/renderer/platform/network/network_state_notifier.
 +    /*effective_type*/ absl::nullopt,
 +    /*http_rtt_msec*/ 0,
 +    /*max_bandwidth_mbps*/ std::numeric_limits<double>::max());
-+  SetNetworkQuality(/*effective_type*/ WebEffectiveConnectionType::kType4G, base::TimeDelta(), base::TimeDelta(), 10000);
++  SetNetworkQuality(
++    /*effective_type*/ WebEffectiveConnectionType::kType4G,
++    base::TimeDelta(), base::TimeDelta(), 10000);
 +}
 +
- NetworkStateNotifier::NetworkStateObserverHandle::NetworkStateObserverHandle(
-     NetworkStateNotifier* notifier,
-     NetworkStateNotifier::ObserverType type,
+ void NetworkStateNotifier::GetMetricsWithWebHoldback(
+     WebConnectionType* type,
+     double* downlink_max_mbps,
 diff --git a/third_party/blink/renderer/platform/network/network_state_notifier.h b/third_party/blink/renderer/platform/network/network_state_notifier.h
 --- a/third_party/blink/renderer/platform/network/network_state_notifier.h
 +++ b/third_party/blink/renderer/platform/network/network_state_notifier.h

--- a/build/patches/Remove-segmentation-platform.patch
+++ b/build/patches/Remove-segmentation-platform.patch
@@ -13,7 +13,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/chrome/browser/segmentation_platform/chrome_browser_main_extra_parts_segmentation_platform.cc b/chrome/browser/segmentation_platform/chrome_browser_main_extra_parts_segmentation_platform.cc
 --- a/chrome/browser/segmentation_platform/chrome_browser_main_extra_parts_segmentation_platform.cc
 +++ b/chrome/browser/segmentation_platform/chrome_browser_main_extra_parts_segmentation_platform.cc
-@@ -15,17 +15,20 @@
+@@ -12,17 +12,20 @@
  #include "components/segmentation_platform/public/segmentation_platform_service.h"
  
  void ChromeBrowserMainExtraPartsSegmentationPlatform::PreCreateThreads() {
@@ -34,7 +34,7 @@ diff --git a/chrome/browser/segmentation_platform/chrome_browser_main_extra_part
    if (!profile || profile->IsOffTheRecord())
      return;
  
-@@ -46,5 +49,6 @@ void ChromeBrowserMainExtraPartsSegmentationPlatform::PostProfileInit(
+@@ -34,5 +37,6 @@ void ChromeBrowserMainExtraPartsSegmentationPlatform::PostProfileInit(
  }
  
  void ChromeBrowserMainExtraPartsSegmentationPlatform::PostMainMessageLoopRun() {

--- a/build/patches/Remove-window-name-on-cross-origin-navigation.patch
+++ b/build/patches/Remove-window-name-on-cross-origin-navigation.patch
@@ -13,7 +13,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/third_party/blink/renderer/core/loader/document_loader.cc b/third_party/blink/renderer/core/loader/document_loader.cc
 --- a/third_party/blink/renderer/core/loader/document_loader.cc
 +++ b/third_party/blink/renderer/core/loader/document_loader.cc
-@@ -2398,7 +2398,7 @@ void DocumentLoader::CommitNavigation() {
+@@ -2474,7 +2474,7 @@ void DocumentLoader::CommitNavigation() {
      // that the name would be nulled and if the name is accessed after we will
      // fire a UseCounter. If we decide to move forward with this change, we'd
      // actually clean the name here.
@@ -22,7 +22,7 @@ diff --git a/third_party/blink/renderer/core/loader/document_loader.cc b/third_p
      frame_->Tree().ExperimentalSetNulledName();
    }
  
-@@ -2409,6 +2409,7 @@ void DocumentLoader::CommitNavigation() {
+@@ -2485,6 +2485,7 @@ void DocumentLoader::CommitNavigation() {
      // TODO(shuuran): CrossSiteCrossBrowsingContextGroupSetNulledName will just
      // record the fact that the name would be nulled and if the name is accessed
      // after we will fire a UseCounter.

--- a/build/patches/Revert-the-removal-of-an-option-to-block-autoplay.patch
+++ b/build/patches/Revert-the-removal-of-an-option-to-block-autoplay.patch
@@ -46,18 +46,18 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/browser_ui/site_settings/android/BUILD.gn
 --- a/components/browser_ui/site_settings/android/BUILD.gn
 +++ b/components/browser_ui/site_settings/android/BUILD.gn
-@@ -171,6 +171,11 @@ android_resources("java_resources") {
-     "java/res/drawable-mdpi/ic_volume_up_grey600_24dp.png",
-     "java/res/drawable-mdpi/permission_background_sync.png",
-     "java/res/drawable-mdpi/permission_javascript.png",
+@@ -197,6 +197,11 @@ android_resources("java_resources") {
+     "java/res/drawable-xxxhdpi/settings_sensors.png",
+     "java/res/drawable-xxxhdpi/web_asset.png",
+     "java/res/drawable/ic_block.xml",
 +    "java/res/drawable-hdpi/settings_autoplay.png",
 +    "java/res/drawable-xhdpi/settings_autoplay.png",
 +    "java/res/drawable-xxhdpi/settings_autoplay.png",
 +    "java/res/drawable-mdpi/settings_autoplay.png",
 +    "java/res/drawable-xxxhdpi/settings_autoplay.png",
-     "java/res/drawable-mdpi/permission_popups.png",
-     "java/res/drawable-mdpi/permission_protected_media.png",
-     "java/res/drawable-mdpi/settings_sensors.png",
+     "java/res/drawable/ic_person_24dp.xml",
+     "java/res/drawable/settings_bluetooth.xml",
+     "java/res/layout/add_site_dialog.xml",
 diff --git a/components/browser_ui/site_settings/android/java/res/drawable-hdpi/settings_autoplay.png b/components/browser_ui/site_settings/android/java/res/drawable-hdpi/settings_autoplay.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..a8a9265f14cd8445ad1f55845099e60dc3c4edf1
@@ -237,7 +237,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
              } else if (type == ContentSettingsType.SOUND) {
                  setUpSoundPreference(preference);
              } else if (type == ContentSettingsType.JAVASCRIPT) {
-@@ -1020,6 +1024,24 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
+@@ -1014,6 +1018,24 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
          setupContentSettingsPreference(preference, currentValue, false /* isEmbargoed */);
      }
  
@@ -308,7 +308,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
-@@ -230,6 +230,15 @@ public final class Website implements WebsiteEntry {
+@@ -235,6 +235,15 @@ public final class Website implements WebsiteEntry {
              } else {
                  RecordUserAction.record("JavascriptContentSetting.DisableBy.SiteSettings");
              }

--- a/build/patches/Samsung-Note-9-SDK27-crazylinker-workaround.patch
+++ b/build/patches/Samsung-Note-9-SDK27-crazylinker-workaround.patch
@@ -11,7 +11,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 diff --git a/base/android/java/src/org/chromium/base/library_loader/LibraryLoader.java b/base/android/java/src/org/chromium/base/library_loader/LibraryLoader.java
 --- a/base/android/java/src/org/chromium/base/library_loader/LibraryLoader.java
 +++ b/base/android/java/src/org/chromium/base/library_loader/LibraryLoader.java
-@@ -508,8 +508,29 @@ public class LibraryLoader {
+@@ -517,8 +517,29 @@ public class LibraryLoader {
      // Note: This cannot be done in the build configuration, as otherwise chrome_public_apk cannot
      // both be used as the basis to ship on L, and the default APK used by developers on 10+.
      private boolean forceSystemLinker() {

--- a/build/patches/Site-setting-for-images.patch
+++ b/build/patches/Site-setting-for-images.patch
@@ -52,8 +52,8 @@ diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/b
 +    "java/res/drawable-mdpi/permission_images.png",
      "java/res/drawable-mdpi/permission_javascript.png",
      "java/res/drawable-mdpi/permission_javascript_jit.png",
-     "java/res/drawable-hdpi/settings_autoplay.png",
-@@ -184,6 +186,7 @@ android_resources("java_resources") {
+     "java/res/drawable-mdpi/permission_popups.png",
+@@ -179,6 +181,7 @@ android_resources("java_resources") {
      "java/res/drawable-mdpi/web_asset.png",
      "java/res/drawable-xhdpi/ic_volume_up_grey600_24dp.png",
      "java/res/drawable-xhdpi/permission_background_sync.png",
@@ -61,7 +61,7 @@ diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/b
      "java/res/drawable-xhdpi/permission_javascript.png",
      "java/res/drawable-xhdpi/permission_javascript_jit.png",
      "java/res/drawable-xhdpi/permission_popups.png",
-@@ -192,6 +195,7 @@ android_resources("java_resources") {
+@@ -187,6 +190,7 @@ android_resources("java_resources") {
      "java/res/drawable-xhdpi/web_asset.png",
      "java/res/drawable-xxhdpi/ic_volume_up_grey600_24dp.png",
      "java/res/drawable-xxhdpi/permission_background_sync.png",
@@ -69,7 +69,7 @@ diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/b
      "java/res/drawable-xxhdpi/permission_javascript.png",
      "java/res/drawable-xxhdpi/permission_javascript_jit.png",
      "java/res/drawable-xxhdpi/permission_popups.png",
-@@ -200,6 +204,7 @@ android_resources("java_resources") {
+@@ -195,6 +199,7 @@ android_resources("java_resources") {
      "java/res/drawable-xxhdpi/web_asset.png",
      "java/res/drawable-xxxhdpi/ic_volume_up_grey600_24dp.png",
      "java/res/drawable-xxxhdpi/permission_background_sync.png",
@@ -222,13 +222,13 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
              case ContentSettingsType.JAVASCRIPT_JIT:
 @@ -516,6 +518,8 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
                  setUpJavascriptPreference(preference);
-             } else if (type == ContentSettingsType.GEOLOCATION) {
-                 setUpLocationPreference(preference);
+             } else if (type == ContentSettingsType.COOKIES) {
+                 setUpCookiesPreference(preference);
 +            } else if (type == ContentSettingsType.IMAGES) {
 +                setUpImagesPreference(preference);
+             } else if (type == ContentSettingsType.GEOLOCATION) {
+                 setUpLocationPreference(preference);
              } else if (type == ContentSettingsType.JAVASCRIPT_JIT) {
-                 setUpJavascriptJitPreference(preference);
-             } else if (type == ContentSettingsType.NOTIFICATIONS) {
 @@ -1137,6 +1141,24 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
                  mSite.isEmbargoed(ContentSettingsType.REQUEST_DESKTOP_SITE));
      }
@@ -312,7 +312,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
-@@ -214,6 +214,13 @@ public final class Website implements WebsiteEntry {
+@@ -219,6 +219,13 @@ public final class Website implements WebsiteEntry {
                          /*isEmbargoed=*/false);
                  setContentSettingException(type, exception);
              }

--- a/build/patches/Timezone-customization.patch
+++ b/build/patches/Timezone-customization.patch
@@ -85,14 +85,14 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/site_settings/C
 diff --git a/components/browser_ui/site_settings/android/BUILD.gn b/components/browser_ui/site_settings/android/BUILD.gn
 --- a/components/browser_ui/site_settings/android/BUILD.gn
 +++ b/components/browser_ui/site_settings/android/BUILD.gn
-@@ -8,6 +8,7 @@ generate_jni("site_settings_jni_headers") {
-   sources = [
-     "java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsFeatureList.java",
+@@ -86,6 +86,7 @@ android_library("java") {
+     "java/src/org/chromium/components/browser_ui/site_settings/WebsitePreference.java",
      "java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java",
+     "java/src/org/chromium/components/browser_ui/site_settings/WebsiteRowPreference.java",
 +    "java/src/org/chromium/components/browser_ui/site_settings/TimezoneOverrideSiteSettingsPreference.java"
    ]
- }
- 
+   annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
+   resources_package = "org.chromium.components.browser_ui.site_settings"
 @@ -214,6 +215,8 @@ android_resources("java_resources") {
      "java/res/xml/single_website_preferences.xml",
      "java/res/xml/site_settings_preferences.xml",
@@ -519,7 +519,7 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
              case ContentSettingsType.AR:
                  return "ar_permission_list";
              case ContentSettingsType.MEDIASTREAM_CAMERA:
-@@ -934,11 +936,13 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
+@@ -928,11 +930,13 @@ public class SingleWebsiteSettings extends SiteSettingsPreferenceFragment
          if (value == null) return;
          setUpPreferenceCommon(preference, value);
  
@@ -601,15 +601,15 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsDelegate.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsDelegate.java
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsDelegate.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsDelegate.java
-@@ -151,6 +151,8 @@ public interface SiteSettingsDelegate {
+@@ -158,6 +158,8 @@ public interface SiteSettingsDelegate {
       */
-     void setFirstPartySetsDataAccessEnabled(boolean enabled);
+     String getFirstPartySetOwner(String memberOrigin);
  
 +    void launchTimeZoneOverrideHelpAndFeedbackActivity(Activity currentActivity);
 +
      /**
-      * Gets the First Party Sets owner hostname given a FPS member origin.
-      * @param memberOrigin FPS member origin.
+      * Returns whether the current implementation of the delegate is able to launch the Clear
+      * Browsing Data dialog in Settings.
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/TimezoneOverrideSiteSettingsPreference.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/TimezoneOverrideSiteSettingsPreference.java
 new file mode 100755
 --- /dev/null
@@ -811,7 +811,7 @@ new file mode 100755
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/Website.java
-@@ -243,6 +243,17 @@ public final class Website implements WebsiteEntry {
+@@ -248,6 +248,17 @@ public final class Website implements WebsiteEntry {
              } else {
                  RecordUserAction.record("SoundContentSetting.UnmuteBy.SiteSettings");
              }
@@ -840,15 +840,15 @@ diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/c
                  return WebsitePermissionsType.CONTENT_SETTING_EXCEPTION;
              case ContentSettingsType.AR:
              case ContentSettingsType.CLIPBOARD_READ_WRITE:
-@@ -151,6 +152,8 @@ public class WebsitePermissionsFetcher {
-      * @param category A category to fetch.
-      * @param callback The callback to run when the fetch is complete.
-      *
+@@ -208,6 +209,8 @@ public class WebsitePermissionsFetcher {
+             for (@ContentSettingsType int type = 0; type < ContentSettingsType.NUM_TYPES; type++) {
+                 addFetcherForContentSettingsType(queue, type);
+             }
 +        queue.add(new ExceptionInfoFetcher(ContentSettingsType.TIMEZONE_OVERRIDE));
 +
-      */
-     public void fetchPreferencesForCategory(
-             SiteSettingsCategory category, WebsitePermissionsCallback callback) {
+         }
+ 
+         /**
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java
@@ -971,7 +971,7 @@ diff --git a/components/content_settings/core/browser/content_settings_pref_prov
    // Obsolete prefs ----------------------------------------------------------
  
    // These prefs have been removed, but need to be registered so they can
-@@ -178,6 +180,10 @@ PrefProvider::PrefProvider(PrefService* prefs,
+@@ -182,6 +184,10 @@ PrefProvider::PrefProvider(PrefService* prefs,
      event_args->set_number_of_exceptions(
          num_exceptions);  // PrefProvider::PrefProvider.
    });
@@ -982,7 +982,7 @@ diff --git a/components/content_settings/core/browser/content_settings_pref_prov
  }
  
  PrefProvider::~PrefProvider() {
-@@ -342,4 +348,14 @@ void PrefProvider::SetClockForTesting(base::Clock* clock) {
+@@ -346,4 +352,14 @@ void PrefProvider::SetClockForTesting(base::Clock* clock) {
    clock_ = clock;
  }
  
@@ -1000,7 +1000,7 @@ diff --git a/components/content_settings/core/browser/content_settings_pref_prov
 diff --git a/components/content_settings/core/browser/content_settings_pref_provider.h b/components/content_settings/core/browser/content_settings_pref_provider.h
 --- a/components/content_settings/core/browser/content_settings_pref_provider.h
 +++ b/components/content_settings/core/browser/content_settings_pref_provider.h
-@@ -65,6 +65,9 @@ class PrefProvider : public UserModifiableProvider {
+@@ -66,6 +66,9 @@ class PrefProvider : public UserModifiableProvider {
  
    ContentSettingsPref* GetPref(ContentSettingsType type) const;
  
@@ -1010,7 +1010,7 @@ diff --git a/components/content_settings/core/browser/content_settings_pref_prov
   private:
    friend class DeadlockCheckerObserver;  // For testing.
  
-@@ -96,6 +99,7 @@ class PrefProvider : public UserModifiableProvider {
+@@ -98,6 +101,7 @@ class PrefProvider : public UserModifiableProvider {
    base::ThreadChecker thread_checker_;
  
    raw_ptr<base::Clock> clock_;
@@ -1060,7 +1060,7 @@ diff --git a/components/content_settings/core/browser/content_settings_utils.cc 
 diff --git a/components/content_settings/core/browser/host_content_settings_map.cc b/components/content_settings/core/browser/host_content_settings_map.cc
 --- a/components/content_settings/core/browser/host_content_settings_map.cc
 +++ b/components/content_settings/core/browser/host_content_settings_map.cc
-@@ -602,6 +602,14 @@ void HostContentSettingsMap::SetClockForTesting(base::Clock* clock) {
+@@ -604,6 +604,14 @@ void HostContentSettingsMap::SetClockForTesting(base::Clock* clock) {
      provider->SetClockForTesting(clock);
  }
  
@@ -1078,7 +1078,7 @@ diff --git a/components/content_settings/core/browser/host_content_settings_map.
 diff --git a/components/content_settings/core/browser/host_content_settings_map.h b/components/content_settings/core/browser/host_content_settings_map.h
 --- a/components/content_settings/core/browser/host_content_settings_map.h
 +++ b/components/content_settings/core/browser/host_content_settings_map.h
-@@ -329,6 +329,9 @@ class HostContentSettingsMap : public content_settings::Observer,
+@@ -330,6 +330,9 @@ class HostContentSettingsMap : public content_settings::Observer,
      allow_invalid_secondary_pattern_for_testing_ = allow;
    }
  

--- a/build/patches/User-agent-customization.patch
+++ b/build/patches/User-agent-customization.patch
@@ -33,7 +33,10 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../strings/android_chrome_strings.grd        |  35 ++++
  chrome/common/pref_names.cc                   |  13 ++
  chrome/common/pref_names.h                    |   8 +
+ .../WebsitePreferenceBridge.java              |   2 +-
+ .../android/website_preference_bridge.cc      |  10 +-
  .../widget/RadioButtonWithEditText.java       |  11 +
+ .../core/browser/host_content_settings_map.cc |   8 +-
  .../embedder_support/user_agent_utils.cc      |  15 +-
  .../navigation_controller_android.cc          |   4 +
  .../navigation_controller_android.h           |   1 +
@@ -41,7 +44,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../browser/web_contents/web_contents_impl.cc |   4 +
  .../framehost/NavigationControllerImpl.java   |   3 +-
  content/renderer/render_thread_impl.cc        |   1 -
- 31 files changed, 766 insertions(+), 16 deletions(-)
+ 34 files changed, 776 insertions(+), 26 deletions(-)
  create mode 100644 chrome/android/java/res/layout/custom_useragent_preferences.xml
  create mode 100644 chrome/android/java/res/xml/useragent_preferences.xml
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/settings/UserAgentPreferences.java
@@ -73,7 +76,7 @@ diff --git a/base/base_switches.h b/base/base_switches.h
 diff --git a/chrome/android/chrome_java_resources.gni b/chrome/android/chrome_java_resources.gni
 --- a/chrome/android/chrome_java_resources.gni
 +++ b/chrome/android/chrome_java_resources.gni
-@@ -661,4 +661,6 @@ chrome_java_resources = [
+@@ -659,4 +659,6 @@ chrome_java_resources = [
    "java/res/xml/privacy_preferences.xml",
    "java/res/xml/search_widget_info.xml",
    "java/res/xml/tracing_preferences.xml",
@@ -83,7 +86,7 @@ diff --git a/chrome/android/chrome_java_resources.gni b/chrome/android/chrome_ja
 diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java_sources.gni
 --- a/chrome/android/chrome_java_sources.gni
 +++ b/chrome/android/chrome_java_sources.gni
-@@ -893,6 +893,7 @@ chrome_java_sources = [
+@@ -896,6 +896,7 @@ chrome_java_sources = [
    "java/src/org/chromium/chrome/browser/payments/ui/DimmingDialog.java",
    "java/src/org/chromium/chrome/browser/payments/ui/LineItem.java",
    "java/src/org/chromium/chrome/browser/payments/ui/PaymentAppComparator.java",
@@ -329,7 +332,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/setting
 +        boolean isOverrideUserAgentEnabled(boolean desktopMode);
 +        void setOverrideUserAgentEnabled(boolean enabled, boolean desktopMode);
 +        String getOverrideUserAgentValue(boolean desktopMode);
-+        void setOverrideUserAgentValue(String timezone, boolean desktopMode);
++        void setOverrideUserAgentValue(String customTimezone, boolean desktopMode);
 +        boolean isDesktopModeViewportMetaEnabled();
 +        void setDesktopModeViewportMetaEnabled(boolean enabled);
      }
@@ -909,7 +912,7 @@ diff --git a/chrome/browser/android/preferences/privacy_preferences_manager_impl
 diff --git a/chrome/browser/preferences/android/java/src/org/chromium/chrome/browser/preferences/ChromePreferenceKeys.java b/chrome/browser/preferences/android/java/src/org/chromium/chrome/browser/preferences/ChromePreferenceKeys.java
 --- a/chrome/browser/preferences/android/java/src/org/chromium/chrome/browser/preferences/ChromePreferenceKeys.java
 +++ b/chrome/browser/preferences/android/java/src/org/chromium/chrome/browser/preferences/ChromePreferenceKeys.java
-@@ -1014,6 +1014,9 @@ public final class ChromePreferenceKeys {
+@@ -1034,6 +1034,9 @@ public final class ChromePreferenceKeys {
      public static final String BLUETOOTH_NOTIFICATION_IDS = "Chrome.Bluetooth.NotificationIds";
      public static final String USB_NOTIFICATION_IDS = "Chrome.USB.NotificationIds";
  
@@ -919,7 +922,7 @@ diff --git a/chrome/browser/preferences/android/java/src/org/chromium/chrome/bro
      /**
       * These values are currently used as SharedPreferences keys, along with the keys in
       * {@link LegacyChromePreferenceKeys#getKeysInUse()}. Add new SharedPreferences keys
-@@ -1155,6 +1158,8 @@ public final class ChromePreferenceKeys {
+@@ -1179,6 +1182,8 @@ public final class ChromePreferenceKeys {
                  SYNC_PROMO_TOTAL_SHOW_COUNT,
                  START_NEXT_SHOW_ON_STARTUP_DECISION_MS,
                  SEARCH_RESUMPTION_MODULE_COLLAPSE_ON_NTP,
@@ -1069,7 +1072,7 @@ diff --git a/chrome/common/pref_names.cc b/chrome/common/pref_names.cc
 diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1245,6 +1245,14 @@ extern const char kDesktopSharingHubEnabled[];
+@@ -1250,6 +1250,14 @@ extern const char kDesktopSharingHubEnabled[];
  #if !BUILDFLAG(IS_ANDROID)
  extern const char kLastWhatsNewVersion[];
  #endif
@@ -1084,6 +1087,41 @@ diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
  
  #if !BUILDFLAG(IS_ANDROID)
  extern const char kLensRegionSearchEnabled[];
+diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java
+--- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java
++++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/WebsitePreferenceBridge.java
+@@ -467,6 +467,6 @@ public class WebsitePreferenceBridge {
+         String toDomainWildcardPattern(String pattern);
+         String toHostOnlyPattern(String pattern);
+         String getCustomTimezone(BrowserContextHandle browserContextHandle);
+-        void setCustomTimezone(BrowserContextHandle browserContextHandle, String timezone);
++        void setCustomTimezone(BrowserContextHandle browserContextHandle, String customTimezone);
+     }
+ }
+diff --git a/components/browser_ui/site_settings/android/website_preference_bridge.cc b/components/browser_ui/site_settings/android/website_preference_bridge.cc
+--- a/components/browser_ui/site_settings/android/website_preference_bridge.cc
++++ b/components/browser_ui/site_settings/android/website_preference_bridge.cc
+@@ -1021,15 +1021,15 @@ JNI_WebsitePreferenceBridge_ToHostOnlyPattern(
+ static void JNI_WebsitePreferenceBridge_SetCustomTimezone(
+     JNIEnv* env,
+     const JavaParamRef<jobject>& jbrowser_context_handle,
+-    const JavaParamRef<jstring>& timezone) {
+-  std::string new_timezone = ConvertJavaStringToUTF8(env, timezone);
++    const JavaParamRef<jstring>& custom_timezone) {
++  std::string new_timezone = ConvertJavaStringToUTF8(env, custom_timezone);
+   GetHostContentSettingsMap(jbrowser_context_handle)->SetTimezoneOverrideValue(new_timezone);
+ }
+ 
+ static base::android::ScopedJavaLocalRef<jstring> JNI_WebsitePreferenceBridge_GetCustomTimezone(
+     JNIEnv* env,
+     const JavaParamRef<jobject>& jbrowser_context_handle) {
+-  std::string timezone;
+-  GetHostContentSettingsMap(jbrowser_context_handle)->GetTimezoneOverrideValue(timezone);
+-  return ConvertUTF8ToJavaString(env, timezone);
++  std::string custom_timezone;
++  GetHostContentSettingsMap(jbrowser_context_handle)->GetTimezoneOverrideValue(custom_timezone);
++  return ConvertUTF8ToJavaString(env, custom_timezone);
+ }
 diff --git a/components/browser_ui/widget/android/java/src/org/chromium/components/browser_ui/widget/RadioButtonWithEditText.java b/components/browser_ui/widget/android/java/src/org/chromium/components/browser_ui/widget/RadioButtonWithEditText.java
 --- a/components/browser_ui/widget/android/java/src/org/chromium/components/browser_ui/widget/RadioButtonWithEditText.java
 +++ b/components/browser_ui/widget/android/java/src/org/chromium/components/browser_ui/widget/RadioButtonWithEditText.java
@@ -1105,6 +1143,26 @@ diff --git a/components/browser_ui/widget/android/java/src/org/chromium/componen
      }
  
      /**
+diff --git a/components/content_settings/core/browser/host_content_settings_map.cc b/components/content_settings/core/browser/host_content_settings_map.cc
+--- a/components/content_settings/core/browser/host_content_settings_map.cc
++++ b/components/content_settings/core/browser/host_content_settings_map.cc
+@@ -604,12 +604,12 @@ void HostContentSettingsMap::SetClockForTesting(base::Clock* clock) {
+     provider->SetClockForTesting(clock);
+ }
+ 
+-void HostContentSettingsMap::GetTimezoneOverrideValue(std::string& timezone) const {
+-  GetPrefProvider()->GetPrefTimezoneOverrideValue(timezone);
++void HostContentSettingsMap::GetTimezoneOverrideValue(std::string& custom_timezone) const {
++  GetPrefProvider()->GetPrefTimezoneOverrideValue(custom_timezone);
+ }
+ 
+-void HostContentSettingsMap::SetTimezoneOverrideValue(const std::string& timezone) {
+-  GetPrefProvider()->SetPrefTimezoneOverrideValue(timezone);
++void HostContentSettingsMap::SetTimezoneOverrideValue(const std::string& custom_timezone) {
++  GetPrefProvider()->SetPrefTimezoneOverrideValue(custom_timezone);
+ }
+ 
+ void HostContentSettingsMap::RecordExceptionMetrics() {
 diff --git a/components/embedder_support/user_agent_utils.cc b/components/embedder_support/user_agent_utils.cc
 --- a/components/embedder_support/user_agent_utils.cc
 +++ b/components/embedder_support/user_agent_utils.cc
@@ -1147,7 +1205,7 @@ diff --git a/components/embedder_support/user_agent_utils.cc b/components/embedd
 diff --git a/content/browser/renderer_host/navigation_controller_android.cc b/content/browser/renderer_host/navigation_controller_android.cc
 --- a/content/browser/renderer_host/navigation_controller_android.cc
 +++ b/content/browser/renderer_host/navigation_controller_android.cc
-@@ -253,6 +253,7 @@ void NavigationControllerAndroid::LoadUrl(
+@@ -255,6 +255,7 @@ NavigationControllerAndroid::LoadUrl(
      jboolean can_load_local_resources,
      jboolean is_renderer_initiated,
      jboolean should_replace_current_entry,
@@ -1155,15 +1213,15 @@ diff --git a/content/browser/renderer_host/navigation_controller_android.cc b/co
      const JavaParamRef<jobject>& j_initiator_origin,
      jboolean has_user_gesture,
      jboolean should_clear_history_list,
-@@ -324,6 +325,9 @@ void NavigationControllerAndroid::LoadUrl(
+@@ -326,6 +327,9 @@ NavigationControllerAndroid::LoadUrl(
  
    params.navigation_ui_data = std::move(navigation_ui_data);
  
 +  params.override_user_agent = static_cast<NavigationController::UserAgentOverrideOption>(
 +    user_agent_override_option);
 +
-   navigation_controller_->LoadURLWithParams(params);
- }
+   base::WeakPtr<NavigationHandle> handle =
+       navigation_controller_->LoadURLWithParams(params);
  
 diff --git a/content/browser/renderer_host/navigation_controller_android.h b/content/browser/renderer_host/navigation_controller_android.h
 --- a/content/browser/renderer_host/navigation_controller_android.h
@@ -1179,7 +1237,7 @@ diff --git a/content/browser/renderer_host/navigation_controller_android.h b/con
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
-@@ -3425,6 +3425,7 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
+@@ -3436,6 +3436,7 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
      switches::kLacrosUseChromeosProtectedMedia,
      switches::kLacrosUseChromeosProtectedAv1,
  #endif
@@ -1198,7 +1256,7 @@ diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser
  #include "base/bind.h"
  #include "base/check_op.h"
  #include "base/command_line.h"
-@@ -2797,6 +2798,9 @@ const blink::web_pref::WebPreferences WebContentsImpl::ComputeWebPreferences() {
+@@ -2799,6 +2800,9 @@ const blink::web_pref::WebPreferences WebContentsImpl::ComputeWebPreferences() {
          !renderer_preferences_.user_agent_override.ua_metadata_override->mobile)
  #endif
        prefs.viewport_meta_enabled = false;
@@ -1211,7 +1269,7 @@ diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser
 diff --git a/content/public/android/java/src/org/chromium/content/browser/framehost/NavigationControllerImpl.java b/content/public/android/java/src/org/chromium/content/browser/framehost/NavigationControllerImpl.java
 --- a/content/public/android/java/src/org/chromium/content/browser/framehost/NavigationControllerImpl.java
 +++ b/content/public/android/java/src/org/chromium/content/browser/framehost/NavigationControllerImpl.java
-@@ -182,6 +182,7 @@ import org.chromium.url.Origin;
+@@ -183,6 +183,7 @@ import org.chromium.url.Origin;
                      params.getBaseUrl(), params.getVirtualUrlForDataUrl(),
                      params.getDataUrlAsString(), params.getCanLoadLocalResources(),
                      params.getIsRendererInitiated(), params.getShouldReplaceCurrentEntry(),
@@ -1219,8 +1277,8 @@ diff --git a/content/public/android/java/src/org/chromium/content/browser/frameh
                      params.getInitiatorOrigin(), params.getHasUserGesture(),
                      params.getShouldClearHistoryList(), inputStart,
                      params.getNavigationUIDataSupplier() == null
-@@ -370,7 +371,7 @@ import org.chromium.url.Origin;
-                 int referrerPolicy, int uaOverrideOption, String extraHeaders,
+@@ -375,7 +376,7 @@ import org.chromium.url.Origin;
+                 String referrerUrl, int referrerPolicy, int uaOverrideOption, String extraHeaders,
                  ResourceRequestBody postData, String baseUrlForDataUrl, String virtualUrlForDataUrl,
                  String dataUrlAsString, boolean canLoadLocalResources, boolean isRendererInitiated,
 -                boolean shouldReplaceCurrentEntry, Origin initiatorOrigin, boolean hasUserGesture,
@@ -1231,7 +1289,7 @@ diff --git a/content/public/android/java/src/org/chromium/content/browser/frameh
 diff --git a/content/renderer/render_thread_impl.cc b/content/renderer/render_thread_impl.cc
 --- a/content/renderer/render_thread_impl.cc
 +++ b/content/renderer/render_thread_impl.cc
-@@ -904,7 +904,6 @@ void RenderThreadImpl::InitializeRenderer(
+@@ -908,7 +908,6 @@ void RenderThreadImpl::InitializeRenderer(
      const std::string& reduced_user_agent,
      const blink::UserAgentMetadata& user_agent_metadata,
      const std::vector<std::string>& cors_exempt_header_list) {


### PR DESCRIPTION
## Description

Sorry for the delay, but it has been a busy week.
these patches updated to v108: few changes, none noteworthy.
only about the `add an always-incognito mode`: the change is related to the management of recent tabs which has been modified upstream. you can find it in `RecentTabsManager.java` where I modified the page opening mode.

## All submissions

* [ ] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
