### PR TITLE
Bottom Toolbar: fix rearrange tab order issue, fix omnibox-modernize-visual-update

### DIFF
--- a/build/patches/Move-navigation-bar-to-bottom.patch
+++ b/build/patches/Move-navigation-bar-to-bottom.patch
@@ -22,11 +22,11 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../tab_management/TabGroupUiProperties.java  |  6 +-
  .../tab_management/TabGroupUiToolbarView.java | 18 +++++
  .../tab_management/TabGroupUiViewBinder.java  |  3 +
- .../tab_management/TabListCoordinator.java    | 77 +++++++++++++++++++
+ .../tab_management/TabListCoordinator.java    | 81 +++++++++++++++++++
  .../tab_management/TabListRecyclerView.java   | 19 ++++-
  .../tab_management/TabSwitcherMediator.java   | 19 +++++
- .../ChromeAccessibilitySettingsDelegate.java  | 52 +++++++++++++
- .../chrome/browser/app/ChromeActivity.java    | 13 ++++
+ .../ChromeAccessibilitySettingsDelegate.java  | 52 ++++++++++++
+ .../chrome/browser/app/ChromeActivity.java    | 13 +++
  .../browser/app/flags/ChromeCachedFlags.java  |  1 +
  .../compositor/CompositorViewHolder.java      |  6 ++
  .../layouts/LayoutManagerChrome.java          | 18 ++++-
@@ -38,12 +38,12 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../scene_layer/TabListSceneLayer.java        | 14 ++++
  .../scene_layer/TabStripSceneLayer.java       | 15 +++-
  .../browser/findinpage/FindToolbarTablet.java | 11 ++-
- .../fullscreen/BrowserControlsManager.java    | 13 ++++
+ .../fullscreen/BrowserControlsManager.java    | 13 +++
  .../messages/MessageContainerCoordinator.java | 17 +++-
  .../modaldialog/ChromeTabModalPresenter.java  |  2 +-
- .../chrome/browser/ntp/NewTabPage.java        | 13 +++-
- .../chrome/browser/ntp/RecentTabsPage.java    | 22 +++++-
- .../browser/searchwidget/SearchActivity.java  | 13 +++-
+ .../chrome/browser/ntp/NewTabPage.java        | 13 ++-
+ .../chrome/browser/ntp/RecentTabsPage.java    | 22 ++++-
+ .../browser/searchwidget/SearchActivity.java  | 13 ++-
  .../browser/settings/SettingsActivity.java    |  5 ++
  .../StatusIndicatorCoordinator.java           | 10 +++
  .../StatusIndicatorSceneLayer.java            |  7 +-
@@ -58,15 +58,16 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  chrome/browser/flag_descriptions.h            |  3 +
  .../flags/android/cached_feature_flags.cc     | 18 +++++
  .../flags/android/chrome_feature_list.cc      |  2 +
- .../browser/flags/CachedFeatureFlags.java     | 19 +++++
+ .../browser/flags/CachedFeatureFlags.java     | 18 +++++
  .../browser/flags/ChromeFeatureList.java      |  4 +
- .../chrome/browser/ui/appmenu/AppMenu.java    | 30 ++++++++
+ .../chrome/browser/ui/appmenu/AppMenu.java    | 30 +++++++
  .../ui/appmenu/AppMenuHandlerImpl.java        | 11 +++
  .../omnibox/LocationBarCoordinator.java       |  9 ++-
  .../browser/omnibox/UrlBarCoordinator.java    | 11 ++-
  .../suggestions/AutocompleteCoordinator.java  | 18 ++++-
  .../suggestions/AutocompleteMediator.java     |  7 +-
- .../OmniboxSuggestionsDropdown.java           | 22 +++++-
+ .../DropdownItemViewInfoListManager.java      | 15 +++-
+ .../OmniboxSuggestionsDropdown.java           | 22 ++++-
  .../OmniboxSuggestionsDropdownEmbedder.java   |  4 +
  .../strings/android_chrome_strings.grd        |  6 ++
  chrome/browser/ui/android/toolbar/BUILD.gn    |  1 +
@@ -85,7 +86,7 @@ License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
  .../accessibility/AccessibilitySettings.java  | 16 ++++
  .../AccessibilitySettingsDelegate.java        |  6 ++
  .../render_widget_host_view_android.cc        |  3 +
- 73 files changed, 854 insertions(+), 57 deletions(-)
+ 74 files changed, 868 insertions(+), 61 deletions(-)
 
 diff --git a/cc/base/features.cc b/cc/base/features.cc
 --- a/cc/base/features.cc
@@ -138,7 +139,7 @@ diff --git a/cc/input/browser_controls_offset_manager.cc b/cc/input/browser_cont
 diff --git a/cc/trees/layer_tree_host_impl.cc b/cc/trees/layer_tree_host_impl.cc
 --- a/cc/trees/layer_tree_host_impl.cc
 +++ b/cc/trees/layer_tree_host_impl.cc
-@@ -4253,6 +4253,9 @@ bool LayerTreeHostImpl::AnimateBrowserControls(base::TimeTicks time) {
+@@ -4306,6 +4306,9 @@ bool LayerTreeHostImpl::AnimateBrowserControls(base::TimeTicks time) {
    if (scroll_delta.IsZero())
      return false;
  
@@ -151,7 +152,7 @@ diff --git a/cc/trees/layer_tree_host_impl.cc b/cc/trees/layer_tree_host_impl.cc
 diff --git a/chrome/android/features/start_surface/java/src/org/chromium/chrome/features/start_surface/StartSurfaceMediator.java b/chrome/android/features/start_surface/java/src/org/chromium/chrome/features/start_surface/StartSurfaceMediator.java
 --- a/chrome/android/features/start_surface/java/src/org/chromium/chrome/features/start_surface/StartSurfaceMediator.java
 +++ b/chrome/android/features/start_surface/java/src/org/chromium/chrome/features/start_surface/StartSurfaceMediator.java
-@@ -85,6 +85,9 @@ import org.chromium.content_public.browser.LoadUrlParams;
+@@ -86,6 +86,9 @@ import org.chromium.content_public.browser.LoadUrlParams;
  import org.chromium.ui.modelutil.PropertyModel;
  import org.chromium.ui.util.ColorUtils;
  
@@ -161,11 +162,11 @@ diff --git a/chrome/android/features/start_surface/java/src/org/chromium/chrome/
  /** The mediator implements the logic to interact with the surfaces and caller. */
  class StartSurfaceMediator implements TabSwitcher.TabSwitcherViewObserver, View.OnClickListener,
                                        StartSurface.OnTabSelectingListener, BackPressHandler,
-@@ -1095,6 +1098,8 @@ class StartSurfaceMediator implements TabSwitcher.TabSwitcherViewObserver, View.
+@@ -1109,6 +1112,8 @@ class StartSurfaceMediator implements TabSwitcher.TabSwitcherViewObserver, View.
      }
  
      private void setTopMargin(int topMargin) {
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM))
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled())
 +            topMargin = 0;
          mPropertyModel.set(TOP_MARGIN, topMargin);
      }
@@ -270,10 +271,10 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
                      }
                  }
 +                updateThemeColor(tab);
-                 if (type == TabSelectionType.FROM_CLOSE) return;
                  if (TabUiFeatureUtilities.isTabGroupsAndroidEnabled(mContext)
                          && getTabsToShowForId(lastId).contains(tab)) {
-@@ -259,6 +291,7 @@ public class TabGroupUiMediator implements SnackbarManager.SnackbarController, B
+                     return;
+@@ -258,6 +290,7 @@ public class TabGroupUiMediator implements SnackbarManager.SnackbarController, B
                  resetTabStripWithRelatedTabsForId(currentTab.getId());
                  RecordUserAction.record("TabStrip.SessionVisibility."
                          + (mIsTabGroupUiVisible ? "Visible" : "Hidden"));
@@ -354,7 +355,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
      }
  
 +    void setPrimaryColorAndApplyTint(int color) {
-+        if (!CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM))
++        if (!ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled())
 +            return;
 +
 +        // change the background color of the bottom bar if the top toolbar is below
@@ -400,7 +401,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
  import android.content.res.Resources;
  import android.graphics.Bitmap;
  import android.graphics.BitmapFactory;
-@@ -47,6 +48,9 @@ import org.chromium.ui.modelutil.SimpleRecyclerViewAdapter;
+@@ -48,6 +49,9 @@ import org.chromium.ui.modelutil.SimpleRecyclerViewAdapter;
  import org.chromium.ui.resources.dynamics.DynamicResourceLoader;
  import org.chromium.ui.widget.ViewLookupCachingFrameLayout;
  
@@ -410,7 +411,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
  import java.lang.annotation.Retention;
  import java.lang.annotation.RetentionPolicy;
  import java.util.List;
