### PR TITLE
Increase maximum adblock filter file size to 20MB

### DIFF
--- a/build/patches/Bromite-subresource-adblocker.patch
+++ b/build/patches/Bromite-subresource-adblocker.patch
@@ -1157,8 +1157,8 @@ new file mode 100644
 +
 +namespace adblock_updater {
 +
-+// maximum 10MB for the filters file
-+const int kMaxBodySize = 1024 * 1024 * 10;
++// maximum 20MB for the filters file
++const int kMaxBodySize = 1024 * 1024 * 20;
 +
 +const int kMaxRetriesOnNetworkChange = 3;
 +


### PR DESCRIPTION
## Description

I've made my own generated filter file, which doesn't fit into 10 MB. The author of [filtrite](https://github.com/xarantolus/filtrite#using-your-own-filter-lists) also mentions this limitation. Hopefully, 20 MB is more than enough for everyone (tm).

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [x] Bromite can be built with these changes
* [x] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [x] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes