### PR TITLE
Fixes the order of the tabs in the tablist

### DIFF
--- a/build/patches/Move-navigation-bar-to-bottom.patch
+++ b/build/patches/Move-navigation-bar-to-bottom.patch
@@ -12,81 +12,80 @@ Support for tablet mode is also included.
 Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
- cc/base/features.cc                           |  4 ++
+ cc/base/features.cc                           |  4 +
  cc/base/features.h                            |  1 +
- cc/input/browser_controls_offset_manager.cc   |  6 +++
- cc/trees/layer_tree_host_impl.cc              |  3 ++
+ cc/input/browser_controls_offset_manager.cc   |  6 ++
+ cc/trees/layer_tree_host_impl.cc              |  3 +
  .../start_surface/StartSurfaceMediator.java   |  5 ++
- .../tab_management/TabGroupUiCoordinator.java |  7 ++-
- .../tab_management/TabGroupUiMediator.java    | 50 +++++++++++++++++-
- .../tab_management/TabGroupUiProperties.java  |  6 ++-
- .../tab_management/TabGroupUiToolbarView.java | 18 +++++++
- .../tab_management/TabGroupUiViewBinder.java  |  3 ++
- .../TabListContainerViewBinder.java           |  4 ++
- .../tab_management/TabListCoordinator.java    |  6 +++
- .../tab_management/TabListRecyclerView.java   | 19 ++++++-
- .../tab_management/TabSwitcherMediator.java   | 16 ++++++
- .../ChromeAccessibilitySettingsDelegate.java  | 52 +++++++++++++++++++
- .../chrome/browser/app/ChromeActivity.java    | 13 +++++
+ .../tab_management/TabGroupUiCoordinator.java |  7 +-
+ .../tab_management/TabGroupUiMediator.java    | 50 +++++++++++-
+ .../tab_management/TabGroupUiProperties.java  |  6 +-
+ .../tab_management/TabGroupUiToolbarView.java | 18 +++++
+ .../tab_management/TabGroupUiViewBinder.java  |  3 +
+ .../tab_management/TabListCoordinator.java    | 77 +++++++++++++++++++
+ .../tab_management/TabListRecyclerView.java   | 19 ++++-
+ .../tab_management/TabSwitcherMediator.java   | 19 +++++
+ .../ChromeAccessibilitySettingsDelegate.java  | 52 +++++++++++++
+ .../chrome/browser/app/ChromeActivity.java    | 13 ++++
  .../browser/app/flags/ChromeCachedFlags.java  |  1 +
- .../compositor/CompositorViewHolder.java      |  6 +++
- .../layouts/LayoutManagerChrome.java          | 18 +++++--
+ .../compositor/CompositorViewHolder.java      |  6 ++
+ .../layouts/LayoutManagerChrome.java          | 18 ++++-
  .../layouts/LayoutManagerChromeTablet.java    |  4 +-
- .../layouts/ToolbarSwipeLayout.java           | 15 +++++-
+ .../layouts/ToolbarSwipeLayout.java           | 15 +++-
  .../overlays/strip/StripLayoutHelper.java     |  2 +-
- .../strip/StripLayoutHelperManager.java       | 36 +++++++++++--
- .../scene_layer/StaticTabSceneLayer.java      |  8 ++-
- .../scene_layer/TabListSceneLayer.java        | 14 +++++
- .../scene_layer/TabStripSceneLayer.java       | 15 +++++-
- .../browser/findinpage/FindToolbarTablet.java | 11 ++--
- .../fullscreen/BrowserControlsManager.java    | 13 +++++
- .../messages/MessageContainerCoordinator.java | 17 +++++-
+ .../strip/StripLayoutHelperManager.java       | 36 +++++++--
+ .../scene_layer/StaticTabSceneLayer.java      |  8 +-
+ .../scene_layer/TabListSceneLayer.java        | 14 ++++
+ .../scene_layer/TabStripSceneLayer.java       | 15 +++-
+ .../browser/findinpage/FindToolbarTablet.java | 11 ++-
+ .../fullscreen/BrowserControlsManager.java    | 13 ++++
+ .../messages/MessageContainerCoordinator.java | 17 +++-
  .../modaldialog/ChromeTabModalPresenter.java  |  2 +-
- .../chrome/browser/ntp/NewTabPage.java        | 13 +++--
- .../chrome/browser/ntp/RecentTabsPage.java    | 22 ++++++--
- .../browser/searchwidget/SearchActivity.java  | 13 ++++-
+ .../chrome/browser/ntp/NewTabPage.java        | 13 +++-
+ .../chrome/browser/ntp/RecentTabsPage.java    | 22 +++++-
+ .../browser/searchwidget/SearchActivity.java  | 13 +++-
  .../browser/settings/SettingsActivity.java    |  5 ++