-@@ -95,6 +99,70 @@ public class TabListCoordinator
+@@ -96,6 +100,74 @@ public class TabListCoordinator
      private boolean mLayoutListenerRegistered;
      private @Nullable TabStripSnapshotter mTabStripSnapshotter;
  
@@ -419,7 +420,9 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
 +
 +        TabListRecyclerView mRecyclerView;
 +
-+        int mTopPadding = 99999;
++        final int MAX_TOP_PADDING = 99999;
++        int mTopPadding = MAX_TOP_PADDING;
++
 +        int mLastPosition = -1;
 +        boolean mIsFirstLayout = true;
 +
@@ -439,10 +442,10 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
 +        @Override
 +        public int getPaddingTop() {
 +            if (mContext.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
-+                mTopPadding = 99999;
++                mTopPadding = MAX_TOP_PADDING;
 +                return 0;
 +            }
-+            if (mTopPadding == 99999) return super.getPaddingTop();
++            if (mTopPadding == MAX_TOP_PADDING) return super.getPaddingTop();
 +            return mTopPadding;
 +        }
 +
@@ -454,26 +457,28 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
 +        @Override
 +        public void scrollToPositionWithOffset(int position, int offset) {
 +            mLastPosition = position;
-+            super.scrollToPositionWithOffset(position, getPaddingBottom());
++            super.scrollToPositionWithOffset(position, offset - getPaddingTop());
 +        }
 +
 +        @Override
 +        public void onLayoutCompleted(RecyclerView.State state) {
 +            super.onLayoutCompleted(state);
 +
-+            if (state.isPreLayout()) return;
++            if (state.isPreLayout() || state.isMeasuring()) return;
 +            View lastView = findViewByPosition(findFirstVisibleItemPosition());
 +            if (lastView != null) {
++                if (mTopPadding == 0) mTopPadding = MAX_TOP_PADDING;
 +                mTopPadding = Math.min(mTopPadding, mRecyclerView.getHeight() - lastView.getHeight());
 +                if (mIsFirstLayout) {
 +                    mIsFirstLayout = false;
-+                    scrollToPositionWithOffset(mLastPosition, 0);
++                    scrollToPositionWithOffset(mLastPosition, getPaddingTop() + getPaddingBottom());
 +                }
 +            }
 +
-+            if (mLastPosition != -1 && mLastPosition >= state.getItemCount()) {
++            if (mLastPosition >= state.getItemCount()) {
 +                ResetTopPosition();
-+                scrollToPositionWithOffset(state.getItemCount()-getSpanCount(), 0);
++                scrollToPositionWithOffset(state.getItemCount()-getSpanCount(),
++                    getPaddingTop() + getPaddingBottom());
 +            }
 +        }
 +    }
@@ -481,11 +486,11 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
      /**
       * Construct a coordinator for UI that shows a list of tabs.
       * @param mode Modes of showing the list of tabs. Can be used in GRID or STRIP.
-@@ -255,6 +323,12 @@ public class TabListCoordinator
+@@ -256,6 +328,12 @@ public class TabListCoordinator
              if (mMode == TabListMode.GRID) {
                  GridLayoutManager gridLayoutManager =
                          new GridLayoutManager(context, GRID_LAYOUT_SPAN_COUNT_COMPACT);
-+                if (titleProvider != null && CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++                if (titleProvider != null && ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                    gridLayoutManager =
 +                        new GridLayoutManagerDockBottom(context, GRID_LAYOUT_SPAN_COUNT_COMPACT);
 +                    ((GridLayoutManagerDockBottom)gridLayoutManager)
@@ -494,7 +499,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
                  mRecyclerView.setLayoutManager(gridLayoutManager);
                  mMediator.registerOrientationListener(gridLayoutManager);
                  mMediator.updateSpanCount(gridLayoutManager,
-@@ -434,6 +508,9 @@ public class TabListCoordinator
+@@ -450,6 +528,9 @@ public class TabListCoordinator
          }
          registerLayoutChangeListener();
          mRecyclerView.prepareTabSwitcherView();
@@ -507,7 +512,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
 diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java
 --- a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java
 +++ b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabListRecyclerView.java
-@@ -36,6 +36,7 @@ import androidx.recyclerview.widget.GridLayoutManager;
+@@ -37,6 +37,7 @@ import androidx.recyclerview.widget.GridLayoutManager;
  import androidx.recyclerview.widget.RecyclerView;
  
  import org.chromium.base.Log;
@@ -515,7 +520,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
  import org.chromium.chrome.browser.flags.ChromeFeatureList;
  import org.chromium.chrome.browser.tabmodel.TabModel;
  import org.chromium.chrome.tab_ui.R;
-@@ -63,6 +64,8 @@ class TabListRecyclerView
+@@ -65,6 +66,8 @@ class TabListRecyclerView
      public static final long BASE_ANIMATION_DURATION_MS = 218;
      public static final long FINAL_FADE_IN_DURATION_MS = 50;
  
@@ -524,7 +529,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
      /**
       * Field trial parameter for downsampling scaling factor.
       */
-@@ -192,6 +195,7 @@ class TabListRecyclerView
+@@ -194,6 +197,7 @@ class TabListRecyclerView
                  ? FINAL_FADE_IN_DURATION_MS
                  : BASE_ANIMATION_DURATION_MS;
  
@@ -532,11 +537,11 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
          setAlpha(0);
          setVisibility(View.VISIBLE);
          mFadeInAnimator = ObjectAnimator.ofFloat(this, View.ALPHA, 1);
-@@ -225,6 +229,11 @@ class TabListRecyclerView
+@@ -228,6 +232,11 @@ class TabListRecyclerView
      }
  
      void setShadowVisibility(boolean shouldShowShadow) {
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()
 +                && mIsVisible) {
 +            // always show shadow
 +            shouldShowShadow = true;
@@ -544,30 +549,30 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
          if (mShadowImageView == null) {
              Context context = getContext();
              mShadowImageView = new ImageView(context);
-@@ -237,7 +246,10 @@ class TabListRecyclerView
+@@ -240,7 +249,10 @@ class TabListRecyclerView
              if (getParent() instanceof FrameLayout) {
                  // Add shadow for grid tab switcher.
                  FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
 -                        LayoutParams.MATCH_PARENT, shadowHeight, Gravity.TOP);
 +                        LayoutParams.MATCH_PARENT, shadowHeight,
-+                        (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM) ?
++                        (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled() ?
 +                            Gravity.BOTTOM :
 +                            Gravity.TOP));
                  mShadowImageView.setLayoutParams(params);
                  mShadowImageView.setTranslationY(mShadowTopOffset);
                  FrameLayout parent = (FrameLayout) getParent();
-@@ -264,6 +276,10 @@ class TabListRecyclerView
+@@ -267,6 +279,10 @@ class TabListRecyclerView
  
      void setShadowTopOffset(int shadowTopOffset) {
          mShadowTopOffset = shadowTopOffset;
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // invert the offset since Gravity is set to BOTTOM
 +            mShadowTopOffset = -mShadowTopOffset;
 +        }
  
          if (mShadowImageView != null && getParent() instanceof FrameLayout) {
              // Since the shadow has no functionality, other than just existing visually, we can use
-@@ -443,6 +459,7 @@ class TabListRecyclerView
+@@ -446,6 +462,7 @@ class TabListRecyclerView
                  mListener.finishedHiding();
              }
          });
@@ -578,7 +583,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
 diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java
 --- a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java
 +++ b/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/TabSwitcherMediator.java
-@@ -43,6 +43,7 @@ import org.chromium.chrome.browser.compositor.layouts.content.TabContentManager;
+@@ -44,6 +44,7 @@ import org.chromium.chrome.browser.compositor.layouts.content.TabContentManager;
  import org.chromium.chrome.browser.flags.ChromeFeatureList;
  import org.chromium.chrome.browser.incognito.reauth.IncognitoReauthController;
  import org.chromium.chrome.browser.incognito.reauth.IncognitoReauthManager;
@@ -586,11 +591,11 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
  import org.chromium.chrome.browser.multiwindow.MultiWindowModeStateDispatcher;
  import org.chromium.chrome.browser.preferences.ChromePreferenceKeys;
  import org.chromium.chrome.browser.preferences.SharedPreferencesManager;
-@@ -457,11 +458,22 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
+@@ -460,11 +461,22 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
              updateTopControlsProperties();
              mContainerViewModel.set(
                      BOTTOM_CONTROLS_HEIGHT, browserControlsStateProvider.getBottomControlsHeight());
-+            if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                mContainerViewModel.set(
 +                    BOTTOM_CONTROLS_HEIGHT, mContainerViewModel.get(BOTTOM_CONTROLS_HEIGHT) +
 +                        mBrowserControlsStateProvider.getContentOffset());
@@ -600,7 +605,7 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
          if (mMode == TabListMode.GRID) {
              mContainerViewModel.set(BOTTOM_PADDING,
                      (int) context.getResources().getDimension(R.dimen.tab_grid_bottom_padding));
-+            if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                // adjust the bottom margin so as not to cover the top toolbar at the bottom
 +                mContainerViewModel.set(
 +                    BOTTOM_PADDING, mContainerViewModel.get(BOTTOM_PADDING) +
@@ -609,22 +614,22 @@ diff --git a/chrome/android/features/tab_ui/java/src/org/chromium/chrome/browser
          }
  
          mContainerView = containerView;
-@@ -588,6 +600,10 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
+@@ -592,6 +604,10 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
          final int contentOffset = mBrowserControlsStateProvider.getContentOffset();
  
          mContainerViewModel.set(TOP_MARGIN, contentOffset);
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // move the view up since the toolbar is at the bottom
 +            mContainerViewModel.set(TOP_MARGIN, 0);
 +        }
          mContainerViewModel.set(SHADOW_TOP_OFFSET, contentOffset);
      }
  
-@@ -744,6 +760,9 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
+@@ -748,6 +764,9 @@ class TabSwitcherMediator implements TabSwitcher.Controller, TabListRecyclerView
      private void setInitialScrollIndexOffset() {
          int offset = mMode == TabListMode.CAROUSEL ? INITIAL_SCROLL_INDEX_OFFSET_CAROUSEL
                                                     : INITIAL_SCROLL_INDEX_OFFSET_GTS;
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            offset = 0;
 +        }
          int initialPosition = Math.max(
@@ -668,7 +673,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/accessibility/s
 +    private static class MoveTopToolbarToBottomDelegate implements BooleanPreferenceDelegate {
 +        @Override
 +        public boolean isEnabled() {
-+            return CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM);
++            return ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled();
 +        }
 +
 +        @Override
@@ -719,14 +724,14 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActiv
  /**
   * A {@link AsyncInitializationActivity} that builds and manages a {@link CompositorViewHolder}
   * and associated classes.
-@@ -748,6 +751,16 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
+@@ -758,6 +761,16 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
                  int toolbarLayoutId = getToolbarLayoutId();
                  if (toolbarLayoutId != ActivityUtils.NO_RESOURCE_ID && controlContainer != null) {
                      controlContainer.initWithToolbar(toolbarLayoutId);
 +                    ImageView shadowImage = findViewById(R.id.toolbar_hairline);
 +                    if (shadowImage != null) {
 +                        // Invert the shadown if the top toolbar is at the bottom
-+                        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++                        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                            ViewGroup.MarginLayoutParams marginParams = (ViewGroup.MarginLayoutParams)shadowImage.getLayoutParams();
 +                            marginParams.setMargins(marginParams.leftMargin, 0,
 +                                marginParams.rightMargin, marginParams.bottomMargin);
@@ -739,18 +744,18 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActiv
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java b/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/app/flags/ChromeCachedFlags.java
-@@ -111,6 +111,7 @@ public class ChromeCachedFlags {
+@@ -110,6 +110,7 @@ public class ChromeCachedFlags {
                  add(ChromeFeatureList.sInstanceSwitcher);
                  add(ChromeFeatureList.sInstantStart);
                  add(ChromeFeatureList.sInterestFeedV2);
 +                add(ChromeFeatureList.sMoveTopToolbarToBottom);
                  add(ChromeFeatureList.sNewWindowAppMenu);
+                 add(ChromeFeatureList.sOmniboxMatchToolbarAndStatusBarColor);
                  add(ChromeFeatureList.sOmniboxModernizeVisualUpdate);
-                 add(ChromeFeatureList.sOmniboxRemoveExcessiveRecycledViewClearCalls);
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/CompositorViewHolder.java b/chrome/android/java/src/org/chromium/chrome/browser/compositor/CompositorViewHolder.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/compositor/CompositorViewHolder.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/compositor/CompositorViewHolder.java
-@@ -83,6 +83,8 @@ import org.chromium.ui.base.WindowAndroid;
+@@ -84,6 +84,8 @@ import org.chromium.ui.base.WindowAndroid;
  import org.chromium.ui.mojom.VirtualKeyboardMode;
  import org.chromium.ui.resources.ResourceManager;
  import org.chromium.ui.resources.dynamics.DynamicResourceLoader;
@@ -759,11 +764,11 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/Comp
  
  import java.util.ArrayList;
  import java.util.HashSet;
-@@ -316,6 +318,10 @@ public class CompositorViewHolder extends FrameLayout
+@@ -317,6 +319,10 @@ public class CompositorViewHolder extends FrameLayout
                          WebContents webContents = mTabVisible.getWebContents();
                          if (webContents == null) return;
                          EventForwarder forwarder = webContents.getEventForwarder();
-+                        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++                        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                            // no need to adjust the touch offsets, since the content view is never moved
 +                            top = 0;
 +                        }
@@ -788,7 +793,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/layo
      public SwipeHandler createToolbarSwipeHandler(boolean supportSwipeDown) {
 -        return new ToolbarSwipeHandler(supportSwipeDown);
 +        boolean move_top_toolbar =
-+            CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM);
++            ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled();
 +        return new ToolbarSwipeHandler(supportSwipeDown && !move_top_toolbar,
 +                                       supportSwipeDown && move_top_toolbar);
      }
@@ -874,7 +879,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/layo
              }
              mLeftTab.setX(leftX);
 -            mLeftTab.setY(mBrowserControlsStateProvider.getContentOffset() / dpToPx);
-+            if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                mLeftTab.setY(0);
 +            } else {
 +                mLeftTab.setY(mBrowserControlsStateProvider.getContentOffset() / dpToPx);
@@ -887,7 +892,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/layo
              }
              mRightTab.setX(rightX);
 -            mRightTab.setY(mBrowserControlsStateProvider.getContentOffset() / dpToPx);
-+            if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                mRightTab.setY(0);
 +            } else {
 +                mRightTab.setY(mBrowserControlsStateProvider.getContentOffset() / dpToPx);
@@ -898,7 +903,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/layo
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelper.java b/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelper.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelper.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelper.java
-@@ -376,7 +376,7 @@ public class StripLayoutHelper implements StripLayoutTab.StripLayoutTabDelegate
+@@ -377,7 +377,7 @@ public class StripLayoutHelper implements StripLayoutTab.StripLayoutTabDelegate
          // position 0 is on the left. Account for that in the offset calculation.
          boolean isRtl = LocalizationUtils.isLayoutRtl();
          boolean useUnadjustedScrollOffset = isRtl != isLeft;
@@ -910,7 +915,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/over
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelperManager.java b/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelperManager.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelperManager.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutHelperManager.java
-@@ -56,6 +56,9 @@ import org.chromium.ui.base.LocalizationUtils;
+@@ -59,6 +59,9 @@ import org.chromium.ui.base.LocalizationUtils;
  import org.chromium.ui.base.PageTransition;
  import org.chromium.ui.resources.ResourceManager;
  import org.chromium.url.GURL;
@@ -920,7 +925,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/over
  
  import java.util.List;
  
-@@ -119,9 +122,13 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
+@@ -122,9 +125,13 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
      private final String mDefaultTitle;
      private final Supplier<LayerTitleCache> mLayerTitleCacheSupplier;
  
@@ -934,7 +939,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/over
              if (mModelSelectorButton.onDown(x, y)) return;
              if (mStripScrim.isVisible()) return;
              getActiveStripLayoutHelper().onDown(time(), x, y, fromMouse, buttons);
-@@ -141,6 +148,7 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
+@@ -144,6 +151,7 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
  
          @Override
          public void drag(float x, float y, float dx, float dy, float tx, float ty) {
@@ -942,7 +947,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/over
              mModelSelectorButton.drag(x, y);
              if (mStripScrim.isVisible()) return;
              getActiveStripLayoutHelper().drag(time(), x, y, dx, dy, tx, ty);
-@@ -148,6 +156,7 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
+@@ -151,6 +159,7 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
  
          @Override
          public void click(float x, float y, boolean fromMouse, int buttons) {
@@ -950,7 +955,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/over
              long time = time();
              if (mModelSelectorButton.click(x, y)) {
                  mModelSelectorButton.handleClick(time);
-@@ -159,13 +168,13 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
+@@ -162,13 +171,13 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
  
          @Override
          public void fling(float x, float y, float velocityX, float velocityY) {
@@ -966,7 +971,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/over
              getActiveStripLayoutHelper().onLongPress(time(), x, y);
          }
  
-@@ -249,7 +258,8 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
+@@ -252,7 +261,8 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
       */
      public StripLayoutHelperManager(Context context, LayoutUpdateHost updateHost,
              LayoutRenderHost renderHost, Supplier<LayerTitleCache> layerTitleCacheSupplier,
@@ -976,7 +981,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/over
          mUpdateHost = updateHost;
          mLayerTitleCacheSupplier = layerTitleCacheSupplier;
          mTabStripTreeProvider = new TabStripSceneLayer(context);
-@@ -292,6 +302,8 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
+@@ -295,6 +305,8 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
                  new StripLayoutHelper(context, updateHost, renderHost, false, mModelSelectorButton);
          mIncognitoHelper =
                  new StripLayoutHelper(context, updateHost, renderHost, true, mModelSelectorButton);
@@ -985,7 +990,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/over
  
          onContextChanged(context);
      }
-@@ -361,9 +373,13 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
+@@ -364,9 +376,13 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
          Tab selectedTab = mTabModelSelector.getCurrentModel().getTabAt(
                  mTabModelSelector.getCurrentModel().index());
          int selectedTabId = selectedTab == null ? TabModel.INVALID_TAB_INDEX : selectedTab.getId();
@@ -1000,13 +1005,13 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/over
          return mTabStripTreeProvider;
      }
  
-@@ -401,7 +417,17 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
+@@ -404,7 +420,17 @@ public class StripLayoutHelperManager implements SceneOverlay, PauseResumeWithNa
          mIncognitoHelper.onSizeChanged(
                  mWidth, mHeight, orientationChanged, LayoutManagerImpl.time());
  
 -        mStripFilterArea.set(0, 0, mWidth, Math.min(getHeight(), visibleViewportOffsetY));
 +        float top = 0;
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM) &&
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled() &&
 +            mBrowserControlsManagerSupplier.get() != null) {
 +            // move the rectangle to grab the touch events as the tab list (in tablet mode)
 +            // is down and is following the toolbar offset as it moves.
@@ -1037,7 +1042,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/scen
          float y = model.get(LayoutTab.CONTENT_OFFSET)
                  + model.get(LayoutTab.RENDER_Y) * LayoutTab.sDpToPx;
 -
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // the page content window never moves, it is fixed at the top
 +            y = 0;
 +        }
@@ -1061,7 +1066,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/scen
  
          TabListSceneLayerJni.get().beginBuildingFrame(mNativePtr, TabListSceneLayer.this);
  
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // the tabs list content window is fixed at the top, where the top toolbar used to be
 +            viewport.top = 0;
 +            backgroundTopOffset = 0;
@@ -1074,7 +1079,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/scen
                  contentOffset = browserControls.getContentOffset();
              }
  
-+            if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                toolbarYOffset = 0;
 +                contentOffset = 0;
 +            }
@@ -1085,7 +1090,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/scen
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/scene_layer/TabStripSceneLayer.java b/chrome/android/java/src/org/chromium/chrome/browser/compositor/scene_layer/TabStripSceneLayer.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/compositor/scene_layer/TabStripSceneLayer.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/compositor/scene_layer/TabStripSceneLayer.java
-@@ -21,6 +21,8 @@ import org.chromium.chrome.browser.layouts.scene_layer.SceneLayer;
+@@ -23,6 +23,8 @@ import org.chromium.chrome.browser.layouts.scene_layer.SceneLayer;
  import org.chromium.chrome.browser.layouts.scene_layer.SceneOverlayLayer;
  import org.chromium.ui.base.LocalizationUtils;
  import org.chromium.ui.resources.ResourceManager;
@@ -1094,7 +1099,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/scen
  
  /**
   * The Java component of what is basically a CC Layer that manages drawing the Tab Strip (which is
-@@ -67,10 +69,19 @@ public class TabStripSceneLayer extends SceneOverlayLayer {
+@@ -77,10 +79,19 @@ public class TabStripSceneLayer extends SceneOverlayLayer {
       */
      public void pushAndUpdateStrip(StripLayoutHelperManager layoutHelper,
              LayerTitleCache layerTitleCache, ResourceManager resourceManager,
@@ -1105,7 +1110,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/scen
  
 -        final boolean visible = yOffset > -layoutHelper.getHeight();
 +        boolean visible = yOffset > -layoutHelper.getHeight();
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +           // the list of open tabs (in tablet mode) is moved down, above the top
 +           // toolbar which is also below.
 +           // values are in pixel.
@@ -1136,7 +1141,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/findinpage/Find
 -            FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) getLayoutParams();
 -            lp.topMargin = anchorView.getBottom() - mYInsetPx;
 -            setLayoutParams(lp);
-+            if (!CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            if (!ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) getLayoutParams();
 +                lp.topMargin = anchorView.getBottom() - mYInsetPx;
 +                setLayoutParams(lp);
@@ -1157,13 +1162,13 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/Brow
  /**
   * A class that manages browser control visibility and positioning.
   */
-@@ -396,6 +399,14 @@ public class BrowserControlsManager
+@@ -395,6 +398,14 @@ public class BrowserControlsManager
          return mTopControlContainerHeight;
      }
  
 +    @Override
 +    public int getTopControlsHeightRealOffset() {
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM))
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled())
 +            return 0;
 +        else
 +            return mTopControlContainerHeight;
@@ -1172,11 +1177,11 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/Brow
      @Override
      public int getTopControlsMinHeight() {
          return mTopControlsMinHeight;
-@@ -462,6 +473,8 @@ public class BrowserControlsManager
+@@ -461,6 +472,8 @@ public class BrowserControlsManager
  
      @Override
      public float getTopVisibleContentOffset() {
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM))
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled())
 +            return 0;
          return getTopControlsHeight() + getTopControlOffset();
      }
@@ -1184,9 +1189,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/Brow
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/messages/MessageContainerCoordinator.java b/chrome/android/java/src/org/chromium/chrome/browser/messages/MessageContainerCoordinator.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/messages/MessageContainerCoordinator.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/messages/MessageContainerCoordinator.java
-@@ -17,6 +17,10 @@ import org.chromium.chrome.browser.flags.ChromeFeatureList;
- import org.chromium.chrome.browser.fullscreen.BrowserControlsManager;
+@@ -18,6 +18,10 @@ import org.chromium.chrome.browser.fullscreen.BrowserControlsManager;
  import org.chromium.components.messages.MessageContainer;
+ import org.chromium.ui.base.ViewUtils;
  
 +import android.view.Gravity;
 +import org.chromium.chrome.browser.flags.ChromeFeatureList;
