### PR TITLE
Remove another way to get field trials

### DIFF
--- a/build/patches/Disable-fetching-of-all-field-trials.patch
+++ b/build/patches/Disable-fetching-of-all-field-trials.patch
@@ -10,15 +10,21 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  android_webview/nonembedded/BUILD.gn          |  2 --
  .../services/VariationsSeedServer.java        |  2 --
  .../metrics/chrome_browser_sampling_trials.cc |  4 +++
+ .../net/system_network_context_manager.cc     |  1 -
  components/ukm/ukm_recorder_impl.cc           |  3 +++
  .../firstrun/VariationsSeedBridge.java        |  2 +-
  .../firstrun/VariationsSeedFetcher.java       | 26 ++++---------------
+ components/variations/net/BUILD.gn            |  2 --
  .../variations/net/omnibox_http_headers.cc    |  4 +--
  .../variations/net/variations_http_headers.cc |  3 +++
  .../service/variations_field_trial_creator.cc |  3 ++-
  .../variations/service/variations_service.cc  | 15 +++--------
+ .../browser/loader/url_loader_throttles.cc    |  2 --
+ .../origin_trials/origin_trials_utils.cc      |  2 +-
+ content/public/common/content_features.cc     |  4 +--
+ .../variations_render_thread_observer.cc      |  9 -------
  .../renderer/core/loader/document_loader.cc   |  7 -----
- 11 files changed, 23 insertions(+), 48 deletions(-)
+ 17 files changed, 26 insertions(+), 65 deletions(-)
 
 diff --git a/android_webview/nonembedded/BUILD.gn b/android_webview/nonembedded/BUILD.gn
 --- a/android_webview/nonembedded/BUILD.gn
@@ -72,6 +78,17 @@ diff --git a/chrome/browser/metrics/chrome_browser_sampling_trials.cc b/chrome/b
    static const char kSampledGroup_Stable[] = "Sampled_NoSeed_Stable";
    static const char kSampledGroup_Other[] = "Sampled_NoSeed_Other";
    const char* sampled_group = kSampledGroup_Other;