- .../StatusIndicatorCoordinator.java           | 10 ++++
- .../StatusIndicatorSceneLayer.java            |  7 ++-
- .../browser/toolbar/ToolbarManager.java       | 37 +++++++++++--
- .../chrome/browser/ui/BottomContainer.java    | 19 +++++++
- .../ui/system/StatusBarColorController.java   |  9 ++++
+ .../StatusIndicatorCoordinator.java           | 10 +++
+ .../StatusIndicatorSceneLayer.java            |  7 +-
+ .../browser/toolbar/ToolbarManager.java       | 37 +++++++--
+ .../chrome/browser/ui/BottomContainer.java    | 19 +++++
+ .../ui/system/StatusBarColorController.java   |  9 +++
  chrome/browser/about_flags.cc                 |  5 ++
- .../scene_layer/tab_strip_scene_layer.cc      | 16 ++++--
- .../BrowserControlsMarginSupplier.java        |  6 +++
- .../BrowserControlsStateProvider.java         |  6 +++
- chrome/browser/flag_descriptions.cc           |  4 ++
- chrome/browser/flag_descriptions.h            |  3 ++
- .../flags/android/cached_feature_flags.cc     | 18 +++++++
+ .../scene_layer/tab_strip_scene_layer.cc      | 16 +++-
+ .../BrowserControlsMarginSupplier.java        |  6 ++
+ .../BrowserControlsStateProvider.java         |  6 ++
+ chrome/browser/flag_descriptions.cc           |  4 +
+ chrome/browser/flag_descriptions.h            |  3 +
+ .../flags/android/cached_feature_flags.cc     | 18 +++++
  .../flags/android/chrome_feature_list.cc      |  2 +
- .../browser/flags/CachedFeatureFlags.java     | 19 +++++++
- .../browser/flags/ChromeFeatureList.java      |  4 ++
- .../chrome/browser/ui/appmenu/AppMenu.java    | 30 +++++++++++
- .../ui/appmenu/AppMenuHandlerImpl.java        | 11 ++++
- .../omnibox/LocationBarCoordinator.java       |  9 +++-
- .../browser/omnibox/UrlBarCoordinator.java    | 11 +++-
- .../suggestions/AutocompleteCoordinator.java  | 18 ++++++-
- .../suggestions/AutocompleteMediator.java     |  7 ++-
- .../OmniboxSuggestionsDropdown.java           | 22 +++++++-
- .../OmniboxSuggestionsDropdownEmbedder.java   |  4 ++
- .../strings/android_chrome_strings.grd        |  6 +++
+ .../browser/flags/CachedFeatureFlags.java     | 19 +++++
+ .../browser/flags/ChromeFeatureList.java      |  4 +
+ .../chrome/browser/ui/appmenu/AppMenu.java    | 30 ++++++++
+ .../ui/appmenu/AppMenuHandlerImpl.java        | 11 +++
+ .../omnibox/LocationBarCoordinator.java       |  9 ++-
+ .../browser/omnibox/UrlBarCoordinator.java    | 11 ++-
+ .../suggestions/AutocompleteCoordinator.java  | 18 ++++-
+ .../suggestions/AutocompleteMediator.java     |  7 +-
+ .../OmniboxSuggestionsDropdown.java           | 22 +++++-
+ .../OmniboxSuggestionsDropdownEmbedder.java   |  4 +
+ .../strings/android_chrome_strings.grd        |  6 ++
  chrome/browser/ui/android/toolbar/BUILD.gn    |  1 +
- .../toolbar/LocationBarFocusScrimHandler.java |  7 +++
- .../bottom/BottomControlsContentDelegate.java |  9 +++-
- .../bottom/BottomControlsCoordinator.java     | 11 +++-
- .../bottom/BottomControlsMediator.java        |  9 ++++
+ .../toolbar/LocationBarFocusScrimHandler.java |  7 ++
+ .../bottom/BottomControlsContentDelegate.java |  9 ++-
+ .../bottom/BottomControlsCoordinator.java     | 11 ++-
+ .../bottom/BottomControlsMediator.java        |  9 +++
  .../bottom/BottomControlsProperties.java      |  5 +-
  .../bottom/BottomControlsViewBinder.java      |  2 +