@@ -1195,12 +1200,12 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/messages/Messag
  /**
   * Coordinator of {@link MessageContainer}, which can adjust margins of the message container
   * and control the visibility of browser control when message is being shown.
-@@ -50,7 +54,12 @@ public class MessageContainerCoordinator implements BrowserControlsStateProvider
+@@ -60,7 +64,12 @@ public class MessageContainerCoordinator implements BrowserControlsStateProvider
          }
          CoordinatorLayout.LayoutParams params =
                  (CoordinatorLayout.LayoutParams) mContainer.getLayoutParams();
 -        params.topMargin = getContainerTopOffset();
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            params.gravity = Gravity.START | Gravity.BOTTOM;
 +            params.bottomMargin = getContainerTopOffset();
 +        } else {
@@ -1209,11 +1214,11 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/messages/Messag
          mContainer.setLayoutParams(params);
      }
  
-@@ -110,6 +119,12 @@ public class MessageContainerCoordinator implements BrowserControlsStateProvider
+@@ -120,6 +129,12 @@ public class MessageContainerCoordinator implements BrowserControlsStateProvider
  
      /** @return Offset of the message container from the top of the screen. */
      private int getContainerTopOffset() {
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            return mControlsManager.getContentOffset()
 +                     + (mControlsManager.getBottomControlsHeight() - mControlsManager.getBottomControlOffset())
 +                     + mContainer.getMessageShadowTopMargin();
@@ -1237,7 +1242,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/modaldialog/Chr
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/NewTabPage.java b/chrome/android/java/src/org/chromium/chrome/browser/ntp/NewTabPage.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/ntp/NewTabPage.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/ntp/NewTabPage.java
-@@ -101,6 +101,8 @@ import org.chromium.content_public.browser.NavigationEntry;
+@@ -98,6 +98,8 @@ import org.chromium.content_public.browser.NavigationEntry;
  import org.chromium.ui.base.DeviceFormFactor;
  import org.chromium.ui.base.WindowAndroid;
  import org.chromium.ui.mojom.WindowOpenDisposition;
@@ -1246,7 +1251,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/NewTabPage.
  
  import java.util.List;
  
-@@ -562,10 +564,15 @@ public class NewTabPage implements NativePage, InvalidationAwareThumbnailProvide
+@@ -559,10 +561,15 @@ public class NewTabPage implements NativePage, InvalidationAwareThumbnailProvide
          // + topControlsDistanceToRest| will give the margin for the current animation frame.
          final int topControlsDistanceToRest = mBrowserControlsStateProvider.getContentOffset()
                  - mBrowserControlsStateProvider.getTopControlsHeight();
@@ -1256,7 +1261,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/NewTabPage.
 -        final int bottomMargin = mBrowserControlsStateProvider.getBottomControlsHeight()
 +        int bottomMargin = mBrowserControlsStateProvider.getBottomControlsHeight()
                  - mBrowserControlsStateProvider.getBottomControlOffset();
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // move the margin of the new tab page up if the top toolbar is at the bottom
 +            bottomMargin += mBrowserControlsStateProvider.getTopControlsHeight();
 +            topMargin = -mBrowserControlsStateProvider.getTopControlsHeight();
@@ -1264,7 +1269,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/NewTabPage.
  
          if (topMargin != layoutParams.topMargin || bottomMargin != layoutParams.bottomMargin) {
              layoutParams.topMargin = topMargin;
-@@ -585,7 +592,7 @@ public class NewTabPage implements NativePage, InvalidationAwareThumbnailProvide
+@@ -582,7 +589,7 @@ public class NewTabPage implements NativePage, InvalidationAwareThumbnailProvide
       *         strip.
       */
      private int getToolbarExtraYOffset() {
@@ -1308,7 +1313,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsP
  
 -        if (!DeviceFormFactor.isNonMultiDisplayContextOnTablet(mActivity)) {
 +        if (!DeviceFormFactor.isNonMultiDisplayContextOnTablet(mActivity) ||
-+                CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++                ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
              mBrowserControlsStateProvider = browserControlsStateProvider;
              mBrowserControlsStateProvider.addObserver(this);
              onBottomControlsHeightChanged(mBrowserControlsStateProvider.getBottomControlsHeight(),
@@ -1326,7 +1331,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsP
          // If the content offset is different from the margin, we use translationY to position the
          // view in line with the content offset.
 -        recentTabsRoot.setTranslationY(contentOffset - topMargin);
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            topMargin = 0;
 +            recentTabsRoot.setTranslationY(0);
 +        } else {
@@ -1335,7 +1340,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ntp/RecentTabsP
  
 -        final int bottomMargin = mBrowserControlsStateProvider.getBottomControlsHeight();
 +        int bottomMargin = mBrowserControlsStateProvider.getBottomControlsHeight();
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            bottomMargin += mBrowserControlsStateProvider.getTopControlsHeight();
 +        }
          if (topMargin != layoutParams.topMargin || bottomMargin != layoutParams.bottomMargin) {
@@ -1360,7 +1365,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/Se
          mSearchBox = (SearchActivityLocationBarLayout) mContentView.findViewById(
                  R.id.search_location_bar);
          mAnchorView = mContentView.findViewById(R.id.toolbar);
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            CoordinatorLayout.LayoutParams layoutParams = (CoordinatorLayout.LayoutParams)
 +                mAnchorView.getLayoutParams();
 +            layoutParams.gravity = Gravity.START | Gravity.BOTTOM;
@@ -1381,7 +1386,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/Se
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsActivity.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsActivity.java
-@@ -258,6 +258,11 @@ public class SettingsActivity extends ChromeBaseAppCompatActivity
+@@ -257,6 +257,11 @@ public class SettingsActivity extends ChromeBaseAppCompatActivity
          if (fragment instanceof INeedSnackbarManager) {
              ((INeedSnackbarManager)fragment).setSnackbarManager(mSnackbarManager);
          }
@@ -1396,7 +1401,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/Settin
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/status_indicator/StatusIndicatorCoordinator.java b/chrome/android/java/src/org/chromium/chrome/browser/status_indicator/StatusIndicatorCoordinator.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/status_indicator/StatusIndicatorCoordinator.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/status_indicator/StatusIndicatorCoordinator.java
-@@ -24,6 +24,11 @@ import org.chromium.ui.modelutil.PropertyModelChangeProcessor;
+@@ -25,6 +25,11 @@ import org.chromium.ui.modelutil.PropertyModelChangeProcessor;
  import org.chromium.ui.resources.ResourceManager;
  import org.chromium.ui.resources.dynamics.ViewResourceAdapter;
  
@@ -1408,11 +1413,11 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/status_indicato
  /**
   * The coordinator for a status indicator that is positioned below the status bar and is persistent.
   * Typically used to relay status, e.g. indicate user is offline.
-@@ -173,6 +178,11 @@ public class StatusIndicatorCoordinator {
+@@ -174,6 +179,11 @@ public class StatusIndicatorCoordinator {
      private void initialize() {
          final ViewStub stub = mActivity.findViewById(R.id.status_indicator_stub);
          final ViewResourceFrameLayout root = (ViewResourceFrameLayout) stub.inflate();
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // status messages (such as the offline indicator) are docked at the bottom
 +            CoordinatorLayout.LayoutParams layoutParams = (CoordinatorLayout.LayoutParams)root.getLayoutParams();
 +            layoutParams.gravity = Gravity.START | Gravity.BOTTOM;
@@ -1438,7 +1443,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/status_indicato
              RectF viewport, RectF visibleViewport, ResourceManager resourceManager, float yOffset) {
 -        final int offset = mBrowserControlsStateProvider.getTopControlsMinHeightOffset();
 +        int offset = mBrowserControlsStateProvider.getTopControlsMinHeightOffset();
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            offset = (int)viewport.bottom - offset;
 +        }
          StatusIndicatorSceneLayerJni.get().updateStatusIndicatorLayer(
@@ -1447,7 +1452,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/status_indicato
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
-@@ -178,6 +178,9 @@ import org.chromium.url.GURL;
+@@ -176,6 +176,9 @@ import org.chromium.url.GURL;
  
  import java.util.List;
  
@@ -1457,7 +1462,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
  /**
   * Contains logic for managing the toolbar visual component.  This class manages the interactions
   * with the rest of the application to ensure the toolbar is always visually up to date.
-@@ -670,7 +673,7 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+@@ -667,7 +670,7 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
                      mEphemeralTabCoordinatorSupplier);
              // clang-format off
              LocationBarCoordinator locationBarCoordinator = new LocationBarCoordinator(
@@ -1466,7 +1471,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
                      PrivacyPreferencesManagerImpl.getInstance(), mLocationBarModel,
                      mActionModeController.getActionModeCallback(),
                      new WindowDelegate(mActivity.getWindow()), windowAndroid, mActivityTabProvider,
-@@ -927,11 +930,13 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+@@ -925,11 +928,13 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
                  // the height won't be measured by the background image.
                  if (mControlContainer.getBackground() == null) {
                      setControlContainerTopMargin(getToolbarExtraYOffset());
@@ -1480,7 +1485,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
                              mControlContainer.removeOnLayoutChangeListener(mLayoutChangeListener);
                              mLayoutChangeListener = null;
                          }
-@@ -1311,13 +1316,25 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+@@ -1309,13 +1314,25 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
          return mLocationBar.getOmniboxStub().isUrlBarFocused();
      }
  
@@ -1488,7 +1493,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
 +
 +    private void MoveBottomBarOverTopBar() {
 +        if (bottomRoot != null &&
-+                CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++                ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // move up the container view of the ui
 +            // below there is the toolbar
 +            bottomRoot.setTranslationY(-mBrowserControlsSizer.getTopControlsHeight());
@@ -1508,7 +1513,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
                  mScrimCoordinator, mOmniboxFocusStateSupplier, mBottomSheetController,
                  mActivityLifecycleDispatcher, mIsWarmOnResumeSupplier, mTabModelSelector,
                  mTabContentManager, mCompositorViewHolder,
-@@ -1326,8 +1343,9 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+@@ -1324,8 +1341,9 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
          mBottomControlsCoordinatorSupplier.set(new BottomControlsCoordinator(mActivity,
                  mWindowAndroid, mLayoutManager, mCompositorViewHolder.getResourceManager(),
                  mBrowserControlsSizer, mFullscreenManager,
@@ -1520,11 +1525,11 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/Toolbar
      }
  
      /**
-@@ -2107,6 +2125,15 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+@@ -2105,6 +2123,15 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
      private void setControlContainerTopMargin(int margin) {
          final ViewGroup.MarginLayoutParams layoutParams =
                  ((ViewGroup.MarginLayoutParams) mControlContainer.getLayoutParams());
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            if (layoutParams.bottomMargin == margin) {
 +                return;
 +            }
@@ -1554,13 +1559,13 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/BottomContai
  
 +    @Override
 +    public void onTopControlsHeightChanged(int topControlsHeight, int topControlsMinHeight) {
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM))
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled())
 +            setTranslationY(mBaseYOffset);
 +    }
 +
 +    @Override
 +    public void onAndroidVisibilityChanged(int visibility) {
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM))
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled())
 +            setTranslationY(mBaseYOffset);
 +    }
 +
@@ -1568,7 +1573,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/BottomContai
      public void setTranslationY(float y) {
          mBaseYOffset = y;
  
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // the snackbar container is moved up because there is the top toolbar at the bottom
 +            mBaseYOffset = -(mBrowserControlsStateProvider.getTopControlsHeight()
 +                             + mBrowserControlsStateProvider.getTopControlOffset());
@@ -1579,9 +1584,9 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/BottomContai
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/system/StatusBarColorController.java b/chrome/android/java/src/org/chromium/chrome/browser/ui/system/StatusBarColorController.java
 --- a/chrome/android/java/src/org/chromium/chrome/browser/ui/system/StatusBarColorController.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/ui/system/StatusBarColorController.java
-@@ -13,6 +13,9 @@ import android.view.Window;
- import androidx.annotation.ColorInt;
+@@ -14,6 +14,9 @@ import androidx.annotation.ColorInt;
  import androidx.annotation.Nullable;
+ import androidx.annotation.VisibleForTesting;
  
 +import org.chromium.chrome.browser.flags.ChromeFeatureList;
 +import org.chromium.chrome.browser.flags.CachedFeatureFlags;
@@ -1589,11 +1594,11 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/system/Statu
  import org.chromium.base.ApiCompatibilityUtils;
  import org.chromium.base.CallbackController;
  import org.chromium.base.supplier.ObservableSupplier;
-@@ -370,6 +373,12 @@ public class StatusBarColorController
+@@ -425,6 +428,12 @@ public class StatusBarColorController
          boolean needsDarkStatusBarIcons = !ColorUtils.shouldUseLightForegroundOnBackground(color);
          ApiCompatibilityUtils.setStatusBarIconColor(root, needsDarkStatusBarIcons);
          ApiCompatibilityUtils.setStatusBarColor(mWindow, color);
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM) &&
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled() &&
 +                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 +            UiUtils.setNavigationBarIconColor(mWindow.getDecorView().getRootView(),
 +                needsDarkStatusBarIcons);
@@ -1605,7 +1610,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/system/Statu
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -7422,6 +7422,11 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -7578,6 +7578,11 @@ const FeatureEntry kFeatureEntries[] = {
       flag_descriptions::kWindowsScrollingPersonalityDescription, kOsAll,
       FEATURE_VALUE_TYPE(features::kWindowsScrollingPersonality)},
  
@@ -1628,7 +1633,7 @@ diff --git a/chrome/browser/android/compositor/scene_layer/tab_strip_scene_layer
  
  using base::android::JavaParamRef;
  using base::android::JavaRef;
-@@ -82,8 +83,10 @@ void TabStripSceneLayer::SetContentTree(
+@@ -81,8 +82,10 @@ void TabStripSceneLayer::SetContentTree(
      content_tree_ = content_tree;
      if (content_tree) {
        layer()->InsertChild(content_tree->layer(), 0);
@@ -1641,9 +1646,9 @@ diff --git a/chrome/browser/android/compositor/scene_layer/tab_strip_scene_layer
      }
    }
  }
-@@ -115,12 +118,17 @@ void TabStripSceneLayer::UpdateTabStripLayer(JNIEnv* env,
-                                              jfloat y_offset,
-                                              jboolean should_readd_background) {
+@@ -115,13 +118,18 @@ void TabStripSceneLayer::UpdateTabStripLayer(JNIEnv* env,
+                                              jboolean should_readd_background,
+                                              jint background_color) {
    gfx::RectF content(0, y_offset, width, height);
 -  layer()->SetPosition(gfx::PointF(0, y_offset));
 +  if (base::FeatureList::IsEnabled(::features::kMoveTopToolbarToBottom)) {
@@ -1654,6 +1659,7 @@ diff --git a/chrome/browser/android/compositor/scene_layer/tab_strip_scene_layer
 +  }
    tab_strip_layer_->SetBounds(gfx::Size(width, height));
    scrollable_strip_layer_->SetBounds(gfx::Size(width, height));
+   tab_strip_layer_->SetBackgroundColor(SkColor4f::FromColor(background_color));
  
    // Content tree should not be affected by tab strip scene layer visibility.
 -  if (content_tree_)
@@ -1677,7 +1683,7 @@ diff --git a/chrome/browser/browser_controls/android/java/src/org/chromium/chrom
                  + mBrowserControlsStateProvider.getTopControlOffset();
          int bottomMargin = mBrowserControlsStateProvider.getBottomControlsHeight()
                  - mBrowserControlsStateProvider.getBottomControlOffset();
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            bottomMargin += topMargin;
 +            topMargin = 0;
 +        }
@@ -1703,7 +1709,7 @@ diff --git a/chrome/browser/browser_controls/android/java/src/org/chromium/chrom
 diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
 --- a/chrome/browser/flag_descriptions.cc
 +++ b/chrome/browser/flag_descriptions.cc
-@@ -1752,6 +1752,10 @@ const char kImprovedKeyboardShortcutsDescription[] =
+@@ -1693,6 +1693,10 @@ const char kImprovedKeyboardShortcutsDescription[] =
      "Ensure keyboard shortcuts work consistently with international keyboard "
      "layouts and deprecate legacy shortcuts.";
  
@@ -1717,7 +1723,7 @@ diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descripti
 diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
 --- a/chrome/browser/flag_descriptions.h
 +++ b/chrome/browser/flag_descriptions.h
-@@ -987,6 +987,9 @@ extern const char kImprovedKeyboardShortcutsDescription[];
+@@ -962,6 +962,9 @@ extern const char kImprovedKeyboardShortcutsDescription[];
  extern const char kCompositorThreadedScrollbarScrollingName[];
  extern const char kCompositorThreadedScrollbarScrollingDescription[];
  
@@ -1770,26 +1776,18 @@ diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browse
  #include "base/metrics/field_trial_params.h"
  #include "base/no_destructor.h"
  #include "base/strings/string_piece_forward.h"
-@@ -250,6 +251,7 @@ const base::Feature* const kFeaturesExposedToJava[] = {
-     &kKitKatSupported,
+@@ -255,6 +256,7 @@ const base::Feature* const kFeaturesExposedToJava[] = {
+     &kIsVoiceSearchEnabledCache,
      &kLensCameraAssistedSearch,
      &kLensOnQuickActionSearchWidget,
 +    &features::kMoveTopToolbarToBottom,
-     &kNewInstanceFromDraggedLink,
      &kNewTabPageTilesTitleWrapAround,
      &kNewWindowAppMenu,
+     &kNotificationPermissionVariant,
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/CachedFeatureFlags.java
-@@ -107,6 +107,7 @@ public class CachedFeatureFlags {
-                     .put(ChromeFeatureList.TAB_GROUPS_FOR_TABLETS, false)
-                     .put(ChromeFeatureList.TAB_SELECTION_EDITOR_V2, false)
-                     .put(ChromeFeatureList.TAB_STRIP_IMPROVEMENTS, false)
-+                    .put(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM, false)
-                     .put(ChromeFeatureList.TAB_TO_GTS_ANIMATION, true)
-                     .put(ChromeFeatureList.TEST_DEFAULT_DISABLED, false)
-                     .put(ChromeFeatureList.TEST_DEFAULT_ENABLED, true)
-@@ -213,6 +214,23 @@ public class CachedFeatureFlags {
+@@ -124,6 +124,23 @@ public class CachedFeatureFlags {
          SharedPreferencesManager.getInstance().writeBoolean(preferenceName, isEnabledInNative);
      }
  
@@ -1813,7 +1811,7 @@ diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/f
      /**
       * Forces a feature to be enabled or disabled for testing.
       *
-@@ -532,6 +550,7 @@ public class CachedFeatureFlags {
+@@ -434,6 +451,7 @@ public class CachedFeatureFlags {
  
      @NativeMethods
      interface Natives {
@@ -1824,16 +1822,16 @@ diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/f
 diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 --- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
 +++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
-@@ -430,6 +430,8 @@ public abstract class ChromeFeatureList {
+@@ -389,6 +389,8 @@ public abstract class ChromeFeatureList {
      public static final String MESSAGES_FOR_ANDROID_SYNC_ERROR = "MessagesForAndroidSyncError";
      public static final String SEARCH_READY_OMNIBOX = "SearchReadyOmnibox";
      public static final String MODAL_PERMISSION_DIALOG_VIEW = "ModalPermissionDialogView";
 +    public static final String MOVE_TOP_TOOLBAR_TO_BOTTOM =
 +            "MoveTopToolbarToBottom";
      public static final String METRICS_SETTINGS_ANDROID = "MetricsSettingsAndroid";
-     public static final String NEW_INSTANCE_FROM_DRAGGED_LINK = "NewInstanceFromDraggedLink";
      public static final String NEW_TAB_PAGE_TILES_TITLE_WRAP_AROUND =
-@@ -714,6 +716,8 @@ public abstract class ChromeFeatureList {
+             "NewTabPageTilesTitleWrapAround";
+@@ -677,6 +679,8 @@ public abstract class ChromeFeatureList {
      public static final CachedFlag sInterestFeedV2 = new CachedFlag(INTEREST_FEED_V2, true);
      public static final CachedFlag sLensCameraAssistedSearch =
              new CachedFlag(LENS_CAMERA_ASSISTED_SEARCH, false);
@@ -1858,7 +1856,7 @@ diff --git a/chrome/browser/ui/android/appmenu/internal/java/src/org/chromium/ch
          }
  
          mListView = (ListView) contentView.findViewById(R.id.app_menu_list);
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // always scroll to the bottom to show new items
 +            mListView.setTranscriptMode(ListView.TRANSCRIPT_MODE_ALWAYS_SCROLL);
 +            // fill content starting from the bottom of the view
@@ -1871,7 +1869,7 @@ diff --git a/chrome/browser/ui/android/appmenu/internal/java/src/org/chromium/ch
          if (popupHeight + popupPosition[1] > visibleDisplayFrame.bottom) {
              mPopup.setHeight(visibleDisplayFrame.height());
          }
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // due to some unknown behaviour, the popup must be resized to
 +            // allow selection without leaving touch
 +            mPopup.setHeight(popupHeight-1);
@@ -1883,7 +1881,7 @@ diff --git a/chrome/browser/ui/android/appmenu/internal/java/src/org/chromium/ch
          int anchorViewX = tempLocation[0];
          int anchorViewY = tempLocation[1];
  
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // moves the view offset up by the height of the popup
 +            anchorViewY -= popupHeight;
 +            // fix it if it goes offscreen
@@ -1898,7 +1896,7 @@ diff --git a/chrome/browser/ui/android/appmenu/internal/java/src/org/chromium/ch
          }
          int availableScreenSpace = Math.max(
                  anchorViewY, appDimensions.height() - anchorViewY - anchorViewImpactHeight);
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // use all available space
 +            availableScreenSpace = appDimensions.height() - anchorViewImpactHeight;
 +            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N) {
@@ -1926,7 +1924,7 @@ diff --git a/chrome/browser/ui/android/appmenu/internal/java/src/org/chromium/ch
          }),
                  this);
  
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // reverses the order of items in the menu
 +            ModelList modelListReversed = new ModelList();
 +            for (int i = 0; i < modelList.size(); i++) {
@@ -1991,12 +1989,12 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
  /**
   * Coordinates the interactions with the UrlBar text component.
   */
-@@ -231,7 +234,13 @@ public class UrlBarCoordinator implements UrlBarEditingTextStateProvider, UrlFoc
+@@ -236,7 +239,13 @@ public class UrlBarCoordinator implements UrlBarEditingTextStateProvider, UrlFoc
          // to show or hide keyboard anyway. This may happen when we schedule keyboard hide, and
          // receive a second request to hide the keyboard instantly.
          if (showKeyboard) {
 -            setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN, /* delay */ false);
-+            if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                // probably due to an android bug, fix the size rather than pan the view.
 +                // with the pan the bar may not always follow the focus if not at the first input by the user
 +                setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE, /* delay */ false);
@@ -2047,7 +2045,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
                  ViewGroup container = (ViewGroup) ((ViewStub) mParent.getRootView().findViewById(
                                                             R.id.omnibox_results_container_stub))
                                                .inflate();
-+                if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++                if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                    // make margins works
 +                    dropdown.getViewGroup().setClipToPadding(true);
 +                    container.bringToFront();
@@ -2070,7 +2068,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
 diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteMediator.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteMediator.java
 --- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteMediator.java
 +++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/AutocompleteMediator.java
-@@ -58,6 +58,9 @@ import org.chromium.ui.modelutil.PropertyModel;
+@@ -56,6 +56,9 @@ import org.chromium.ui.modelutil.PropertyModel;
  import org.chromium.ui.mojom.WindowOpenDisposition;
  import org.chromium.url.GURL;
  
@@ -2080,17 +2078,64 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
  import java.lang.annotation.Retention;
  import java.lang.annotation.RetentionPolicy;
  import java.util.List;
-@@ -1011,7 +1014,9 @@ class AutocompleteMediator implements OnSuggestionsReceivedListener,
+@@ -1010,7 +1013,9 @@ class AutocompleteMediator implements OnSuggestionsReceivedListener,
+     @Override
      public void onSuggestionDropdownScroll() {
-         if (mDropdownViewInfoListBuilder.hasFullyConcealedElements()) {
-             mSuggestionsListScrolled = true;
--            mDelegate.setKeyboardVisibility(false, false);
-+            if (!CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
-+                mDelegate.setKeyboardVisibility(false, false);
-+            }
-         }
+         mSuggestionsListScrolled = true;
+-        mDelegate.setKeyboardVisibility(false, false);
++        if (!ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
++            mDelegate.setKeyboardVisibility(false, false);
++        }
      }
  
+     /**
+diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/DropdownItemViewInfoListManager.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/DropdownItemViewInfoListManager.java
+--- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/DropdownItemViewInfoListManager.java
++++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/DropdownItemViewInfoListManager.java
+@@ -11,6 +11,8 @@ import android.view.View;
+ import androidx.annotation.NonNull;
+ import androidx.annotation.Px;
+ 
++import org.chromium.chrome.browser.flags.CachedFeatureFlags;
++import org.chromium.chrome.browser.flags.ChromeFeatureList;
+ import org.chromium.chrome.browser.omnibox.OmniboxFeatures;
+ import org.chromium.chrome.browser.omnibox.R;
+ import org.chromium.chrome.browser.ui.theme.BrandedColorScheme;
+@@ -165,6 +167,7 @@ class DropdownItemViewInfoListManager {
+         GroupSection previousSection = null;
+         GroupSection currentSection;
+ 
++        boolean toolbarToBottom = ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled();
+         for (int i = 0; i < mSourceViewInfoList.size(); i++) {
+             final DropdownItemViewInfo item = mSourceViewInfoList.get(i);
+             final PropertyModel model = item.model;
+@@ -180,18 +183,22 @@ class DropdownItemViewInfoListManager {
+                 var topMargin = applyRounding ? groupTopMargin : suggestionVerticalMargin;
+                 var bottomMargin = applyRounding ? groupBottomMargin : suggestionVerticalMargin;
+ 
+-                model.set(DropdownCommonProperties.BG_TOP_CORNER_ROUNDED, applyRounding);
++                model.set(toolbarToBottom ?
++                    DropdownCommonProperties.BG_BOTTOM_CORNER_ROUNDED :
++                    DropdownCommonProperties.BG_TOP_CORNER_ROUNDED, applyRounding);
+                 // Do not have margin for the first suggestion, otherwise the first suggestion will
+                 // have a big gap with the Omnibox.
+-                model.set(DropdownCommonProperties.TOP_MARGIN,
++                model.set(toolbarToBottom ? DropdownCommonProperties.BOTTOM_MARGIN : DropdownCommonProperties.TOP_MARGIN,
+                         previousItem == null
+                                 ? getSuggestionListTopMargin(item.processor.getViewTypeId())
+                                 : topMargin);
+ 
+                 if (previousItem != null) {
+                     previousItem.model.set(
+-                            DropdownCommonProperties.BG_BOTTOM_CORNER_ROUNDED, applyRounding);
+-                    previousItem.model.set(DropdownCommonProperties.BOTTOM_MARGIN, bottomMargin);
++                            toolbarToBottom ?
++                                DropdownCommonProperties.BG_TOP_CORNER_ROUNDED :
++                                DropdownCommonProperties.BG_BOTTOM_CORNER_ROUNDED, applyRounding);
++                    previousItem.model.set(toolbarToBottom ? DropdownCommonProperties.TOP_MARGIN : DropdownCommonProperties.BOTTOM_MARGIN, bottomMargin);
+                 }
+ 
+                 previousItem = item;
 diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/OmniboxSuggestionsDropdown.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/OmniboxSuggestionsDropdown.java
 --- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/OmniboxSuggestionsDropdown.java
 +++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/OmniboxSuggestionsDropdown.java
@@ -2104,7 +2149,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
  /** A widget for showing a list of omnibox suggestions. */
  public class OmniboxSuggestionsDropdown extends RecyclerView {
      private static final long DEFERRED_INITIAL_SHRINKING_LAYOUT_FROM_IME_DURATION_MS = 300;
-@@ -208,7 +211,8 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
+@@ -246,7 +249,8 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
       * Constructs a new list designed for containing omnibox suggestions.
       * @param context Context used for contained views.
       */
@@ -2114,7 +2159,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
          super(context, null, android.R.attr.dropDownListViewStyle);
          setFocusable(true);
          setFocusableInTouchMode(true);
-@@ -218,13 +222,25 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
+@@ -256,13 +260,25 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
          setItemAnimator(null);
  
          mLayoutScrollListener = new SuggestionLayoutScrollListener(context);
@@ -2125,7 +2170,7 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
          final Resources resources = context.getResources();
          int paddingBottom =
                  resources.getDimensionPixelOffset(R.dimen.omnibox_suggestion_list_padding_bottom);
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // reverse the layout so that the items are at the bottom (in reverse order)
 +            // and anchored to the bottom edge
 +            mLayoutScrollListener.setReverseLayout(true);
@@ -2141,11 +2186,11 @@ diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/brow
          ViewCompat.setPaddingRelative(this, 0, 0, 0, paddingBottom);
  
          mStandardBgColor = shouldShowModernizeVisualUpdate
-@@ -442,6 +458,8 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
+@@ -480,6 +496,8 @@ public class OmniboxSuggestionsDropdown extends RecyclerView {
      }
  
      private int calculateAnchorBottomRelativeToContent() {
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM))
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled())
 +            return 0;
          View contentView =
                  mEmbedder.getAnchorView().getRootView().findViewById(android.R.id.content);
@@ -2208,7 +2253,7 @@ diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/brow
  
          Resources resources = context.getResources();
          int topMargin = resources.getDimensionPixelSize(R.dimen.tab_strip_height);
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // since the top bar is at the bottom, we need to cover the whole page
 +            topMargin = 0;
 +        }
@@ -2304,7 +2349,7 @@ diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/brow
      void setBottomControlsVisible(boolean visible) {
 +        if (visible == true
 +                && mIsBottomControlsVisible == false
-+                && CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++                && ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // always show the toolbar if the bottom controls are visible, so as not to leave the hole below.
 +            mBrowserControlsSizer.getBrowserVisibilityDelegate().showControlsTransient();
 +        }
@@ -2393,7 +2438,7 @@ diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/brow
          boolean isShadowVisible = mBottomView.getVisibility() != View.VISIBLE;
  
 +        float offsetPy = viewport.height() + mCurrentYOffsetPx;
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // fix the offset of the fake bottom controls, used only for animations
 +            offsetPy -= (mBottomView.getHeight() - mCurrentYOffsetPx + mTopControlsMinHeightOffset);
 +        }
@@ -2423,7 +2468,7 @@ diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/brow
      @Override
      public void initWithToolbar(int toolbarLayoutId) {
          try (TraceEvent te = TraceEvent.scoped("ToolbarControlContainer.initWithToolbar")) {
-+            if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++            if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +                // the top toolbar is docked at the bottom
 +                CoordinatorLayout.LayoutParams layoutParams = (CoordinatorLayout.LayoutParams)getLayoutParams();
 +                layoutParams.gravity = Gravity.START | Gravity.BOTTOM;
@@ -2485,7 +2530,7 @@ diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/brow
 diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/TopToolbarSceneLayer.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/TopToolbarSceneLayer.java
 --- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/TopToolbarSceneLayer.java
 +++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/TopToolbarSceneLayer.java
-@@ -14,6 +14,8 @@ import org.chromium.components.browser_ui.widget.ClipDrawableProgressBar.Drawing
+@@ -13,6 +13,8 @@ import org.chromium.components.browser_ui.widget.ClipDrawableProgressBar.Drawing
  import org.chromium.ui.modelutil.PropertyKey;
  import org.chromium.ui.modelutil.PropertyModel;
  import org.chromium.ui.resources.ResourceManager;
@@ -2494,12 +2539,12 @@ diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/brow
  
  /** A SceneLayer to render the top toolbar. This is the "view" piece of the top toolbar overlay. */
  @JNINamespace("android")
-@@ -39,13 +41,20 @@ class TopToolbarSceneLayer extends SceneOverlayLayer {
+@@ -38,13 +40,20 @@ class TopToolbarSceneLayer extends SceneOverlayLayer {
      /** Push all information about the texture to native at once. */
      private void pushProperties(PropertyModel model) {
          if (mResourceManagerSupplier.get() == null) return;
 +        float offsetY = model.get(TopToolbarOverlayProperties.Y_OFFSET);
-+        if (CachedFeatureFlags.isEnabled(ChromeFeatureList.MOVE_TOP_TOOLBAR_TO_BOTTOM)) {
++        if (ChromeFeatureList.sMoveTopToolbarToBottom.isEnabled()) {
 +            // fix the offset of the fake top controls, used only for animations
 +            offsetY = model.get(TopToolbarOverlayProperties.VIEWPORT_HEIGHT) -
 +                      model.get(TopToolbarOverlayProperties.TOOLBAR_HEIGHT) -
@@ -2539,15 +2584,15 @@ diff --git a/components/browser_ui/accessibility/android/java/src/org/chromium/c
      private TextScalePreference mTextScalePref;
      private PageZoomPreference mPageZoomDefaultZoomPref;
      private ChromeSwitchPreference mPageZoomAlwaysShowPref;
-@@ -43,6 +44,7 @@ public class AccessibilitySettings
-     private AccessibilitySettingsDelegate mDelegate;
+@@ -44,6 +45,7 @@ public class AccessibilitySettings
      private BooleanPreferenceDelegate mReaderForAccessibilityDelegate;
      private BooleanPreferenceDelegate mAccessibilityTabSwitcherDelegate;
+     private double mPageZoomLatestDefaultZoomPrefValue;
 +    private BooleanPreferenceDelegate mMoveTopToolbarToBottomDelegate;
  
      private FontSizePrefs mFontSizePrefs;
      private FontSizePrefsObserver mFontSizePrefsObserver = new FontSizePrefsObserver() {
-@@ -62,6 +64,10 @@ public class AccessibilitySettings
+@@ -63,6 +65,10 @@ public class AccessibilitySettings
          mFontSizePrefs = FontSizePrefs.getInstance(delegate.getBrowserContextHandle());
      }
  
@@ -2558,7 +2603,7 @@ diff --git a/components/browser_ui/accessibility/android/java/src/org/chromium/c
      @Override
      public void onActivityCreated(Bundle savedInstanceState) {
          super.onActivityCreated(savedInstanceState);
-@@ -126,6 +132,12 @@ public class AccessibilitySettings
+@@ -127,6 +133,12 @@ public class AccessibilitySettings
              getPreferenceScreen().removePreference(accessibilityTabSwitcherPref);
          }
  
@@ -2571,7 +2616,7 @@ diff --git a/components/browser_ui/accessibility/android/java/src/org/chromium/c
          Preference captions = findPreference(PREF_CAPTIONS);
          captions.setOnPreferenceClickListener(preference -> {
              Intent intent = new Intent(Settings.ACTION_CAPTIONING_SETTINGS);
-@@ -175,7 +187,11 @@ public class AccessibilitySettings
+@@ -186,7 +198,11 @@ public class AccessibilitySettings
                      mDelegate.getBrowserContextHandle(), (Integer) newValue);
          } else if (PREF_PAGE_ZOOM_ALWAYS_SHOW.equals(preference.getKey())) {
              PageZoomUtils.setShouldAlwaysShowZoomMenuItem((Boolean) newValue);
@@ -2617,7 +2662,7 @@ diff --git a/content/browser/renderer_host/render_widget_host_view_android.cc b/
  #include "cc/base/math_util.h"
  #include "cc/layers/layer.h"
  #include "cc/layers/surface_layer.h"
-@@ -479,6 +480,8 @@ void RenderWidgetHostViewAndroid::OnRenderFrameMetadataChangedBeforeActivation(
+@@ -845,6 +846,8 @@ void RenderWidgetHostViewAndroid::OnRenderFrameMetadataChangedBeforeActivation(
    // factor. Thus, |top_content_offset| in CSS pixels is also in DIPs.
    float top_content_offset =
        metadata.top_controls_height * metadata.top_controls_shown_ratio;


### PR DESCRIPTION
## Description

sorry, i found a bug in the last implementation i did (https://github.com/bromite/bromite/pull/2524)
the bug was related to a miscalculation of the offset when moving a tab, which made an annoying and uncontrolled scroll.
with this pull I fix that problem and also https://github.com/bromite/bromite/issues/2514

note that the patch is for v109

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Bromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [X] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes
