### PR TITLE
Update Bromite-subresource-adblocker.patch

### DIFF
--- a/build/patches/Bromite-subresource-adblocker.patch
+++ b/build/patches/Bromite-subresource-adblocker.patch
@@ -1158,7 +1158,7 @@ new file mode 100644
 +namespace adblock_updater {
 +
 +// maximum 20MB for the filters file
-+const int kMaxBodySize = 1024 * 1024 * 20;
++const int kMaxBodySize = 1024 * 1024 * 50;
 +
 +const int kMaxRetriesOnNetworkChange = 3;
 +


### PR DESCRIPTION
https://github.com/uazo/cromite/blob/d3d806286434d11e526bb01b4138997805dced9d/build/patches/Bromite-subresource-adblocker.patch#L1149

## Description

*Please explain here what feature or bugfix these changes are addressing and why they should be included*

Expanding Subresource Filter Size flexibility upto 50MB, Their are Millions of Websites, and Billions of webpages, So hence, the solution. Many thanks in advance.

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [x] Bromite can be built with these changes
* [ ] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [ ] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
