### PR TITLE
Use helper macros to define base::Features

### DIFF
--- a/build/patches/AImageReader-CFI-crash-mitigations.patch
+++ b/build/patches/AImageReader-CFI-crash-mitigations.patch
@@ -30,9 +30,9 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  gpu/config/gpu_workaround_list.txt          |  1 +
  gpu/ipc/service/gpu_init.cc                 |  5 +++++
  gpu/ipc/service/stream_texture_android.cc   | 11 ++++++++++-
- media/base/media_switches.cc                |  4 ++++
+ media/base/media_switches.cc                |  5 +++++
  media/base/media_switches.h                 |  1 +
- 12 files changed, 65 insertions(+), 5 deletions(-)
+ 12 files changed, 66 insertions(+), 5 deletions(-)
 
 diff --git a/base/android/android_image_reader_compat.cc b/base/android/android_image_reader_compat.cc
 --- a/base/android/android_image_reader_compat.cc
@@ -231,13 +231,14 @@ diff --git a/gpu/ipc/service/stream_texture_android.cc b/gpu/ipc/service/stream_
 diff --git a/media/base/media_switches.cc b/media/base/media_switches.cc
 --- a/media/base/media_switches.cc
 +++ b/media/base/media_switches.cc
-@@ -750,6 +750,10 @@ BASE_FEATURE(kHardwareSecureDecryptionExperiment,
+@@ -750,6 +750,11 @@ BASE_FEATURE(kHardwareSecureDecryptionExperiment,
  // Allows automatically disabling hardware secure Content Decryption Module
  // (CDM) after failures or crashes to fallback to software secure CDMs. If this
  // feature is disabled, the fallback will never happen and users could be stuck
 +// Enables the Android Image Reader path for Video decoding(for AVDA and MCVD)
-+const base::Feature kAImageReaderVideoOutput{"AImageReaderVideoOutput",
-+                                             base::FEATURE_ENABLED_BY_DEFAULT};
++BASE_FEATURE(kAImageReaderVideoOutput,
++             "AImageReaderVideoOutput",
++             base::FEATURE_ENABLED_BY_DEFAULT);
 +
  // in playback failures.
  BASE_FEATURE(kHardwareSecureDecryptionFallback,
@@ -249,7 +250,7 @@ diff --git a/media/base/media_switches.h b/media/base/media_switches.h
  MEDIA_EXPORT BASE_DECLARE_FEATURE(kVaapiVp9kSVCHWEncoding);
  #endif  // defined(ARCH_CPU_X86_FAMILY) && BUILDFLAG(IS_CHROMEOS)
  MEDIA_EXPORT BASE_DECLARE_FEATURE(kVideoBlitColorAccuracy);
-+MEDIA_EXPORT extern const base::Feature kAImageReaderVideoOutput;
++MEDIA_EXPORT BASE_DECLARE_FEATURE(kAImageReaderVideoOutput);
  MEDIA_EXPORT BASE_DECLARE_FEATURE(kVp9kSVCHWDecoding);
  MEDIA_EXPORT BASE_DECLARE_FEATURE(kWakeLockOptimisationHiddenMuted);
  MEDIA_EXPORT BASE_DECLARE_FEATURE(kWebContentsCaptureHiDpi);

--- a/build/patches/Add-AllowUserCertificates-flag.patch
+++ b/build/patches/Add-AllowUserCertificates-flag.patch
@@ -115,14 +115,14 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browse
 diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser/flags/android/chrome_feature_list.h
 --- a/chrome/browser/flags/android/chrome_feature_list.h
 +++ b/chrome/browser/flags/android/chrome_feature_list.h
-@@ -12,6 +12,7 @@
- namespace chrome {
- namespace android {
- 
-+extern const base::Feature kAllowUserCertificates;
- // Alphabetical:
- BASE_DECLARE_FEATURE(kAdaptiveButtonInTopToolbar);
+@@ -17,6 +17,7 @@ BASE_DECLARE_FEATURE(kAdaptiveButtonInTopToolbar);
  BASE_DECLARE_FEATURE(kAdaptiveButtonInTopToolbarCustomizationV2);
+ BASE_DECLARE_FEATURE(kAddToHomescreenIPH);
+ BASE_DECLARE_FEATURE(kAllowNewIncognitoTabIntents);
++BASE_DECLARE_FEATURE(kAllowUserCertificates);
+ BASE_DECLARE_FEATURE(kAndroidScrollOptimizations);
+ BASE_DECLARE_FEATURE(kAndroidSearchEngineChoiceNotification);
+ BASE_DECLARE_FEATURE(kAssistantConsentModal);
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java

--- a/build/patches/Add-IsCleartextPermitted-flag.patch
+++ b/build/patches/Add-IsCleartextPermitted-flag.patch
@@ -8,10 +8,10 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  chrome/browser/about_flags.cc           | 4 ++++
  chrome/browser/flag_descriptions.cc     | 4 ++++
  chrome/browser/flag_descriptions.h      | 3 +++
- net/base/features.cc                    | 3 +++
+ net/base/features.cc                    | 4 ++++
  net/base/features.h                     | 2 ++
  net/url_request/url_request_http_job.cc | 4 ++++
- 6 files changed, 20 insertions(+)
+ 6 files changed, 21 insertions(+)
 
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
@@ -57,12 +57,13 @@ diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptio
 diff --git a/net/base/features.cc b/net/base/features.cc
 --- a/net/base/features.cc
 +++ b/net/base/features.cc
-@@ -113,6 +113,9 @@ BASE_FEATURE(kPartitionNelAndReportingByNetworkIsolationKey,
+@@ -113,6 +113,10 @@ BASE_FEATURE(kPartitionNelAndReportingByNetworkIsolationKey,
               "PartitionNelAndReportingByNetworkIsolationKey",         // must be enabled
               base::FEATURE_ENABLED_BY_DEFAULT);                       // in Bromite
  
-+const base::Feature kIsCleartextPermitted{"IsCleartextPermitted",
-+                                      base::FEATURE_ENABLED_BY_DEFAULT};
++BASE_FEATURE(kIsCleartextPermitted,
++             "IsCleartextPermitted",
++             base::FEATURE_ENABLED_BY_DEFAULT);
 +
  BASE_FEATURE(kEnableDoubleKeyNetworkAnonymizationKey,
               "EnableDoubleKeyNetworkAnonymizationKey",
@@ -74,7 +75,7 @@ diff --git a/net/base/features.h b/net/base/features.h
  // origin requests are restricted to contain at most the source origin.
  NET_EXPORT BASE_DECLARE_FEATURE(kCapReferrerToOriginOnCrossOrigin);
  
-+NET_EXPORT extern const base::Feature kIsCleartextPermitted;
++NET_EXPORT BASE_DECLARE_FEATURE(kIsCleartextPermitted);
 +
  // Support for altering the parameters used for DNS transaction timeout. See
  // ResolveContext::SecureTransactionTimeout().

--- a/build/patches/Add-bookmark-import-export-actions.patch
+++ b/build/patches/Add-bookmark-import-export-actions.patch
@@ -1306,7 +1306,7 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser
  BASE_DECLARE_FEATURE(kTabStripRedesign);
  BASE_DECLARE_FEATURE(kTabSwitcherOnReturn);
  BASE_DECLARE_FEATURE(kTabToGTSAnimation);
-+extern const base::Feature kBookmarksExportUseSaf;
++BASE_DECLARE_FEATURE(kBookmarksExportUseSaf);
  BASE_DECLARE_FEATURE(kTestDefaultDisabled);
  BASE_DECLARE_FEATURE(kTestDefaultEnabled);
  BASE_DECLARE_FEATURE(kToolbarMicIphAndroid);

--- a/build/patches/Add-flag-for-save-data-header.patch
+++ b/build/patches/Add-flag-for-save-data-header.patch
@@ -9,8 +9,8 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  chrome/browser/flag_descriptions.h                        | 3 +++
  .../browser/loader/browser_initiated_resource_request.cc  | 8 ++++++++
  services/network/public/cpp/features.cc                   | 5 +++++
- services/network/public/cpp/features.h                    | 3 ++-
- 6 files changed, 26 insertions(+), 2 deletions(-)
+ services/network/public/cpp/features.h                    | 2 +-
+ 6 files changed, 25 insertions(+), 2 deletions(-)
 
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
@@ -88,10 +88,10 @@ diff --git a/services/network/public/cpp/features.cc b/services/network/public/c
               "ExpectCTReporting",
               base::FEATURE_ENABLED_BY_DEFAULT);
  
-+
 +// Enable save-data header separately (without enabled data reduction service).
-+const base::Feature kEnableSaveDataHeader{"EnableSaveDataHeader",
-+                                           base::FEATURE_DISABLED_BY_DEFAULT};
++BASE_FEATURE(kEnableSaveDataHeader,
++             "EnableSaveDataHeader",
++             base::FEATURE_DISABLED_BY_DEFAULT);
 +
  BASE_FEATURE(kNetworkErrorLogging,
               "NetworkErrorLogging",
@@ -99,13 +99,12 @@ diff --git a/services/network/public/cpp/features.cc b/services/network/public/c
 diff --git a/services/network/public/cpp/features.h b/services/network/public/cpp/features.h
 --- a/services/network/public/cpp/features.h
 +++ b/services/network/public/cpp/features.h
-@@ -51,7 +51,8 @@ extern const base::FeatureParam<TrustTokenOriginTrialSpec>
+@@ -50,7 +50,7 @@ extern const base::FeatureParam<TrustTokenOriginTrialSpec>
      kTrustTokenOperationsRequiringOriginTrial;
  COMPONENT_EXPORT(NETWORK_CPP)
  extern const base::FeatureParam<bool> kPlatformProvidedTrustTokenIssuance;
 -
-+COMPONENT_EXPORT(NETWORK_CPP)
-+extern const base::Feature kEnableSaveDataHeader;
++COMPONENT_EXPORT(NETWORK_CPP) BASE_DECLARE_FEATURE(kEnableSaveDataHeader);
  COMPONENT_EXPORT(NETWORK_CPP)
  BASE_DECLARE_FEATURE(kWebSocketReassembleShortMessages);
  

--- a/build/patches/Add-flag-to-disable-IPv6-probes.patch
+++ b/build/patches/Add-flag-to-disable-IPv6-probes.patch
@@ -10,8 +10,8 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  components/subresource_filter/tools/BUILD.gn             | 6 ++++++
  .../url_formatter/spoof_checks/top_domains/BUILD.gn      | 3 ++-
  net/dns/host_resolver_manager.cc                         | 9 ++++++++-
- services/network/public/cpp/features.cc                  | 4 ++++
- services/network/public/cpp/features.h                   | 2 ++
+ services/network/public/cpp/features.cc                  | 5 +++++
+ services/network/public/cpp/features.h                   | 1 +
  8 files changed, 33 insertions(+), 2 deletions(-)
 
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
@@ -128,13 +128,14 @@ diff --git a/net/dns/host_resolver_manager.cc b/net/dns/host_resolver_manager.cc
 diff --git a/services/network/public/cpp/features.cc b/services/network/public/cpp/features.cc
 --- a/services/network/public/cpp/features.cc
 +++ b/services/network/public/cpp/features.cc
-@@ -38,6 +38,10 @@ BASE_FEATURE(kThrottleDelayable,
+@@ -38,6 +38,11 @@ BASE_FEATURE(kThrottleDelayable,
               "ThrottleDelayable",
               base::FEATURE_ENABLED_BY_DEFAULT);
  
 +// Enable IPv6 ping probes to RIPE DNS.
-+const base::Feature kIPv6Probing{"IPv6Probing",
-+                                       base::FEATURE_ENABLED_BY_DEFAULT};
++BASE_FEATURE(kIPv6Probing,
++             "IPv6Probing",
++             base::FEATURE_ENABLED_BY_DEFAULT);
 +
  // When kPriorityRequestsDelayableOnSlowConnections is enabled, HTTP
  // requests fetched from a SPDY/QUIC/H2 proxies can be delayed by the
@@ -142,14 +143,13 @@ diff --git a/services/network/public/cpp/features.cc b/services/network/public/c
 diff --git a/services/network/public/cpp/features.h b/services/network/public/cpp/features.h
 --- a/services/network/public/cpp/features.h
 +++ b/services/network/public/cpp/features.h
-@@ -18,6 +18,8 @@ COMPONENT_EXPORT(NETWORK_CPP) BASE_DECLARE_FEATURE(kNetworkErrorLogging);
+@@ -17,6 +17,7 @@ COMPONENT_EXPORT(NETWORK_CPP) BASE_DECLARE_FEATURE(kExpectCTReporting);
+ COMPONENT_EXPORT(NETWORK_CPP) BASE_DECLARE_FEATURE(kNetworkErrorLogging);
  COMPONENT_EXPORT(NETWORK_CPP) BASE_DECLARE_FEATURE(kReporting);
  COMPONENT_EXPORT(NETWORK_CPP) BASE_DECLARE_FEATURE(kThrottleDelayable);
++COMPONENT_EXPORT(NETWORK_CPP) BASE_DECLARE_FEATURE(kIPv6Probing);
  COMPONENT_EXPORT(NETWORK_CPP)
-+extern const base::Feature kIPv6Probing;
-+COMPONENT_EXPORT(NETWORK_CPP)
  BASE_DECLARE_FEATURE(kDelayRequestsOnMultiplexedConnections);
  COMPONENT_EXPORT(NETWORK_CPP)
- BASE_DECLARE_FEATURE(kPauseBrowserInitiatedHeavyTrafficForP2P);
 --
 2.25.1

--- a/build/patches/Add-flag-to-disable-vibration.patch
+++ b/build/patches/Add-flag-to-disable-vibration.patch
@@ -4,17 +4,17 @@ Subject: Add flag to disable vibration
 
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- chrome/browser/about_flags.cc                                 | 4 ++++
- chrome/browser/flag_descriptions.cc                           | 3 +++
- chrome/browser/flag_descriptions.h                            | 2 ++
- content/child/runtime_features.cc                             | 1 +
- content/public/common/content_features.cc                     | 4 ++++
- content/public/common/content_features.h                      | 2 ++
- third_party/blink/public/platform/web_runtime_features.h      | 1 +
- .../blink/renderer/modules/vibration/vibration_controller.cc  | 3 +++
- .../blink/renderer/platform/exported/web_runtime_features.cc  | 4 ++++
- .../blink/renderer/platform/runtime_enabled_features.json5    | 4 ++++
- 10 files changed, 28 insertions(+)
+ chrome/browser/about_flags.cc                                | 4 ++++
+ chrome/browser/flag_descriptions.cc                          | 3 +++
+ chrome/browser/flag_descriptions.h                           | 2 ++
+ content/child/runtime_features.cc                            | 1 +
+ content/public/common/content_features.cc                    | 5 +++++
+ content/public/common/content_features.h                     | 2 ++
+ third_party/blink/public/platform/web_runtime_features.h     | 1 +
+ .../blink/renderer/modules/vibration/vibration_controller.cc | 3 +++
+ .../blink/renderer/platform/exported/web_runtime_features.cc | 4 ++++
+ .../blink/renderer/platform/runtime_enabled_features.json5   | 4 ++++
+ 10 files changed, 29 insertions(+)
 
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
@@ -69,13 +69,14 @@ diff --git a/content/child/runtime_features.cc b/content/child/runtime_features.
 diff --git a/content/public/common/content_features.cc b/content/public/common/content_features.cc
 --- a/content/public/common/content_features.cc
 +++ b/content/public/common/content_features.cc
-@@ -130,6 +130,10 @@ BASE_FEATURE(kBackForwardCacheMemoryControls,
+@@ -130,6 +130,11 @@ BASE_FEATURE(kBackForwardCacheMemoryControls,
  #endif
  );
  
 +// Enables vibration; an user gesture will still be required if enabled.
-+const base::Feature kVibration{"Vibration",
-+                                    base::FEATURE_DISABLED_BY_DEFAULT};
++BASE_FEATURE(kVibration,
++             "Vibration",
++             base::FEATURE_DISABLED_BY_DEFAULT);
 +
  // When this feature is enabled, private network requests initiated from
  // non-secure contexts in the `public` address space  are blocked.
@@ -87,7 +88,7 @@ diff --git a/content/public/common/content_features.h b/content/public/common/co
      kCompositorLockTimeout;
  
  #endif  // BUILDFLAG(IS_ANDROID)
-+CONTENT_EXPORT extern const base::Feature kVibration;
++CONTENT_EXPORT BASE_DECLARE_FEATURE(kVibration);
 +
  
  #if BUILDFLAG(IS_MAC)

--- a/build/patches/Add-menu-item-to-bookmark-all-tabs.patch
+++ b/build/patches/Add-menu-item-to-bookmark-all-tabs.patch
@@ -491,14 +491,14 @@ diff --git a/components/bookmarks/browser/bookmark_codec.cc b/components/bookmar
 diff --git a/components/bookmarks/browser/bookmark_codec.h b/components/bookmarks/browser/bookmark_codec.h
 --- a/components/bookmarks/browser/bookmark_codec.h
 +++ b/components/bookmarks/browser/bookmark_codec.h
-@@ -48,6 +48,7 @@ class BookmarkCodec {
-   base::Value Encode(
+@@ -49,6 +49,7 @@ class BookmarkCodec {
        const BookmarkNode* bookmark_bar_node,
        const BookmarkNode* other_folder_node,
-+      const BookmarkNode* tabs_folder_node,
        const BookmarkNode* mobile_folder_node,
++      const BookmarkNode* tabs_folder_node,
        const BookmarkNode::MetaInfoMap* model_meta_info_map,
        const BookmarkNode::MetaInfoMap* model_unsynced_meta_info_map,
+       std::string sync_metadata_str);
 @@ -62,6 +63,7 @@ class BookmarkCodec {
                BookmarkNode* bb_node,
                BookmarkNode* other_folder_node,

--- a/build/patches/Bromite-auto-updater.patch
+++ b/build/patches/Bromite-auto-updater.patch
@@ -1277,7 +1277,7 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser
  BASE_DECLARE_FEATURE(kHandleMediaIntents);
  BASE_DECLARE_FEATURE(kImmersiveUiMode);
  BASE_DECLARE_FEATURE(kIncognitoReauthenticationForAndroid);
-+extern const base::Feature kInlineUpdateFlow;
++BASE_DECLARE_FEATURE(kInlineUpdateFlow);
  BASE_DECLARE_FEATURE(kIncognitoScreenshot);
  BASE_DECLARE_FEATURE(kInfobarScrollOptimization);
  BASE_DECLARE_FEATURE(kImprovedA2HS);

--- a/build/patches/Disable-TLS-resumption.patch
+++ b/build/patches/Disable-TLS-resumption.patch
@@ -28,13 +28,13 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  chrome/browser/about_flags.cc        |  6 +++
  chrome/browser/flag_descriptions.cc  |  8 ++++
  chrome/browser/flag_descriptions.h   |  6 +++
- net/base/features.cc                 |  6 +++
+ net/base/features.cc                 |  8 ++++
  net/base/features.h                  |  6 +++
  net/http/http_network_session.cc     |  1 +
  net/quic/quic_stream_factory.cc      | 35 ++++++++++++++++-
  net/socket/ssl_client_socket_impl.cc | 59 ++++++++++++++++++++++++++++
  net/socket/ssl_client_socket_impl.h  |  2 +
- 9 files changed, 128 insertions(+), 1 deletion(-)
+ 9 files changed, 130 insertions(+), 1 deletion(-)
 
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
@@ -89,15 +89,17 @@ diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptio
 diff --git a/net/base/features.cc b/net/base/features.cc
 --- a/net/base/features.cc
 +++ b/net/base/features.cc
-@@ -61,6 +61,12 @@ const base::FeatureParam<base::TimeDelta> kUseDnsHttpsSvcbSecureExtraTimeMin{
+@@ -61,6 +61,14 @@ const base::FeatureParam<base::TimeDelta> kUseDnsHttpsSvcbSecureExtraTimeMin{
      &kUseDnsHttpsSvcb, "UseDnsHttpsSvcbSecureExtraTimeMin",
      base::Milliseconds(5)};
  
-+const base::Feature kDisableTLSResumption{"DisableTLSResumption",
-+                                          base::FEATURE_ENABLED_BY_DEFAULT};
++BASE_FEATURE(kDisableTLSResumption,
++             "DisableTLSResumption",
++             base::FEATURE_ENABLED_BY_DEFAULT);
 +
-+const base::Feature kLogTLSResumption{"LogTLSResumption",
-+                                      base::FEATURE_DISABLED_BY_DEFAULT};
++BASE_FEATURE(kLogTLSResumption,
++             "LogTLSResumption",
++             base::FEATURE_DISABLED_BY_DEFAULT);
 +
  BASE_FEATURE(kUseDnsHttpsSvcbAlpn,
               "UseDnsHttpsSvcbAlpn",
@@ -110,10 +112,10 @@ diff --git a/net/base/features.h b/net/base/features.h
  NET_EXPORT BASE_DECLARE_FEATURE(kEnableTLS13EarlyData);
  
 +// Disables TLS resumption.
-+NET_EXPORT extern const base::Feature kDisableTLSResumption;
++NET_EXPORT BASE_DECLARE_FEATURE(kDisableTLSResumption);
 +
 +// Log TLS resumption.
-+NET_EXPORT extern const base::Feature kLogTLSResumption;
++NET_EXPORT BASE_DECLARE_FEATURE(kLogTLSResumption);
 +
  // Enables the TLS Encrypted ClientHello feature.
  // https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-13

--- a/build/patches/Disable-smart-selection-by-default.patch
+++ b/build/patches/Disable-smart-selection-by-default.patch
@@ -68,7 +68,7 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser
  BASE_DECLARE_FEATURE(kCacheDeprecatedSystemLocationSetting);
  BASE_DECLARE_FEATURE(kChromeNewDownloadTab);
  BASE_DECLARE_FEATURE(kChromeShareLongScreenshot);
-+extern const base::Feature kChromeSmartSelection;
++BASE_DECLARE_FEATURE(kChromeSmartSelection);
  BASE_DECLARE_FEATURE(kChromeShareScreenshot);
  BASE_DECLARE_FEATURE(kChromeSharingHub);
  BASE_DECLARE_FEATURE(kChromeSharingHubLaunchAdjacent);

--- a/build/patches/Disable-text-fragments-by-default.patch
+++ b/build/patches/Disable-text-fragments-by-default.patch
@@ -13,11 +13,11 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  chrome/browser/flag_descriptions.h                           | 3 +++
  chrome/browser/ui/prefs/prefs_tab_helper.cc                  | 2 +-
  content/child/runtime_features.cc                            | 1 +
- third_party/blink/common/features.cc                         | 4 ++++
+ third_party/blink/common/features.cc                         | 5 +++++
  third_party/blink/public/common/features.h                   | 1 +
  third_party/blink/renderer/core/dom/document.cc              | 5 +++++
  .../blink/renderer/platform/runtime_enabled_features.json5   | 5 ++---
- 10 files changed, 31 insertions(+), 4 deletions(-)
+ 10 files changed, 32 insertions(+), 4 deletions(-)
 
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
@@ -102,13 +102,14 @@ diff --git a/content/child/runtime_features.cc b/content/child/runtime_features.
 diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
 --- a/third_party/blink/common/features.cc
 +++ b/third_party/blink/common/features.cc
-@@ -496,6 +496,10 @@ BASE_FEATURE(kDropInputEventsBeforeFirstPaint,
+@@ -496,6 +496,11 @@ BASE_FEATURE(kDropInputEventsBeforeFirstPaint,
               "DropInputEventsBeforeFirstPaint",
               base::FEATURE_DISABLED_BY_DEFAULT);
  
 +// Enable text snippets in URL fragments. https://crbug.com/919204.
-+const base::Feature kTextFragmentAnchor{"TextFragmentAnchor",
-+                                        base::FEATURE_DISABLED_BY_DEFAULT};
++BASE_FEATURE(kTextFragmentAnchor,
++             "TextFragmentAnchor",
++             base::FEATURE_DISABLED_BY_DEFAULT);
 +
  // File handling icons. https://crbug.com/1218213
  BASE_FEATURE(kFileHandlingIcons,
@@ -120,7 +121,7 @@ diff --git a/third_party/blink/public/common/features.h b/third_party/blink/publ
  BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kDecodeLossyWebPImagesToYUV);
  
  BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kWebFontsCacheAwareTimeoutAdaption);
-+BLINK_COMMON_EXPORT extern const base::Feature kTextFragmentAnchor;
++BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kTextFragmentAnchor);
  
  BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kAudioWorkletThreadRealtimePriority);
  

--- a/build/patches/Enable-share-intent.patch
+++ b/build/patches/Enable-share-intent.patch
@@ -375,14 +375,14 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browse
 diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser/flags/android/chrome_feature_list.h
 --- a/chrome/browser/flags/android/chrome_feature_list.h
 +++ b/chrome/browser/flags/android/chrome_feature_list.h
-@@ -141,6 +141,7 @@ BASE_DECLARE_FEATURE(kSearchEnginePromoExistingDeviceV2);
- BASE_DECLARE_FEATURE(kSearchEnginePromoNewDevice);
+@@ -142,6 +142,7 @@ BASE_DECLARE_FEATURE(kSearchEnginePromoNewDevice);
  BASE_DECLARE_FEATURE(kSearchEnginePromoNewDeviceV2);
  BASE_DECLARE_FEATURE(kShareButtonInTopToolbar);
-+extern const base::Feature kSharedIntentUI;
- extern const base::Feature kSearchReadyOmniboxFeature;
+ BASE_DECLARE_FEATURE(kSearchReadyOmniboxFeature);
++BASE_DECLARE_FEATURE(kSharedIntentUI);
  BASE_DECLARE_FEATURE(kSharingHubLinkToggle);
  BASE_DECLARE_FEATURE(kShowScrollableMVTOnNTPAndroid);
+ BASE_DECLARE_FEATURE(kFeedPositionAndroid);
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java

--- a/build/patches/Re-introduce-kWebAuthCable.patch
+++ b/build/patches/Re-introduce-kWebAuthCable.patch
@@ -12,9 +12,9 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../webauthn/authenticator_dialog_browsertest.cc  |  7 +++++++
  .../webauthn/chrome_webauthn_browsertest.cc       |  2 ++
  .../webauth/authenticator_impl_unittest.cc        | 15 +++++++++++++--
- content/public/common/content_features.cc         |  6 ++++++
+ content/public/common/content_features.cc         |  7 +++++++
  content/public/common/content_features.h          |  1 +
- 6 files changed, 36 insertions(+), 2 deletions(-)
+ 6 files changed, 37 insertions(+), 2 deletions(-)
 
 diff --git a/chrome/browser/ui/views/webauthn/authenticator_dialog_view_browsertest.cc b/chrome/browser/ui/views/webauthn/authenticator_dialog_view_browsertest.cc
 --- a/chrome/browser/ui/views/webauthn/authenticator_dialog_view_browsertest.cc
@@ -118,15 +118,16 @@ diff --git a/content/browser/webauth/authenticator_impl_unittest.cc b/content/br
 diff --git a/content/public/common/content_features.cc b/content/public/common/content_features.cc
 --- a/content/public/common/content_features.cc
 +++ b/content/public/common/content_features.cc
-@@ -1283,6 +1283,12 @@ BASE_FEATURE(kWebAssemblyTrapHandler,
+@@ -1284,6 +1284,13 @@ BASE_FEATURE(kWebAssemblyTrapHandler,
  #endif
  );
  
 +// Controls whether CTAP2 devices can communicate via the WebAuthentication API
 +// using pairingless BLE protocol.
 +// https://w3c.github.io/webauthn
-+const base::Feature kWebAuthCable{"WebAuthenticationCable",                 // must be disabled
-+                                  base::FEATURE_DISABLED_BY_DEFAULT};       // by default in Bromite
++BASE_FEATURE(kWebAuthCable,
++             "WebAuthenticationCable",                 // must be disabled
++             base::FEATURE_DISABLED_BY_DEFAULT);       // by default in Bromite
 +
  // Controls whether WebAuthn conditional UI requests are supported.
  BASE_FEATURE(kWebAuthConditionalUI,
@@ -138,7 +139,7 @@ diff --git a/content/public/common/content_features.h b/content/public/common/co
  CONTENT_EXPORT BASE_DECLARE_FEATURE(kWebRtcUseGpuMemoryBufferVideoFrames);
  CONTENT_EXPORT BASE_DECLARE_FEATURE(kWebUICodeCache);
  CONTENT_EXPORT BASE_DECLARE_FEATURE(kWebUIReportOnlyTrustedTypes);
-+CONTENT_EXPORT extern const base::Feature kWebAuthCable;
++CONTENT_EXPORT BASE_DECLARE_FEATURE(kWebAuthCable);
  CONTENT_EXPORT BASE_DECLARE_FEATURE(kWebUsb);
  CONTENT_EXPORT BASE_DECLARE_FEATURE(kWebXr);
  CONTENT_EXPORT BASE_DECLARE_FEATURE(kWebXrArModule);

--- a/build/patches/Restore-Search-Ready-Omnibox-flag.patch
+++ b/build/patches/Restore-Search-Ready-Omnibox-flag.patch
@@ -104,7 +104,7 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser
  BASE_DECLARE_FEATURE(kSearchEnginePromoNewDevice);
  BASE_DECLARE_FEATURE(kSearchEnginePromoNewDeviceV2);
  BASE_DECLARE_FEATURE(kShareButtonInTopToolbar);
-+extern const base::Feature kSearchReadyOmniboxFeature;
++BASE_DECLARE_FEATURE(kSearchReadyOmniboxFeature);
  BASE_DECLARE_FEATURE(kSharingHubLinkToggle);
  BASE_DECLARE_FEATURE(kShowScrollableMVTOnNTPAndroid);
  BASE_DECLARE_FEATURE(kFeedPositionAndroid);

--- a/build/patches/Restore-offline-indicator-v2-flag.patch
+++ b/build/patches/Restore-offline-indicator-v2-flag.patch
@@ -209,7 +209,7 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser
  BASE_DECLARE_FEATURE(kLensOnQuickActionSearchWidget);
  BASE_DECLARE_FEATURE(kLocationBarModelOptimizations);
  BASE_DECLARE_FEATURE(kNewInstanceFromDraggedLink);
-+extern const base::Feature kOfflineIndicatorV2;
++BASE_DECLARE_FEATURE(kOfflineIndicatorV2);
  BASE_DECLARE_FEATURE(kNewTabPageTilesTitleWrapAround);
  BASE_DECLARE_FEATURE(kNewWindowAppMenu);
  BASE_DECLARE_FEATURE(kNotificationPermissionVariant);


### PR DESCRIPTION
## Description

Followed upstream for:
- Use helper macros to define base::Features
see https://bugs.chromium.org/p/chromium/issues/detail?id=1364289

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
