### PR TITLE
Restoring ua reduction

### DIFF
--- a/build/patches/Guard-for-user-agent-reduction.patch
+++ b/build/patches/Guard-for-user-agent-reduction.patch
@@ -4,9 +4,54 @@ Subject: Guard for user-agent reduction
 
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- third_party/blink/common/features.cc | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ chrome/browser/chrome_content_browser_client.cc     |  2 +-
+ content/common/user_agent.cc                        | 13 +++++--------
+ third_party/blink/common/features.cc                |  4 ++--
+ .../platform/runtime_enabled_features.json5         |  3 ++-
+ 4 files changed, 10 insertions(+), 12 deletions(-)
 
+diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -1475,7 +1475,7 @@ void ChromeContentBrowserClient::RegisterProfilePrefs(
+   registry->RegisterIntegerPref(
+       prefs::kUserAgentReduction,
+       static_cast<int>(
+-          embedder_support::UserAgentReductionEnterprisePolicyState::kDefault));
++          embedder_support::UserAgentReductionEnterprisePolicyState::kForceEnabled));
+   registry->RegisterBooleanPref(prefs::kOriginAgentClusterDefaultEnabled, true);
+   registry->RegisterIntegerPref(
+       prefs::kForceMajorVersionToMinorPositionInUserAgent,
+diff --git a/content/common/user_agent.cc b/content/common/user_agent.cc
+--- a/content/common/user_agent.cc
++++ b/content/common/user_agent.cc
+@@ -323,14 +323,7 @@ std::string BuildUserAgentFromProduct(const std::string& product) {
+ }
+ 
+ std::string BuildModelInfo() {
+-  std::string model;
+-#if BUILDFLAG(IS_ANDROID)
+-  // Only send the model information if on the release build of Android,
+-  // matching user agent behaviour.
+-  if (base::SysInfo::GetAndroidBuildCodename() == "REL")
+-    model = base::SysInfo::HardwareModelName();
+-#endif
+-  return model;
++  return std::string();
+ }
+ 
+ #if BUILDFLAG(IS_ANDROID)
+@@ -351,6 +344,10 @@ std::string GetAndroidOSInfo(
+     IncludeAndroidModel include_android_model) {
+   std::string android_info_str;
+ 
++  // Do not send information about the device.
++  include_android_model = IncludeAndroidModel::Exclude;
++  include_android_build_number = IncludeAndroidBuildNumber::Exclude;
++
+   // Send information about the device.
+   bool semicolon_inserted = false;
+   if (include_android_model == IncludeAndroidModel::Include) {
 diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
 --- a/third_party/blink/common/features.cc
 +++ b/third_party/blink/common/features.cc
@@ -21,5 +66,18 @@ diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/fea
  const base::FeatureParam<bool> kLegacyWindowsPlatform = {
      &kReduceUserAgentPlatformOsCpu, "legacy_windows_platform", true};
  
+diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+--- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
++++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+@@ -2711,7 +2711,8 @@
+       base_feature: "UserAgentClientHint",
+     },
+     {
+-      name: "UserAgentReduction",
++      name: "UserAgentReduction",  // always enabled
++      status: "stable",            // in bromite
+       origin_trial_feature_name: "UserAgentReduction",
+       origin_trial_allows_third_party: true,
+       // iOS not included as it should not send a reduced User-Agent string.
 --
 2.25.1


### PR DESCRIPTION
## Description

Fix UA reduction by default

Fix for #2491

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
