### PR TITLE
Configuration panel for referral policy

### DIFF
--- a/build/patches/Remove-HTTP-referrals-in-cross-origin-navigation.patch
+++ b/build/patches/Remove-HTTP-referrals-in-cross-origin-navigation.patch
@@ -11,13 +11,106 @@ A preference is also introduced to completely removes referrals management, for 
 Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- chrome/android/java/res/xml/privacy_preferences.xml       | 4 ++++
- .../chrome/browser/privacy/settings/PrivacySettings.java  | 8 ++++++++
- .../browser/ui/android/strings/android_chrome_strings.grd | 3 +++
- content/browser/renderer_host/navigation_request.cc       | 7 +++++++
- services/network/public/cpp/resource_request.h            | 2 +-
- 5 files changed, 23 insertions(+), 1 deletion(-)
+ chrome/android/chrome_java_resources.gni      |  2 +
+ chrome/android/chrome_java_sources.gni        |  2 +
+ ...button_group_referer_policy_preference.xml | 47 ++++++++++
+ .../java/res/xml/privacy_preferences.xml      |  4 +
+ .../res/xml/referer_policy_preferences.xml    | 31 +++++++
+ .../privacy/settings/PrivacySettings.java     |  6 ++
+ .../RadioButtonGroupRefererSettings.java      | 89 +++++++++++++++++++
+ .../settings/RefererSettingsFragment.java     | 79 ++++++++++++++++
+ .../net/system_network_context_manager.cc     |  4 +
+ chrome/browser/renderer_preferences_util.cc   |  1 +
+ .../strings/android_chrome_strings.grd        | 24 +++++
+ chrome/browser/ui/prefs/pref_watcher.cc       |  2 +
+ chrome/browser/ui/prefs/prefs_tab_helper.cc   |  2 +
+ chrome/common/pref_names.cc                   |  3 +
+ chrome/common/pref_names.h                    |  1 +
+ .../renderer_host/navigation_request.cc       |  8 ++
+ .../network/public/cpp/resource_request.h     |  2 +-
+ .../renderer_preferences.h                    |  1 +
+ 18 files changed, 307 insertions(+), 1 deletion(-)
+ create mode 100644 chrome/android/java/res/layout/radio_button_group_referer_policy_preference.xml
+ create mode 100644 chrome/android/java/res/xml/referer_policy_preferences.xml
+ create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/RadioButtonGroupRefererSettings.java
+ create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/RefererSettingsFragment.java
 
