### PR TITLE
Remove redundant patch hunk

### DIFF
--- a/build/patches/Override-Navigator-Language.patch
+++ b/build/patches/Override-Navigator-Language.patch
@@ -9,9 +9,8 @@ Original License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.
 License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
 ---
  .../browser/language/AppLocaleUtils.java      | 20 +++++++++++++++++++
- .../AppLanguagePreferenceDelegate.java        |  8 ++++++++
  .../renderer_host/render_process_host_impl.cc |  6 +++++-
- 3 files changed, 33 insertions(+), 1 deletion(-)
+ 2 files changed, 25 insertions(+), 1 deletion(-)
 
 diff --git a/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/AppLocaleUtils.java b/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/AppLocaleUtils.java
 --- a/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/AppLocaleUtils.java
@@ -50,24 +49,6 @@ diff --git a/chrome/browser/language/android/java/src/org/chromium/chrome/browse
      /**
       * Gets the first original system locale from {@link LocaleManager}. This is the language that
       * Chrome would use if there was no override set. If there are no possible UI languages en-US is
-diff --git a/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/settings/AppLanguagePreferenceDelegate.java b/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/settings/AppLanguagePreferenceDelegate.java
---- a/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/settings/AppLanguagePreferenceDelegate.java
-+++ b/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/settings/AppLanguagePreferenceDelegate.java
-@@ -87,6 +87,14 @@ public class AppLanguagePreferenceDelegate {
- 
-         // Disable preference so a second downloaded cannot be started while one is in progress.
-         mPreference.setEnabled(false);
-+
-+        AppLocaleUtils.setAppLanguagePref(code, (success) -> {
-+            if (success) {
-+                languageSplitDownloadComplete();
-+            } else {
-+                languageSplitDownloadFailed();
-+            }
-+        });
-     }
- 
-     /**
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -92,5 +73,6 @@ diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content
    command_line->AppendSwitchASCII(switches::kLang, locale);
  
    // A non-empty RendererCmdPrefix implies that Zygote is disabled.
---
-2.25.1
+-- 
+2.39.0
+

--- a/build/patches/Remove-binary-blob-integrations.patch
+++ b/build/patches/Remove-binary-blob-integrations.patch
@@ -44,7 +44,6 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  chrome/browser/BUILD.gn                       |   2 -
  chrome/browser/language/android/BUILD.gn      |   2 -
  .../language/AppLanguagePromoDialog.java      |  23 -
- .../AppLanguagePreferenceDelegate.java        |   8 -
  .../language/settings/LanguageSettings.java   |   6 -
  .../prefetch/prefetch_service_factory.cc      |  16 -
  .../browser/password_manager/android/BUILD.gn |   4 -
@@ -110,7 +109,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  third_party/android_deps/BUILD.gn             | 539 +-----------------
  .../preconditions/javatests/BUILD.gn          |   1 -
  .../gms/ChromiumPlayServicesAvailability.java |  10 +-
- 86 files changed, 99 insertions(+), 2060 deletions(-)
+ 85 files changed, 99 insertions(+), 2052 deletions(-)
 
 diff --git a/android_webview/expectations/system_webview_bundle.AndroidManifest.expected b/android_webview/expectations/system_webview_bundle.AndroidManifest.expected
 --- a/android_webview/expectations/system_webview_bundle.AndroidManifest.expected
@@ -1006,24 +1005,6 @@ diff --git a/chrome/browser/language/android/java/src/org/chromium/chrome/browse
 -                messageView.setText(failedText);
 -                mLoadingModal.set(ModalDialogProperties.POSITIVE_BUTTON_TEXT,
 -                        mActivity.getText(R.string.ok).toString());
--            }
--        });
-     }
- 
-     /**
-diff --git a/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/settings/AppLanguagePreferenceDelegate.java b/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/settings/AppLanguagePreferenceDelegate.java
---- a/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/settings/AppLanguagePreferenceDelegate.java
-+++ b/chrome/browser/language/android/java/src/org/chromium/chrome/browser/language/settings/AppLanguagePreferenceDelegate.java
-@@ -87,14 +87,6 @@ public class AppLanguagePreferenceDelegate {
- 
-         // Disable preference so a second downloaded cannot be started while one is in progress.
-         mPreference.setEnabled(false);
--
--        AppLocaleUtils.setAppLanguagePref(code, (success) -> {
--            if (success) {
--                languageSplitDownloadComplete();
--            } else {
--                languageSplitDownloadFailed();
 -            }
 -        });
      }
@@ -4317,5 +4298,6 @@ diff --git a/third_party/android_deps/util/org/chromium/gms/ChromiumPlayServices
 +        return 16; // API_UNAVAILABLE
      }
  }
---
-2.25.1
+-- 
+2.39.0
+


### PR DESCRIPTION
* One patch removes it, the other adds it

## Description

*Please explain here what feature or bugfix these changes are addressing and why they should be included*

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [ ] Bromite can be built with these changes
* [ ] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [x] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
