### PR TITLE
Update Add-DuckDuckGo-Lite-search-engine.patch

### DIFF
--- a/build/patches/Add-DuckDuckGo-Lite-search-engine.patch
+++ b/build/patches/Add-DuckDuckGo-Lite-search-engine.patch
@@ -17,7 +17,7 @@ diff --git a/components/search_engines/prepopulated_engines.json b/components/se
      },
  
 +    "duckduckgo_light": {
-+      "name": "DuckDuckGo Light",
++      "name": "DuckDuckGo Lite",
 +      "keyword": "duckduckgo.com/lite",
 +      "favicon_url": "https://duckduckgo.com/favicon.ico",
 +      "search_url": "https://duckduckgo.com/lite/?q={searchTerms}",


### PR DESCRIPTION
Fixed typo - "DuckDuckGo Light" -> "DuckDuckGo Lite"