+diff --git a/chrome/android/chrome_java_resources.gni b/chrome/android/chrome_java_resources.gni
+--- a/chrome/android/chrome_java_resources.gni
++++ b/chrome/android/chrome_java_resources.gni
+@@ -658,6 +658,8 @@ chrome_java_resources = [
+   "java/res/xml/phone_as_a_security_key_accessory_filter.xml",
+   "java/res/xml/incognito_preferences.xml",
+   "java/res/xml/privacy_preferences.xml",
++  "java/res/xml/referer_policy_preferences.xml",
++  "java/res/layout/radio_button_group_referer_policy_preference.xml",
+   "java/res/xml/search_widget_info.xml",
+   "java/res/xml/tracing_preferences.xml",
+   "java/res/xml/useragent_preferences.xml",
+diff --git a/chrome/android/chrome_java_sources.gni b/chrome/android/chrome_java_sources.gni
+--- a/chrome/android/chrome_java_sources.gni
++++ b/chrome/android/chrome_java_sources.gni
+@@ -923,6 +923,8 @@ chrome_java_sources = [
+   "java/src/org/chromium/chrome/browser/privacy/settings/PrivacyPreferencesManagerImpl.java",
+   "java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java",
+   "java/src/org/chromium/chrome/browser/privacy/settings/IncognitoSettings.java",
++  "java/src/org/chromium/chrome/browser/privacy/settings/RefererSettingsFragment.java",
++  "java/src/org/chromium/chrome/browser/privacy/settings/RadioButtonGroupRefererSettings.java",
+   "java/src/org/chromium/chrome/browser/provider/BaseColumns.java",
+   "java/src/org/chromium/chrome/browser/provider/BookmarkColumns.java",
+   "java/src/org/chromium/chrome/browser/provider/ChromeBrowserProviderImpl.java",
+diff --git a/chrome/android/java/res/layout/radio_button_group_referer_policy_preference.xml b/chrome/android/java/res/layout/radio_button_group_referer_policy_preference.xml
+new file mode 100644
+--- /dev/null
++++ b/chrome/android/java/res/layout/radio_button_group_referer_policy_preference.xml
+@@ -0,0 +1,47 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!--
++    This file is part of Bromite.
++
++    Bromite is free software: you can redistribute it and/or modify
++    it under the terms of the GNU General Public License as published by
++    the Free Software Foundation, either version 3 of the License, or
++    (at your option) any later version.
++
++    Bromite is distributed in the hope that it will be useful,
++    but WITHOUT ANY WARRANTY; without even the implied warranty of
++    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++    GNU General Public License for more details.
++
++    You should have received a copy of the GNU General Public License
++    along with Bromite. If not, see <https://www.gnu.org/licenses/>.
++-->
++
++<org.chromium.components.browser_ui.widget.RadioButtonWithDescriptionLayout
++    xmlns:android="http://schemas.android.com/apk/res/android"
++    xmlns:app="http://schemas.android.com/apk/res-auto"
++    android:layout_width="match_parent"
++    android:layout_height="wrap_content"
++    android:focusable="false">
++
++    <org.chromium.components.browser_ui.widget.RadioButtonWithDescription
++        android:id="@+id/no_cross_origin_top_frame_policy"
++        android:layout_width="match_parent"
++        android:layout_height="wrap_content"
++        app:primaryText="@string/no_cross_origin_top_frame_policy_title"
++        app:descriptionText="@string/no_cross_origin_top_frame_policy_summary" />
++
++    <org.chromium.components.browser_ui.widget.RadioButtonWithDescription
++        android:id="@+id/standard_referer_policy"
++        android:layout_width="match_parent"
++        android:layout_height="wrap_content"
++        app:primaryText="@string/standard_referer_policy_title"
++        app:descriptionText="@string/standard_referer_policy_summary" />
++
++    <org.chromium.components.browser_ui.widget.RadioButtonWithDescription
++        android:id="@+id/disable_referer_policy"
++        android:layout_width="match_parent"
++        android:layout_height="wrap_content"
++        app:primaryText="@string/disable_referer_policy_title"
++        app:descriptionText="@string/disable_referer_policy_summary" />
++
++</org.chromium.components.browser_ui.widget.RadioButtonWithDescriptionLayout>
 diff --git a/chrome/android/java/res/xml/privacy_preferences.xml b/chrome/android/java/res/xml/privacy_preferences.xml
 --- a/chrome/android/java/res/xml/privacy_preferences.xml
 +++ b/chrome/android/java/res/xml/privacy_preferences.xml
@@ -25,67 +118,381 @@ diff --git a/chrome/android/java/res/xml/privacy_preferences.xml b/chrome/androi
          android:title="@string/close_tabs_on_exit_title"
          android:summary="@string/close_tabs_on_exit_summary"
          android:defaultValue="false" />
-+    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
-+        android:key="enable_referrers"
-+        android:title="@string/enable_referrers_title"
-+        android:defaultValue="false" />
++    <Preference
++        android:key="referers_policy"
++        android:title="@string/referers_policy_title"
++        android:fragment="org.chromium.chrome.browser.privacy.settings.RefererSettingsFragment"/>
      <Preference
          android:fragment="org.chromium.chrome.browser.privacy.settings.DoNotTrackSettings"
          android:key="do_not_track"
+diff --git a/chrome/android/java/res/xml/referer_policy_preferences.xml b/chrome/android/java/res/xml/referer_policy_preferences.xml
+new file mode 100644
+--- /dev/null
++++ b/chrome/android/java/res/xml/referer_policy_preferences.xml
+@@ -0,0 +1,31 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!--
++    This file is part of Bromite.
++
++    Bromite is free software: you can redistribute it and/or modify
++    it under the terms of the GNU General Public License as published by
++    the Free Software Foundation, either version 3 of the License, or
++    (at your option) any later version.
++
++    Bromite is distributed in the hope that it will be useful,
++    but WITHOUT ANY WARRANTY; without even the implied warranty of
++    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++    GNU General Public License for more details.
++
++    You should have received a copy of the GNU General Public License
++    along with Bromite. If not, see <https://www.gnu.org/licenses/>.
++-->
++
++<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
++    xmlns:app="http://schemas.android.com/apk/res-auto">
++
++    <org.chromium.components.browser_ui.settings.TextMessagePreference
++        android:key="summary"
++        android:summary="@string/referers_policy_summary"
++        app:allowDividerBelow="false" />
++    <org.chromium.chrome.browser.privacy.settings.RadioButtonGroupRefererSettings
++        android:key="referer_page_radio_button_group"
++        android:selectable="false"
++        app:allowDividerAbove="false"
++        app:allowDividerBelow="false" />
++</PreferenceScreen>
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettings.java
-@@ -61,6 +61,7 @@ public class PrivacySettings
+@@ -24,6 +24,7 @@ import org.chromium.chrome.browser.flags.ChromeFeatureList;
+ import org.chromium.chrome.browser.incognito.reauth.IncognitoReauthSettingSwitchPreference;
+ import org.chromium.chrome.browser.preferences.Pref;
+ import org.chromium.chrome.browser.prefetch.settings.PreloadPagesSettingsFragment;
++import org.chromium.chrome.browser.privacy.settings.RefererSettingsFragment;
+ import org.chromium.chrome.browser.privacy.secure_dns.SecureDnsSettings;
+ import org.chromium.chrome.browser.privacy_sandbox.PrivacySandboxBridge;
+ import org.chromium.chrome.browser.privacy_sandbox.PrivacySandboxReferrer;
+@@ -61,6 +62,7 @@ public class PrivacySettings
      private static final String PREF_HTTPS_FIRST_MODE = "https_first_mode";
      private static final String PREF_SECURE_DNS = "secure_dns";
      private static final String PREF_DO_NOT_TRACK = "do_not_track";
-+    private static final String PREF_ENABLE_REFERRERS = "enable_referrers";
++    private static final String PREF_REFERER_POLICY = "referers_policy";
      private static final String PREF_CLEAR_BROWSING_DATA = "clear_browsing_data";
      private static final String PREF_PRIVACY_GUIDE = "privacy_guide";
      private static final String PREF_INCOGNITO_LOCK = "incognito_lock";
-@@ -174,6 +175,9 @@ public class PrivacySettings
-         } else if (PREF_CAN_MAKE_PAYMENT.equals(key)) {
-             UserPrefs.get(Profile.getLastUsedRegularProfile())
-                     .setBoolean(Pref.CAN_MAKE_PAYMENT_ENABLED, (boolean) newValue);
-+        } else if (PREF_ENABLE_REFERRERS.equals(key)) {
-+            UserPrefs.get(Profile.getLastUsedRegularProfile())
-+                    .setBoolean(Pref.ENABLE_REFERRERS, (boolean) newValue);
-         } else if (PREF_HTTPS_FIRST_MODE.equals(key)) {
-             UserPrefs.get(Profile.getLastUsedRegularProfile())
-                     .setBoolean(Pref.HTTPS_ONLY_MODE_ENABLED, (boolean) newValue);
-@@ -227,6 +231,10 @@ public class PrivacySettings
+@@ -227,6 +229,10 @@ public class PrivacySettings
                              : R.string.text_off);
          }
  