- .../bottom/ScrollingBottomViewSceneLayer.java | 20 ++++++-
- .../toolbar/top/ToolbarControlContainer.java  | 11 ++++
- .../top/TopToolbarOverlayCoordinator.java     |  7 +++
- .../top/TopToolbarOverlayProperties.java      |  8 ++-
- .../toolbar/top/TopToolbarSceneLayer.java     | 11 +++-
- .../res/xml/accessibility_preferences.xml     |  4 ++
- .../accessibility/AccessibilitySettings.java  | 16 ++++++
- .../AccessibilitySettingsDelegate.java        |  6 +++
- .../render_widget_host_view_android.cc        |  3 ++
- 74 files changed, 784 insertions(+), 57 deletions(-)
+ .../bottom/ScrollingBottomViewSceneLayer.java | 20 ++++-
+ .../toolbar/top/ToolbarControlContainer.java  | 11 +++
+ .../top/TopToolbarOverlayCoordinator.java     |  7 ++
+ .../top/TopToolbarOverlayProperties.java      |  8 +-
+ .../toolbar/top/TopToolbarSceneLayer.java     | 11 ++-
+ .../res/xml/accessibility_preferences.xml     |  4 +
+ .../accessibility/AccessibilitySettings.java  | 16 ++++
+ .../AccessibilitySettingsDelegate.java        |  6 ++
+ .../render_widget_host_view_android.cc        |  3 +
+ 73 files changed, 854 insertions(+), 57 deletions(-)
 
 diff --git a/cc/base/features.cc b/cc/base/features.cc
 --- a/cc/base/features.cc
@@ -390,31 +389,18 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
          }
      }
  }
-diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListContainerViewBinder.java b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListContainerViewBinder.java
---- a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListContainerViewBinder.java
-+++ b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListContainerViewBinder.java
-@@ -21,6 +21,8 @@ import androidx.recyclerview.widget.LinearLayoutManager;
- import org.chromium.components.browser_ui.styles.ChromeColors;
- import org.chromium.ui.modelutil.PropertyKey;
- import org.chromium.ui.modelutil.PropertyModel;
-+import org.chromium.chrome.browser.flags.CachedFeatureFlags;
-+import org.chromium.chrome.browser.flags.ChromeFeatureList;
- 
- /**
-  * ViewBinder for TabListRecyclerView.
-@@ -57,6 +59,8 @@ class TabListContainerViewBinder {
-             params.topMargin = newTopMargin;
-             view.requestLayout();
-         } else if (BOTTOM_CONTROLS_HEIGHT == propertyKey) {
-+            if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM))
-+                return;
-             FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) view.getLayoutParams();
-             params.bottomMargin = model.get(BOTTOM_CONTROLS_HEIGHT);
-             view.requestLayout();
 diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListCoordinator.java b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListCoordinator.java
 --- a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListCoordinator.java
 +++ b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListCoordinator.java
-@@ -47,6 +47,9 @@ import org.chromium.ui.modelutil.SimpleRecyclerViewAdapter;
+@@ -7,6 +7,7 @@ package org.chromium.chrome.browser.tasks.tab_management;
+ import static org.chromium.chrome.browser.tasks.tab_management.TabListModel.CardProperties.CARD_TYPE;
+ 
+ import android.content.Context;
++import android.content.res.Configuration;
+ import android.content.res.Resources;
+ import android.graphics.Bitmap;
+ import android.graphics.BitmapFactory;
+@@ -47,6 +48,9 @@ import org.chromium.ui.modelutil.SimpleRecyclerViewAdapter;
  import org.chromium.ui.resources.dynamics.DynamicResourceLoader;
  import org.chromium.ui.widget.ViewLookupCachingFrameLayout;
  
@@ -424,16 +410,100 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
  import java.lang.annotation.Retention;
  import java.lang.annotation.RetentionPolicy;
  import java.util.List;
-@@ -255,6 +258,9 @@ public class TabListCoordinator
+@@ -95,6 +99,70 @@ public class TabListCoordinator
+     private boolean mLayoutListenerRegistered;
+     private @Nullable TabStripSnapshotter mTabStripSnapshotter;
+ 
++    public class GridLayoutManagerDockBottom extends GridLayoutManager {
++        Context mContext;
++
++        TabListRecyclerView mRecyclerView;
++
++        int mTopPadding = 99999;
++        int mLastPosition = -1;
++        boolean mIsFirstLayout = true;
++
++        public GridLayoutManagerDockBottom(Context context, int spanCount) {
++            super(context, spanCount);
++            mContext = context;
++        }
++
++        public void setTabListRecyclerView(TabListRecyclerView recyclerView) {
++            mRecyclerView = recyclerView;
++        }
++
++        public void ResetTopPosition() {
++            mIsFirstLayout = true;
++        }
++
++        @Override
++        public int getPaddingTop() {
++            if (mContext.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
++                mTopPadding = 99999;
++                return 0;
++            }
++            if (mTopPadding == 99999) return super.getPaddingTop();
++            return mTopPadding;
++        }
++
++        @Override
++        public int getPaddingBottom() {
++            return 1;
++        }
++
++        @Override
++        public void scrollToPositionWithOffset(int position, int offset) {
++            mLastPosition = position;
++            super.scrollToPositionWithOffset(position, getPaddingBottom());
++        }
++
++        @Override
++        public void onLayoutCompleted(RecyclerView.State state) {
++            super.onLayoutCompleted(state);
++
++            if (state.isPreLayout()) return;
++            View lastView = findViewByPosition(findFirstVisibleItemPosition());
++            if (lastView != null) {
++                mTopPadding = Math.min(mTopPadding, mRecyclerView.getHeight() - lastView.getHeight());
++                if (mIsFirstLayout) {
++                    mIsFirstLayout = false;
++                    scrollToPositionWithOffset(mLastPosition, 0);
++                }
++            }
++
++            if (mLastPosition != -1 && mLastPosition >= state.getItemCount()) {
++                ResetTopPosition();
++                scrollToPositionWithOffset(state.getItemCount()-getSpanCount(), 0);
++            }
++        }
++    }
++
+     /**
+      * Construct a coordinator for UI that shows a list of tabs.
+      * @param mode Modes of showing the list of tabs. Can be used in GRID or STRIP.
+@@ -255,6 +323,12 @@ public class TabListCoordinator
              if (mMode == TabListMode.GRID) {
                  GridLayoutManager gridLayoutManager =
                          new GridLayoutManager(context, GRID_LAYOUT_SPAN_COUNT_COMPACT);
-+                // invert the order if the toolbar is at bottom
-+                if (titleProvider != null && CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM))
-+                    gridLayoutManager.setReverseLayout(true);
++                if (titleProvider != null && CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++                    gridLayoutManager =
++                        new GridLayoutManagerDockBottom(context, GRID_LAYOUT_SPAN_COUNT_COMPACT);
++                    ((GridLayoutManagerDockBottom)gridLayoutManager)
++                        .setTabListRecyclerView(mRecyclerView);
++                }
                  mRecyclerView.setLayoutManager(gridLayoutManager);
                  mMediator.registerOrientationListener(gridLayoutManager);
                  mMediator.updateSpanCount(gridLayoutManager,
+@@ -434,6 +508,9 @@ public class TabListCoordinator
+         }
+         registerLayoutChangeListener();
+         mRecyclerView.prepareTabSwitcherView();
++        GridLayoutManager glm = (GridLayoutManager) mRecyclerView.getLayoutManager();
++        if (glm instanceof GridLayoutManagerDockBottom)
++            ((GridLayoutManagerDockBottom)glm).ResetTopPosition();
+         mMediator.prepareTabSwitcherView();
+         mMediator.registerOnScrolledListener(mRecyclerView);
+     }
 diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java
 --- a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java
 +++ b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java
@@ -550,6 +620,16 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
          mContainerViewModel.set(SHADOW_TOP_OFFSET, contentOffset);
      }
  
+@@ -744,6 +760,9 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
+     private void setInitialScrollIndexOffset() {
+         int offset = mMode == TabListMode.CAROUSEL ? INITIAL_SCROLL_INDEX_OFFSET_CAROUSEL
+                                                    : INITIAL_SCROLL_INDEX_OFFSET_GTS;
++        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            offset = 0;
++        }
+         int initialPosition = Math.max(
+                 mTabModelSelector.getTabModelFilterProvider().getCurrentTabModelFilter().index()
+                         - offset,
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/accessibility/settings/ChromeAccessibilitySettingsDelegate.java b/chrome/android/java/src/org/chromium/chrome/browser/accessibility/settings/ChromeAccessibilitySettingsDelegate.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/accessibility/settings/ChromeAccessibilitySettingsDelegate.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/accessibility/settings/ChromeAccessibilitySettingsDelegate.java


### PR DESCRIPTION
## Description

I finally solved it by leaving the default order but aligning the tabs to the bottom, as shown in the picture
![image](https://user-images.githubusercontent.com/29201891/209951336-eb36283d-4b36-4dec-ae02-39a8d2fa37e1.png)

Fix for #2456

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