+diff --git a/chrome/browser/net/system_network_context_manager.cc b/chrome/browser/net/system_network_context_manager.cc
+--- a/chrome/browser/net/system_network_context_manager.cc
++++ b/chrome/browser/net/system_network_context_manager.cc
+@@ -699,7 +699,6 @@ void SystemNetworkContextManager::AddSSLConfigToNetworkContextParams(
+ 
+ void SystemNetworkContextManager::ConfigureDefaultNetworkContextParams(
+     network::mojom::NetworkContextParams* network_context_params) {
+-  variations::UpdateCorsExemptHeaderForVariations(network_context_params);
+   GoogleURLLoaderThrottle::UpdateCorsExemptHeader(network_context_params);
+ 
+   network_context_params->enable_brotli = true;
 diff --git a/components/ukm/ukm_recorder_impl.cc b/components/ukm/ukm_recorder_impl.cc
 --- a/components/ukm/ukm_recorder_impl.cc
 +++ b/components/ukm/ukm_recorder_impl.cc
@@ -143,6 +160,18 @@ diff --git a/components/variations/android/java/src/org/chromium/components/vari
              String milestone, String channel, @Nullable SeedInfo curSeedInfo) {
          SeedFetchInfo fetchInfo = new SeedFetchInfo();
          HttpURLConnection connection = null;
+diff --git a/components/variations/net/BUILD.gn b/components/variations/net/BUILD.gn
+--- a/components/variations/net/BUILD.gn
++++ b/components/variations/net/BUILD.gn
+@@ -33,8 +33,6 @@ static_library("net") {
+   # third_party/blink/public/common does not build on iOS
+   if (!is_ios) {
+     sources += [
+-      "variations_url_loader_throttle.cc",
+-      "variations_url_loader_throttle.h",
+     ]
+     deps += [
+       "//components/variations:variations_mojom",
 diff --git a/components/variations/net/omnibox_http_headers.cc b/components/variations/net/omnibox_http_headers.cc
 --- a/components/variations/net/omnibox_http_headers.cc
 +++ b/components/variations/net/omnibox_http_headers.cc
@@ -215,6 +244,63 @@ diff --git a/components/variations/service/variations_service.cc b/components/va
      return false;
  
    last_request_was_http_retry_ = is_http_retry;
+diff --git a/content/browser/loader/url_loader_throttles.cc b/content/browser/loader/url_loader_throttles.cc
+--- a/content/browser/loader/url_loader_throttles.cc
++++ b/content/browser/loader/url_loader_throttles.cc
+@@ -45,8 +45,6 @@ CreateContentBrowserURLLoaderThrottles(
+   // TODO(crbug.com/1094303): Consider whether we want to use the WebContents to
+   // determine the value for variations::Owner. Alternatively, this is the
+   // browser side, and we might be fine with Owner::kUnknown.
+-  variations::VariationsURLLoaderThrottle::AppendThrottleIfNeeded(
+-      browser_context->GetVariationsClient(), &throttles);
+ 
+   ClientHintsControllerDelegate* client_hint_delegate =
+       browser_context->GetClientHintsControllerDelegate();
+diff --git a/content/browser/origin_trials/origin_trials_utils.cc b/content/browser/origin_trials/origin_trials_utils.cc
+--- a/content/browser/origin_trials/origin_trials_utils.cc
++++ b/content/browser/origin_trials/origin_trials_utils.cc
+@@ -14,7 +14,7 @@ namespace {
+ std::vector<std::string> GetHeaderValues(
+     base::StringPiece header_name,
+     const net::HttpResponseHeaders* headers) {
+-  if (!headers) {
++  if ((true)) {
+     return {};
+   }
+   size_t iter = 0;
+diff --git a/content/public/common/content_features.cc b/content/public/common/content_features.cc
+--- a/content/public/common/content_features.cc
++++ b/content/public/common/content_features.cc
+@@ -768,8 +768,8 @@ BASE_FEATURE(kPepperCrossOriginRedirectRestriction,
+ // things before receiving the response, for instance it can affect the next
+ // navigation's network request.
+ BASE_FEATURE(kPersistentOriginTrials,
+-             "PersistentOriginTrials",
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             "PersistentOriginTrials",            // always disabled
++             base::FEATURE_DISABLED_BY_DEFAULT);  // in bromite
+ 
+ // A browser-side equivalent of the Blink feature "DocumentPictureInPictureAPI".
+ // This is used for sanity checks to ensure that the feature can't be enabled by
+diff --git a/content/renderer/variations_render_thread_observer.cc b/content/renderer/variations_render_thread_observer.cc
+--- a/content/renderer/variations_render_thread_observer.cc
++++ b/content/renderer/variations_render_thread_observer.cc
+@@ -56,15 +56,6 @@ void VariationsRenderThreadObserver::AppendThrottleIfNeeded(
+     const url::Origin& top_frame_origin,
+     std::vector<std::unique_ptr<blink::URLLoaderThrottle>>* throttles) {
+   variations::OmniboxURLLoaderThrottle::AppendThrottleIfNeeded(throttles);
+-
+-  variations::mojom::VariationsHeadersPtr variations_headers =
+-      GetVariationsData()->GetVariationsHeaders();
+-
+-  if (!variations_headers.is_null()) {
+-    throttles->push_back(
+-        std::make_unique<variations::VariationsURLLoaderThrottle>(
+-            std::move(variations_headers), top_frame_origin));
+-  }
+ }
+ 
+ void VariationsRenderThreadObserver::RegisterMojoInterfaces(
 diff --git a/third_party/blink/renderer/core/loader/document_loader.cc b/third_party/blink/renderer/core/loader/document_loader.cc
 --- a/third_party/blink/renderer/core/loader/document_loader.cc
 +++ b/third_party/blink/renderer/core/loader/document_loader.cc


### PR DESCRIPTION
## Description

As per object, I have found a new flag for the field trials and eliminated the handling.

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