-+        ChromeSwitchPreference enableReferrerPref = findPreference(PREF_ENABLE_REFERRERS);
-+        enableReferrerPref.setChecked(prefService.getBoolean(Pref.ENABLE_REFERRERS));
-+        enableReferrerPref.setOnPreferenceChangeListener(this);
++        Preference refererPolicyPref = findPreference(PREF_REFERER_POLICY);
++        refererPolicyPref.setSummary(
++                RefererSettingsFragment.getRefererSummaryString(getContext()));
 +
          Preference preloadPagesPreference = findPreference(PREF_PRELOAD_PAGES);
          if (preloadPagesPreference != null) {
              preloadPagesPreference.setSummary(
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/RadioButtonGroupRefererSettings.java b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/RadioButtonGroupRefererSettings.java
+new file mode 100644
+--- /dev/null
++++ b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/RadioButtonGroupRefererSettings.java
+@@ -0,0 +1,89 @@
++/*
++    This file is part of Bromite.
++
++    Bromite is free software: you can redistribute it and/or modify
++    it under the terms of the GNU General Public License as published by
++    the Free Software Foundation, either version 3 of the License, or
++    (at your option) any later version.
++
++    Bromite is distributed in the hope that it will be useful,
++    but WITHOUT ANY WARRANTY; without even the implied warranty of
++    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++    GNU General Public License for more details.
++
++    You should have received a copy of the GNU General Public License
++    along with Bromite. If not, see <https://www.gnu.org/licenses/>.
++*/
++
++package org.chromium.chrome.browser.privacy.settings;
++
++import android.content.Context;
++import android.util.AttributeSet;
++import android.view.View;
++import android.widget.RadioGroup;
++
++import androidx.preference.Preference;
++import androidx.preference.PreferenceViewHolder;
++
++import org.chromium.chrome.R;
++import org.chromium.chrome.browser.flags.ChromeFeatureList;
++import org.chromium.components.browser_ui.widget.RadioButtonWithDescription;
++import org.chromium.components.browser_ui.widget.RadioButtonWithDescriptionLayout;
++
++public class RadioButtonGroupRefererSettings extends Preference
++        implements RadioGroup.OnCheckedChangeListener {
++
++    private RadioButtonWithDescription mStandardReferer;
++    private RadioButtonWithDescription mNoCrossOriginReferer;
++    private RadioButtonWithDescription mNoReferer;
++    private int mRefererPolicy;
++
++    public RadioButtonGroupRefererSettings(Context context, AttributeSet attrs) {
++        super(context, attrs);
++        setLayoutResource(R.layout.radio_button_group_referer_policy_preference);
++    }
++
++    public void init(boolean enableReferer, int refererPolicy) {
++        if (!enableReferer)
++            mRefererPolicy = 0;
++        else
++            mRefererPolicy = refererPolicy;
++    }
++
++    @Override
++    public void onCheckedChanged(RadioGroup group, int checkedId) {
++        if (checkedId == mStandardReferer.getId()) {
++            mRefererPolicy = 1;
++        } else if (checkedId == mNoCrossOriginReferer.getId()) {
++            mRefererPolicy = 2;
++        } else if (checkedId == mNoReferer.getId()) {
++            mRefererPolicy = 0;
++        } else {
++            assert false : "Should not be reached.";
++        }
++        callChangeListener(mRefererPolicy);
++    }
++
++    @Override
++    public void onBindViewHolder(PreferenceViewHolder holder) {
++        super.onBindViewHolder(holder);
++
++        mStandardReferer = (RadioButtonWithDescription) holder.findViewById(
++                R.id.standard_referer_policy);
++        mNoCrossOriginReferer = (RadioButtonWithDescription) holder.findViewById(
++                R.id.no_cross_origin_top_frame_policy);
++        mNoReferer = (RadioButtonWithDescription) holder.findViewById(R.id.disable_referer_policy);
++
++        RadioButtonWithDescriptionLayout groupLayout =
++                (RadioButtonWithDescriptionLayout) mNoReferer.getRootView();
++        setCheckedState(mRefererPolicy);
++        groupLayout.setOnCheckedChangeListener(this);
++    }
++
++    public void setCheckedState(int checkedState) {
++        mRefererPolicy = checkedState;
++        mStandardReferer.setChecked(checkedState == 1);
++        mNoCrossOriginReferer.setChecked(checkedState == 2);
++        mNoReferer.setChecked(checkedState == 0);
++    }
++}
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/RefererSettingsFragment.java b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/RefererSettingsFragment.java
+new file mode 100644
+--- /dev/null
++++ b/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/RefererSettingsFragment.java
+@@ -0,0 +1,79 @@
++/*
++    This file is part of Bromite.
++
++    Bromite is free software: you can redistribute it and/or modify
++    it under the terms of the GNU General Public License as published by
++    the Free Software Foundation, either version 3 of the License, or
++    (at your option) any later version.
++
++    Bromite is distributed in the hope that it will be useful,
++    but WITHOUT ANY WARRANTY; without even the implied warranty of
++    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++    GNU General Public License for more details.
++
++    You should have received a copy of the GNU General Public License
++    along with Bromite. If not, see <https://www.gnu.org/licenses/>.
++*/
++
++package org.chromium.chrome.browser.privacy.settings;
++
++import android.os.Bundle;
++import android.content.Context;
++
++import androidx.preference.Preference;
++import androidx.preference.PreferenceFragmentCompat;
++
++import org.chromium.chrome.R;
++import org.chromium.chrome.browser.preferences.Pref;
++import org.chromium.chrome.browser.profiles.Profile;
++import org.chromium.components.browser_ui.settings.TextMessagePreference;
++import org.chromium.components.browser_ui.settings.SettingsUtils;
++import org.chromium.components.prefs.PrefService;
++import org.chromium.components.user_prefs.UserPrefs;
++
++public class RefererSettingsFragment
++        extends PreferenceFragmentCompat
++        implements Preference.OnPreferenceChangeListener {
++
++    static final String PREF_REFERER_POLICY = "referer_page_radio_button_group";
++
++    private RadioButtonGroupRefererSettings mRefererPreference;
++    private final PrefService prefService = UserPrefs.get(Profile.getLastUsedRegularProfile());
++
++    public static String getRefererSummaryString(Context context) {
++        int policy = UserPrefs.get(Profile.getLastUsedRegularProfile())
++                              .getInteger(Pref.REFERRERS_POLICY);
++
++        if (policy == 0) {
++            return context.getString(R.string.disable_referer_policy_title);
++        }
++        if (policy == 1) {
++            return context.getString(R.string.standard_referer_policy_title);
++        }
++        if (policy == 2) {
++            return context.getString(R.string.no_cross_origin_top_frame_policy_title);
++        }
++        assert false : "Should not be reached";
++        return "";
++    }
++
++    @Override
++    public void onCreatePreferences(Bundle bundle, String s) {
++        SettingsUtils.addPreferencesFromResource(this, R.xml.referer_policy_preferences);
++        getActivity().setTitle(R.string.referers_policy_title);
++
++        mRefererPreference = findPreference(PREF_REFERER_POLICY);
++        mRefererPreference.init(prefService.getBoolean(Pref.ENABLE_REFERRERS),
++                                prefService.getInteger(Pref.REFERRERS_POLICY));
++        mRefererPreference.setOnPreferenceChangeListener(this);
++    }
++
++    @Override
++    public boolean onPreferenceChange(Preference preference, Object newValue) {
++        UserPrefs.get(Profile.getLastUsedRegularProfile())
++                 .setInteger(Pref.REFERRERS_POLICY, (int)newValue);
++        UserPrefs.get(Profile.getLastUsedRegularProfile())
++                 .setBoolean(Pref.ENABLE_REFERRERS, (int)newValue != 0);
++        return true;
++    }
++}
+diff --git a/chrome/browser/net/system_network_context_manager.cc b/chrome/browser/net/system_network_context_manager.cc
+--- a/chrome/browser/net/system_network_context_manager.cc
++++ b/chrome/browser/net/system_network_context_manager.cc
+@@ -479,6 +479,9 @@ SystemNetworkContextManager::SystemNetworkContextManager(
+       base::BindRepeating(&SystemNetworkContextManager::UpdateReferrersEnabled,
+                           base::Unretained(this)));
+ 
++  local_state_->SetDefaultPrefValue(
++      prefs::kReferrersPolicy, base::Value(2));
++
+   pref_change_registrar_.Add(
+       prefs::kExplicitlyAllowedNetworkPorts,
+       base::BindRepeating(
+@@ -545,6 +548,7 @@ void SystemNetworkContextManager::RegisterPrefs(PrefRegistrySimple* registry) {
+   // the system NetworkContext, and the per-profile pref values are used for
+   // the profile NetworkContexts.
+   registry->RegisterBooleanPref(prefs::kEnableReferrers, true);
++  registry->RegisterIntegerPref(prefs::kReferrersPolicy, 2);
+ 
+   registry->RegisterBooleanPref(prefs::kQuickCheckEnabled, true);
+ 
+diff --git a/chrome/browser/renderer_preferences_util.cc b/chrome/browser/renderer_preferences_util.cc
+--- a/chrome/browser/renderer_preferences_util.cc
++++ b/chrome/browser/renderer_preferences_util.cc
+@@ -115,6 +115,7 @@ void UpdateFromSystemSettings(blink::RendererPreferences* prefs,
+   prefs->accept_languages = GetLanguageListForProfile(
+       profile, pref_service->GetString(language::prefs::kAcceptLanguages));
+   prefs->enable_referrers = pref_service->GetBoolean(prefs::kEnableReferrers);
++  prefs->referrers_policy = pref_service->GetInteger(prefs::kReferrersPolicy);
+   prefs->enable_do_not_track =
+       pref_service->GetBoolean(prefs::kEnableDoNotTrack);
+   prefs->enable_encrypted_media =
 diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
 --- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
 +++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
-@@ -879,6 +879,9 @@ CHAR_LIMIT guidelines:
+@@ -879,6 +879,30 @@ CHAR_LIMIT guidelines:
  
  For example, some websites may respond to this request by showing you ads that aren’t based on other websites you’ve visited. Many websites will still collect and use your browsing data — for example to improve security, to provide content, ads and recommendations, and to generate reporting statistics.
        </message>
-+      <message name="IDS_ENABLE_REFERRERS_TITLE" desc="Title for 'Enable referrers' preference">
-+        Enable HTTP Referer header
++      <message name="IDS_REFERERS_POLICY_TITLE" desc="Title for 'Enable referers' preference">
++        HTTP Referer header policy
++      </message>
++      <message name="IDS_REFERERS_POLICY_SUMMARY" desc="Summary for a section in Settings that controls referer policy.">
++        Allow to change default HTTP Referer header policy
++      </message>
++      <message name="IDS_STANDARD_REFERER_POLICY_TITLE" desc="Title for 'standard referer' preference">
++        Standard HTTP Referrer header policy
++      </message>
++      <message name="IDS_STANDARD_REFERER_POLICY_SUMMARY" desc="Summary for 'standard referer' preference">
++        Send only origin if the request is cross-origin
++      </message>
++      <message name="IDS_NO_CROSS_ORIGIN_TOP_FRAME_POLICY_TITLE" desc="Title for 'standard referer' preference">
++        Disable if cross-origin and user begins navigation
++      </message>
++      <message name="IDS_NO_CROSS_ORIGIN_TOP_FRAME_POLICY_SUMMARY" desc="Summary for 'no cross origin referer' preference">
++        Remove referrer if the navigation is cross-origin and occurs in the top frame otherwise send only origin if the request is cross-origin
++      </message>
++      <message name="IDS_DISABLE_REFERER_POLICY_TITLE" desc="Title for 'disable referer' preference">
++        Disable all referrers
++      </message>
++      <message name="IDS_DISABLE_REFERER_POLICY_SUMMARY" desc="Summary for 'disable referer' preference">
++        Disable all referrers, may break navigation
 +      </message>
        <message name="IDS_CAN_MAKE_PAYMENT_TITLE" desc="Title for preference to allow websites to know whether you have payment methods available through PaymentRequest.CanMakePayment interface">
          Access payment methods
        </message>
+diff --git a/chrome/browser/ui/prefs/pref_watcher.cc b/chrome/browser/ui/prefs/pref_watcher.cc
+--- a/chrome/browser/ui/prefs/pref_watcher.cc
++++ b/chrome/browser/ui/prefs/pref_watcher.cc
+@@ -84,6 +84,8 @@ PrefWatcher::PrefWatcher(Profile* profile) : profile_(profile) {
+                                      renderer_callback);
+   profile_pref_change_registrar_.Add(prefs::kEnableReferrers,
+                                      renderer_callback);
++  profile_pref_change_registrar_.Add(prefs::kReferrersPolicy,
++                                     renderer_callback);
+   profile_pref_change_registrar_.Add(prefs::kEnableEncryptedMedia,
+                                      renderer_callback);
+   profile_pref_change_registrar_.Add(prefs::kWebRTCIPHandlingPolicy,
+diff --git a/chrome/browser/ui/prefs/prefs_tab_helper.cc b/chrome/browser/ui/prefs/prefs_tab_helper.cc
+--- a/chrome/browser/ui/prefs/prefs_tab_helper.cc
++++ b/chrome/browser/ui/prefs/prefs_tab_helper.cc
+@@ -360,6 +360,8 @@ void PrefsTabHelper::RegisterProfilePrefs(
+   registry->RegisterBooleanPref(
+       prefs::kEnableReferrers,
+       !base::FeatureList::IsEnabled(features::kNoReferrers));
++  registry->RegisterIntegerPref(
++      prefs::kReferrersPolicy, 2); // NoCrossOriginReferer
+   registry->RegisterBooleanPref(prefs::kEnableEncryptedMedia, true);
+   registry->RegisterBooleanPref(prefs::kScrollToTextFragmentEnabled, false);
+ #if BUILDFLAG(IS_ANDROID)
+diff --git a/chrome/common/pref_names.cc b/chrome/common/pref_names.cc
+--- a/chrome/common/pref_names.cc
++++ b/chrome/common/pref_names.cc
+@@ -1432,6 +1432,9 @@ const char kEnableHyperlinkAuditing[] = "enable_a_ping";
+ // Whether to enable sending referrers.
+ const char kEnableReferrers[] = "enable_referrers";
+ 
++// Set referrer policy.
++const char kReferrersPolicy[] = "referrers_policy";
++
+ // Whether to send the DNT header.
+ const char kEnableDoNotTrack[] = "enable_do_not_track";
+ 
+diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
+--- a/chrome/common/pref_names.h
++++ b/chrome/common/pref_names.h
+@@ -442,6 +442,7 @@ extern const char kPinnedTabs[];
+ extern const char kDisable3DAPIs[];
+ extern const char kEnableHyperlinkAuditing[];
+ extern const char kEnableReferrers[];
++extern const char kReferrersPolicy[];
+ extern const char kEnableDoNotTrack[];
+ extern const char kEnableEncryptedMedia[];
+ 
 diff --git a/content/browser/renderer_host/navigation_request.cc b/content/browser/renderer_host/navigation_request.cc
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
-@@ -431,6 +431,13 @@ void AddAdditionalRequestHeaders(
+@@ -431,6 +431,14 @@ void AddAdditionalRequestHeaders(
          blink::mojom::Referrer(GURL(), network::mojom::ReferrerPolicy::kNever);
    }
  
-+  if (!url::IsSameOriginWith(referrer->url.GetAsReferrer(), url) &&
-+      frame_tree_node->IsOutermostMainFrame()) {
++  if (render_prefs.enable_referrers && render_prefs.referrers_policy == 2 &&
++        !url::IsSameOriginWith(referrer->url.GetAsReferrer(), url) &&
++        frame_tree_node->IsOutermostMainFrame()) {
 +    // remove referrer if the navigation is done on the top frame
 +    *referrer =
 +        blink::mojom::Referrer(GURL(), network::mojom::ReferrerPolicy::kNever);
@@ -106,5 +513,16 @@ diff --git a/services/network/public/cpp/resource_request.h b/services/network/p
    net::HttpRequestHeaders headers;
    net::HttpRequestHeaders cors_exempt_headers;
    int load_flags = 0;
+diff --git a/third_party/blink/public/common/renderer_preferences/renderer_preferences.h b/third_party/blink/public/common/renderer_preferences/renderer_preferences.h
+--- a/third_party/blink/public/common/renderer_preferences/renderer_preferences.h
++++ b/third_party/blink/public/common/renderer_preferences/renderer_preferences.h
+@@ -40,6 +40,7 @@ struct BLINK_COMMON_EXPORT RendererPreferences {
+   absl::optional<base::TimeDelta> caret_blink_interval;
+   bool use_custom_colors{true};
+   bool enable_referrers{true};
++  uint32_t referrers_policy{2};
+   bool allow_cross_origin_auth_prompt{false};
+   bool enable_do_not_track{false};
+   bool enable_encrypted_media{true};
 --
 2.25.1


### PR DESCRIPTION
## Description

I modified the patch to add a configuration panel:
![image](https://user-images.githubusercontent.com/29201891/209949217-3e0f06f7-b70b-48f5-b5b1-d78aa83a9528.png)

the options, as we said, become three:
![image](https://user-images.githubusercontent.com/29201891/209949238-d859860c-0313-4776-99e5-a2f1d028a1be.png)

texts may be incorrect, feel free of course to modify them as you see fit.

fixes #2397 

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
