### PR TITLE
Fix some lost changes after v108

### DIFF
--- a/build/patches/Disable-all-predictors-code.patch
+++ b/build/patches/Disable-all-predictors-code.patch
@@ -6,6 +6,7 @@ Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
  .../chrome_hints_manager.cc                   |  1 +
+ .../optimization_guide_keyed_service.cc       |  1 -
  chrome/common/chrome_features.cc              |  8 ++--
  .../optimization_guide/core/hints_fetcher.cc  |  1 +
  .../optimization_guide/core/hints_manager.cc  |  5 +++
@@ -15,7 +16,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  components/optimization_guide/features.gni    |  4 +-
  components/permissions/features.cc            |  8 ++--
  third_party/blink/common/features.cc          |  8 +---
- 10 files changed, 40 insertions(+), 40 deletions(-)
+ 11 files changed, 40 insertions(+), 41 deletions(-)
 
 diff --git a/chrome/browser/optimization_guide/chrome_hints_manager.cc b/chrome/browser/optimization_guide/chrome_hints_manager.cc
 --- a/chrome/browser/optimization_guide/chrome_hints_manager.cc
@@ -28,6 +29,17 @@ diff --git a/chrome/browser/optimization_guide/chrome_hints_manager.cc b/chrome/
  
    if (prediction->prediction_source() !=
        NavigationPredictorKeyedService::PredictionSource::
+diff --git a/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc b/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
+--- a/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
++++ b/chrome/browser/optimization_guide/optimization_guide_keyed_service.cc
+@@ -320,7 +320,6 @@ void OptimizationGuideKeyedService::RemoveObserverForOptimizationTargetModel(
+ void OptimizationGuideKeyedService::RegisterOptimizationTypes(
+     const std::vector<optimization_guide::proto::OptimizationType>&
+         optimization_types) {
+-  hints_manager_->RegisterOptimizationTypes(optimization_types);
+ }
+ 
+ optimization_guide::OptimizationGuideDecision
 diff --git a/chrome/common/chrome_features.cc b/chrome/common/chrome_features.cc
 --- a/chrome/common/chrome_features.cc
 +++ b/chrome/common/chrome_features.cc

--- a/build/patches/Disable-conversion-measurement-api.patch
+++ b/build/patches/Disable-conversion-measurement-api.patch
@@ -17,11 +17,12 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../aggregatable_report_sender.cc                 | 15 +++++++--------
  .../attribution_reporting/attribution_host.cc     |  1 +
  .../attribution_report_network_sender.cc          | 15 ++++++++-------
+ .../attribution_storage_sql.cc                    |  8 +++++---
  content/browser/storage_partition_impl.cc         |  7 +------
  content/public/browser/navigation_controller.cc   |  1 -
  third_party/blink/common/features.cc              |  4 ++--
  .../platform/runtime_enabled_features.json5       |  7 +++++++
- 10 files changed, 32 insertions(+), 33 deletions(-)
+ 11 files changed, 37 insertions(+), 36 deletions(-)
 
 diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
 --- a/chrome/browser/flags/android/chrome_feature_list.cc
@@ -142,6 +143,31 @@ diff --git a/content/browser/attribution_reporting/attribution_report_network_se
    network::SimpleURLLoader* loader = it->get();
  
    // Consider a non-200 HTTP code as a non-internal error.
+diff --git a/content/browser/attribution_reporting/attribution_storage_sql.cc b/content/browser/attribution_reporting/attribution_storage_sql.cc
+--- a/content/browser/attribution_reporting/attribution_storage_sql.cc
++++ b/content/browser/attribution_reporting/attribution_storage_sql.cc
+@@ -422,6 +422,8 @@ DestinationLimitResult GetDestinationLimitResult(
+   }
+ }
+ 
++bool g_run_in_memory = true;
++
+ }  // namespace
+ 
+ // static
+@@ -433,9 +435,9 @@ bool AttributionStorageSql::DeleteStorageForTesting(
+ AttributionStorageSql::AttributionStorageSql(
+     const base::FilePath& user_data_directory,
+     std::unique_ptr<AttributionStorageDelegate> delegate)
+-    : path_to_database_(user_data_directory.empty()
+-                            ? base::FilePath()
+-                            : DatabasePath(user_data_directory)),
++    : path_to_database_(user_data_directory.empty() || g_run_in_memory
++                             ? base::FilePath()
++                             : DatabasePath(user_data_directory)),
+       delegate_(std::move(delegate)),
+       rate_limit_table_(delegate_.get()) {
+   DCHECK(delegate_);
 diff --git a/content/browser/storage_partition_impl.cc b/content/browser/storage_partition_impl.cc
 --- a/content/browser/storage_partition_impl.cc
 +++ b/content/browser/storage_partition_impl.cc

--- a/build/patches/Remove-segmentation-platform.patch
+++ b/build/patches/Remove-segmentation-platform.patch
@@ -7,9 +7,9 @@ Also fixes a crash on startup.
 Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- .../chrome_browser_main_extra_parts_segmentation_platform.cc  | 4 ++++
- components/segmentation_platform/public/features.cc           | 4 ----
- 2 files changed, 4 insertions(+), 4 deletions(-)
+ ...rome_browser_main_extra_parts_segmentation_platform.cc | 4 ++++
+ components/segmentation_platform/public/features.cc       | 8 ++------
+ 2 files changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/chrome/browser/segmentation_platform/chrome_browser_main_extra_parts_segmentation_platform.cc b/chrome/browser/segmentation_platform/chrome_browser_main_extra_parts_segmentation_platform.cc
 --- a/chrome/browser/segmentation_platform/chrome_browser_main_extra_parts_segmentation_platform.cc
@@ -45,6 +45,17 @@ diff --git a/chrome/browser/segmentation_platform/chrome_browser_main_extra_part
 diff --git a/components/segmentation_platform/public/features.cc b/components/segmentation_platform/public/features.cc
 --- a/components/segmentation_platform/public/features.cc
 +++ b/components/segmentation_platform/public/features.cc
+@@ -9,8 +9,8 @@
+ namespace segmentation_platform::features {
+ 
+ BASE_FEATURE(kSegmentationPlatformFeature,
+-             "SegmentationPlatform",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             "SegmentationPlatform",                // disabled by default
++             base::FEATURE_DISABLED_BY_DEFAULT);    // in Bromite
+ 
+ BASE_FEATURE(kSegmentationStructuredMetricsFeature,
+              "SegmentationStructuredMetrics",
 @@ -34,11 +34,7 @@ BASE_FEATURE(kSegmentationPlatformSearchUser,
  
  BASE_FEATURE(kSegmentationPlatformFeedSegmentFeature,


### PR DESCRIPTION
## Description

We missed some changes during the porting to 108.
I propose them to you again

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
